### PR TITLE
ci: Add Python CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,43 @@
+name: Python
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check:
+    name: Format & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Check formatting
+        run: ruff format --check src tests
+      - name: Lint
+        run: ruff check src tests
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest -v


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow for Python
- Set up branch protection on main (requires passing CI, PRs required)

## CI Checks
- **Format & Lint**: ruff format --check, ruff check
- **Test Suite**: pytest on Python 3.10, 3.11, 3.12

## Branch Protection
- Requires "Format & Lint" and "Test Suite (3.12)" to pass
- PRs required for all changes to main
- Keeps branch up to date before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)