### PR TITLE
feat: Add uninstall-cli.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt lint test clean install dev venv
+.PHONY: check fmt lint test clean install uninstall dev venv
 
 # Run all quality gates (format check, lint, tests)
 check: fmt lint test
@@ -54,3 +54,19 @@ install: venv
 	@echo ""
 	@echo "Make sure ~/.local/bin is in your PATH:"
 	@echo '  export PATH="$$HOME/.local/bin:$$PATH"'
+
+# Uninstall: LaunchAgent + CLI + MCP config
+uninstall:
+	@echo "Uninstalling..."
+	./scripts/uninstall-launchagent.sh
+	@echo ""
+	@echo "Removing from Claude Code..."
+	@CLAUDE_CMD=$$(command -v claude || echo "$$HOME/.local/bin/claude"); \
+	if [ -x "$$CLAUDE_CMD" ]; then \
+		$$CLAUDE_CMD mcp remove --scope user event-bus 2>/dev/null && \
+			echo "Removed event-bus from Claude Code" || \
+			echo "event-bus not found in Claude Code"; \
+	fi
+	@echo ""
+	@echo "Uninstall complete!"
+	@echo "Note: venv and source code remain in place."

--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ The LaunchAgent and dev.sh set `EVENT_BUS_ICON` automatically.
 | Script | Purpose |
 |--------|---------|
 | `install-launchagent.sh` | Install as macOS LaunchAgent (auto-start) + CLI |
-| `install-cli.sh` | Install CLI to ~/.local/bin for hooks/scripts |
-| `uninstall-launchagent.sh` | Remove LaunchAgent |
+| `install-cli.sh` | Install CLI symlink to ~/.local/bin |
+| `uninstall-launchagent.sh` | Remove LaunchAgent + CLI |
+| `uninstall-cli.sh` | Remove CLI symlink only |
 | `dev.sh` | Run in foreground with auto-reload |
 
 ## Icon Generation

--- a/scripts/uninstall-cli.sh
+++ b/scripts/uninstall-cli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Uninstall event-bus-cli from ~/.local/bin
+
+CLI_PATH="$HOME/.local/bin/event-bus-cli"
+
+if [[ ! -e "$CLI_PATH" && ! -L "$CLI_PATH" ]]; then
+    echo "event-bus-cli not installed."
+    exit 0
+fi
+
+rm -f "$CLI_PATH"
+echo "Removed event-bus-cli from ~/.local/bin"

--- a/scripts/uninstall-launchagent.sh
+++ b/scripts/uninstall-launchagent.sh
@@ -18,6 +18,11 @@ echo "Removing plist..."
 rm -f "$PLIST_DEST"
 
 echo "Event bus LaunchAgent uninstalled."
+
+# Also uninstall CLI
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/uninstall-cli.sh"
+
 echo ""
 echo "Note: Logs remain at ~/.claude/event-bus.log"
 osascript -e 'display notification "LaunchAgent uninstalled" with title "Evan Bus"' 2>/dev/null


### PR DESCRIPTION
## Summary
- Add `scripts/uninstall-cli.sh` to remove CLI symlink
- `uninstall-launchagent.sh` now also calls `uninstall-cli.sh`
- Updated README scripts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)