### PR TITLE
feat: Add auto-notify on DMs with comprehensive error handling

### DIFF
--- a/src/event_bus/server.py
+++ b/src/event_bus/server.py
@@ -527,6 +527,16 @@ def publish_event(
     # Auto-refresh heartbeat when session publishes
     _auto_heartbeat(session_id)
 
+    # Validate channel format for known channel types
+    if channel not in ["all"] and ":" in channel:
+        channel_type, _, channel_value = channel.partition(":")
+        if channel_type in ["session", "repo", "machine"]:
+            if not channel_value:
+                logger.warning(
+                    f"Invalid {channel_type} channel format: '{channel}'. "
+                    f"Expected '{channel_type}:<value>'"
+                )
+
     # Auto-notify on direct messages (DMs)
     if channel.startswith("session:"):
         parts = channel.split(":", 1)


### PR DESCRIPTION
## Summary

Implements RFC #8 auto-notify feature with robust error handling and logging based on PR review feedback.

### Features Added
- **Auto-notify on DMs**: Sends macOS notification when `session:{id}` DM is published
- **Registration tips**: Includes helpful guidance in `register_session()` response  
- **Enhanced documentation**: Updated `event-bus://guide` with best practices and "Human as Router" pattern

### Error Handling Improvements
- Log notification failures instead of silently failing (#1)
- Validate channel format and log malformed channels (#5)
- Handle missing sessions with descriptive warnings (#3)
- Wrap notification calls in try-except for resilience (#2)
- Enhanced subprocess error logging with stderr/stdout (#4)

### Test Coverage
Added 5 new tests (99 total passing):
- Notification failure resilience (#2)
- Anonymous sender DMs (#6)
- Deleted sender sessions (#7)
- Channel exclusion - repo/machine don't notify (#8)
- Improved truncation test behavior (#12)

### Documentation Updates
- Realistic session IDs in examples (`brave-tiger` vs `abc123`) (#9)
- Incremental polling pattern (`since_id=last_seen_id`) (#10)
- osascript fallback documentation (#11)
- PID cleanup notes for local sessions (#14)

## Test Plan

- [x] All 99 tests passing
- [x] Format and lint checks pass
- [x] Error handling tested for all edge cases
- [x] Documentation accurately reflects implementation

## Closes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)