### PR TITLE
feat: Add install-cli.sh for easy CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ When running multiple Claude Code sessions (via `/parallel-work` or separate ter
 # Clone and install
 git clone https://github.com/evansenter/claude-event-bus.git
 cd claude-event-bus
-pip install -e .
+python3 -m venv .venv && source .venv/bin/activate && pip install -e .
 
-# Install as LaunchAgent (recommended - auto-starts on login)
+# Install as LaunchAgent (recommended - auto-starts on login, also installs CLI)
 ./scripts/install-launchagent.sh
+
+# Or install just the CLI (for use in hooks/scripts)
+./scripts/install-cli.sh
 
 # Or run in dev mode (foreground, auto-reload)
 ./scripts/dev.sh
@@ -97,7 +100,8 @@ The LaunchAgent and dev.sh set `EVENT_BUS_ICON` automatically.
 
 | Script | Purpose |
 |--------|---------|
-| `install-launchagent.sh` | Install as macOS LaunchAgent (auto-start) |
+| `install-launchagent.sh` | Install as macOS LaunchAgent (auto-start) + CLI |
+| `install-cli.sh` | Install CLI to ~/.local/bin for hooks/scripts |
 | `uninstall-launchagent.sh` | Remove LaunchAgent |
 | `dev.sh` | Run in foreground with auto-reload |
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Install event-bus-cli to ~/.local/bin for use in shell scripts and hooks
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_PYTHON="$PROJECT_DIR/.venv/bin/python"
+INSTALL_DIR="$HOME/.local/bin"
+CLI_PATH="$INSTALL_DIR/event-bus-cli"
+
+# Check venv exists
+if [[ ! -f "$VENV_PYTHON" ]]; then
+    echo "Error: Virtual environment not found at $PROJECT_DIR/.venv"
+    echo "Run: python3 -m venv .venv && source .venv/bin/activate && pip install -e ."
+    exit 1
+fi
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+
+# Create wrapper script
+cat > "$CLI_PATH" << EOF
+#!/bin/bash
+# event-bus-cli wrapper - installed by claude-event-bus
+# Source: $PROJECT_DIR
+exec "$VENV_PYTHON" -m event_bus.cli "\$@"
+EOF
+
+chmod +x "$CLI_PATH"
+
+echo "Installed event-bus-cli to $CLI_PATH"
+
+# Check if ~/.local/bin is in PATH
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+    echo ""
+    echo "Warning: $INSTALL_DIR is not in your PATH"
+    echo "Add this to your shell profile (.bashrc, .zshrc, etc.):"
+    echo ""
+    echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+fi
+
+# Test it works
+if "$CLI_PATH" --help > /dev/null 2>&1; then
+    echo "Verified: event-bus-cli is working"
+else
+    echo "Warning: event-bus-cli installed but test failed"
+    exit 1
+fi

--- a/scripts/install-launchagent.sh
+++ b/scripts/install-launchagent.sh
@@ -46,6 +46,11 @@ if launchctl list | grep -q "$LABEL"; then
     echo "  Logs: ~/.claude/event-bus.log"
     echo "  Errors: ~/.claude/event-bus.err"
     echo ""
+
+    # Also install CLI for use in hooks/scripts
+    echo "Installing CLI..."
+    "$SCRIPT_DIR/install-cli.sh"
+    echo ""
     echo "To uninstall: $SCRIPT_DIR/uninstall-launchagent.sh"
     osascript -e 'display notification "LaunchAgent installed and running" with title "Evan Bus"' 2>/dev/null
 else


### PR DESCRIPTION
## Summary
Implements RFC #9 - Better installation story for event-bus-cli.

## Changes
- **`scripts/install-cli.sh`** - Creates wrapper script in `~/.local/bin/event-bus-cli`
- **`scripts/install-launchagent.sh`** - Now also installs CLI automatically
- **README.md** - Updated with CLI installation instructions

## Usage
```bash
# Standalone CLI install
./scripts/install-cli.sh

# Or via LaunchAgent install (does both)
./scripts/install-launchagent.sh
```

After installation, hooks and scripts can use:
```bash
event-bus-cli register --name "my-session" --pid $$
event-bus-cli publish --type "done" --payload "Finished"
event-bus-cli notify --title "Build" --message "Complete"
```

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)