### PR TITLE
feat: Add make install for one-command setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,11 @@ MCP server providing an event bus for cross-session Claude Code communication. S
 ## Commands
 
 ```bash
-# Install with dev dependencies
+# Full installation (venv + deps + LaunchAgent + CLI + MCP)
+make install
+
+# Install with dev dependencies (for development)
 make dev
-# or: pip install -e ".[dev]"
 
 # Run all quality gates (format, lint, test)
 make check
@@ -21,15 +23,14 @@ make fmt      # Check formatting
 make lint     # Run linter
 make test     # Run tests
 
-# Install as LaunchAgent (auto-starts on login, auto-restarts on crash)
-./scripts/install-launchagent.sh
-
 # Uninstall LaunchAgent
 ./scripts/uninstall-launchagent.sh
 
 # Run in dev mode (foreground, auto-reload)
 ./scripts/dev.sh
 ```
+
+**Note**: `make install` is idempotent - safe to run multiple times. It will skip steps that are already complete.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt lint test clean install dev
+.PHONY: check fmt lint test clean install dev venv
 
 # Run all quality gates (format check, lint, tests)
 check: fmt lint test
@@ -20,10 +20,37 @@ clean:
 	rm -rf build/ dist/ *.egg-info .pytest_cache .ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-# Install in development mode
-install:
-	pip install -e .
+# Create virtual environment
+venv:
+	@if [ ! -d .venv ]; then \
+		echo "Creating virtual environment..."; \
+		python3 -m venv .venv; \
+	fi
 
-# Install with dev dependencies
-dev:
-	pip install -e ".[dev]"
+# Install with dev dependencies (for development)
+dev: venv
+	.venv/bin/pip install -e ".[dev]"
+
+# Full installation: venv + deps + LaunchAgent + CLI + MCP
+install: venv
+	@echo "Installing dependencies..."
+	.venv/bin/pip install -e .
+	@echo ""
+	@echo "Installing LaunchAgent..."
+	./scripts/install-launchagent.sh
+	@echo ""
+	@echo "Adding to Claude Code..."
+	@CLAUDE_CMD=$$(command -v claude || echo "$$HOME/.local/bin/claude"); \
+	if [ -x "$$CLAUDE_CMD" ]; then \
+		$$CLAUDE_CMD mcp add --transport http --scope user event-bus http://localhost:8080/mcp 2>/dev/null && \
+			echo "Added event-bus to Claude Code" || \
+			echo "event-bus already configured in Claude Code"; \
+	else \
+		echo "Note: claude not found. Run manually:"; \
+		echo "  claude mcp add --transport http --scope user event-bus http://localhost:8080/mcp"; \
+	fi
+	@echo ""
+	@echo "Installation complete!"
+	@echo ""
+	@echo "Make sure ~/.local/bin is in your PATH:"
+	@echo '  export PATH="$$HOME/.local/bin:$$PATH"'

--- a/README.md
+++ b/README.md
@@ -31,26 +31,34 @@ When running multiple Claude Code sessions (via `/parallel-work` or separate ter
 ## Installation
 
 ```bash
-# Clone and install
+# Clone and install everything
 git clone https://github.com/evansenter/claude-event-bus.git
 cd claude-event-bus
-python3 -m venv .venv && source .venv/bin/activate && pip install -e .
-
-# Install as LaunchAgent (recommended - auto-starts on login, also installs CLI)
-./scripts/install-launchagent.sh
-
-# Or install just the CLI (for use in hooks/scripts)
-./scripts/install-cli.sh
-
-# Or run in dev mode (foreground, auto-reload)
-./scripts/dev.sh
+make install
 ```
 
-## Add to Claude Code
+This installs:
+- Virtual environment with dependencies
+- LaunchAgent (auto-starts on login)
+- CLI to `~/.local/bin/event-bus-cli`
+- MCP server to Claude Code
+
+Make sure `~/.local/bin` is in your PATH:
+```bash
+export PATH="$HOME/.local/bin:$PATH"  # add to ~/.zshrc
+```
+
+## Development
 
 ```bash
-# Add globally (available in all projects)
-claude mcp add --transport http --scope user event-bus http://localhost:8080/mcp
+# Install with dev dependencies
+make dev
+
+# Run in dev mode (foreground, auto-reload)
+./scripts/dev.sh
+
+# Run quality checks
+make check
 ```
 
 ## MCP Tools

--- a/src/event_bus/cli.py
+++ b/src/event_bus/cli.py
@@ -187,7 +187,7 @@ def main():
         help="Event bus URL (default: http://127.0.0.1:8080/mcp)",
     )
 
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     # register
     p_register = subparsers.add_parser("register", help="Register a session")
@@ -226,6 +226,12 @@ def main():
     p_notify.set_defaults(func=cmd_notify)
 
     args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        print("\nUse -h or --help with any command for more details.")
+        sys.exit(1)
+
     args.func(args)
 
 


### PR DESCRIPTION
## Summary
Adds `make install` for complete one-command installation.

## What it does
```bash
git clone https://github.com/evansenter/claude-event-bus.git
cd claude-event-bus
make install
```

Installs:
- Virtual environment with dependencies
- LaunchAgent (auto-starts on login)
- CLI to `~/.local/bin/event-bus-cli`
- MCP server to Claude Code

## Idempotent
Safe to run multiple times - skips already-complete steps:
- venv: only creates if missing
- pip install: updates existing
- LaunchAgent: stops/reloads existing
- CLI: overwrites wrapper
- MCP: prints "already exists" if configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)