### PR TITLE
feat: Rename pid to client_id for session coherence

### DIFF
--- a/src/event_bus/cli.py
+++ b/src/event_bus/cli.py
@@ -2,7 +2,7 @@
 """CLI wrapper for event bus - for use in shell scripts and hooks.
 
 Usage:
-    event-bus-cli register [--name NAME] [--pid PID]
+    event-bus-cli register [--name NAME] [--client-id ID]
     event-bus-cli unregister --session-id ID
     event-bus-cli sessions
     event-bus-cli publish --type TYPE --payload PAYLOAD [--channel CHANNEL] [--session-id ID]
@@ -12,7 +12,7 @@ Usage:
 
 Examples:
     # Register session (for SessionStart hook)
-    event-bus-cli register --name "my-feature" --pid $$
+    event-bus-cli register --name "my-feature" --client-id "abc123"
 
     # Unregister session (for SessionEnd hook)
     event-bus-cli unregister --session-id abc123
@@ -107,8 +107,8 @@ def cmd_register(args):
     else:
         # Default to current directory name
         arguments["name"] = os.path.basename(os.getcwd())
-    if args.pid:
-        arguments["pid"] = args.pid
+    if args.client_id:
+        arguments["client_id"] = args.client_id
     arguments["cwd"] = os.getcwd()
 
     result = call_tool("register_session", arguments, url=args.url)
@@ -136,7 +136,7 @@ def cmd_sessions(args):
     for s in result:
         print(f"  {s['session_id']}  {s['name']}")
         print(f"    repo: {s['repo']}, machine: {s['machine']}")
-        print(f"    age: {int(s['age_seconds'])}s, pid: {s.get('pid', 'N/A')}")
+        print(f"    age: {int(s['age_seconds'])}s, client_id: {s.get('client_id', 'N/A')}")
         print()
 
 
@@ -251,7 +251,9 @@ def main():
     # register
     p_register = subparsers.add_parser("register", help="Register a session")
     p_register.add_argument("--name", help="Session name (default: directory name)")
-    p_register.add_argument("--pid", type=int, help="Process ID for deduplication")
+    p_register.add_argument(
+        "--client-id", help="Client identifier for deduplication (e.g., CC session ID or PID)"
+    )
     p_register.set_defaults(func=cmd_register)
 
     # unregister

--- a/src/event_bus/guide.md
+++ b/src/event_bus/guide.md
@@ -14,7 +14,7 @@ each session is isolated. This MCP server lets sessions:
 
 | Tool | Purpose |
 |------|---------|
-| `register_session(name, machine?, cwd?, pid?)` | Register yourself, get a session_id |
+| `register_session(name, machine?, cwd?, client_id?)` | Register yourself, get a session_id |
 | `list_sessions()` | See all active sessions |
 | `publish_event(type, payload, channel?)` | Send event to a channel |
 | `get_events(since_id?, limit?, session_id?)` | Poll for new events |
@@ -178,10 +178,11 @@ The notification alerts the **human** who routes the message to the correct sess
 ## Tips
 
 - `register_session` returns `last_event_id` - use it to start polling from the right place
+- Pass `client_id` to enable session resumption across restarts (e.g., CC session ID or PID)
 - `get_events` and `publish_event` auto-refresh your heartbeat
 - `get_events()` with no since_id returns newest first; with since_id returns chronological
 - `list_sessions()` returns most recently active sessions first
 - Sessions are auto-cleaned after 7 days of inactivity
-- Local sessions are cleaned immediately on PID death (remote sessions use 7-day timeout)
+- Local sessions with numeric client_ids (PIDs) are cleaned immediately on process death
 - The repo name is auto-detected from your working directory
 - SessionStart hooks can auto-register you on startup

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,7 @@ class TestCmdRegister:
         mock_getcwd.return_value = "/home/user/project"
         mock_call.return_value = {"session_id": "abc123", "name": "my-session"}
 
-        args = Namespace(name="my-session", pid=None, url=None)
+        args = Namespace(name="my-session", client_id=None, url=None)
         cli.cmd_register(args)
 
         mock_call.assert_called_once_with(
@@ -103,7 +103,7 @@ class TestCmdRegister:
         mock_getcwd.return_value = "/home/user/my-project"
         mock_call.return_value = {"session_id": "abc123", "name": "my-project"}
 
-        args = Namespace(name=None, pid=None, url=None)
+        args = Namespace(name=None, client_id=None, url=None)
         cli.cmd_register(args)
 
         mock_call.assert_called_once_with(
@@ -114,16 +114,16 @@ class TestCmdRegister:
 
     @patch("event_bus.cli.call_tool")
     @patch("event_bus.cli.os.getcwd")
-    def test_register_with_pid(self, mock_getcwd, mock_call):
-        """Test register with PID."""
+    def test_register_with_client_id(self, mock_getcwd, mock_call):
+        """Test register with client_id."""
         mock_getcwd.return_value = "/home/user/project"
         mock_call.return_value = {"session_id": "abc123"}
 
-        args = Namespace(name="test", pid=12345, url=None)
+        args = Namespace(name="test", client_id="abc-session", url=None)
         cli.cmd_register(args)
 
         call_args = mock_call.call_args[0][1]
-        assert call_args["pid"] == 12345
+        assert call_args["client_id"] == "abc-session"
 
 
 class TestCmdUnregister:
@@ -168,7 +168,7 @@ class TestCmdSessions:
                 "repo": "my-repo",
                 "machine": "my-machine",
                 "age_seconds": 120,
-                "pid": 12345,
+                "client_id": "xyz789",
             }
         ]
 
@@ -643,14 +643,16 @@ class TestMainArgumentParsing:
         """Test register subcommand parsing."""
         import sys
 
-        with patch.object(sys, "argv", ["cli", "register", "--name", "test", "--pid", "123"]):
+        with patch.object(
+            sys, "argv", ["cli", "register", "--name", "test", "--client-id", "abc123"]
+        ):
             with patch("event_bus.cli.cmd_register") as mock_cmd:
                 mock_cmd.return_value = None
                 cli.main()
 
                 args = mock_cmd.call_args[0][0]
                 assert args.name == "test"
-                assert args.pid == 123
+                assert args.client_id == "abc123"
 
     def test_unregister_parser(self):
         """Test unregister subcommand parsing."""


### PR DESCRIPTION
## Summary

Implements RFC #29: Session coherence via `pid` → `client_id` rename.

- Rename `pid: int | None` to `client_id: str | None` in schema and API
- Change deduplication key from `(machine, cwd, pid)` to `(machine, client_id)`
- Update `is_pid_alive` → `is_client_alive` with non-numeric client_id handling
- Breaking migration: drops old sessions table and recreates with new schema
- Update CLI `--pid` → `--client-id` argument
- Update all tests and documentation

This enables Claude Code sessions to pass their own session ID (or any string identifier) for reattachment across restarts, rather than relying on PIDs which are process-specific.

Closes #29

## Test plan

- [x] All 140 tests pass (`make check`)
- [x] Verified schema migration drops old pid-based table
- [x] Verified session deduplication works with string client_ids
- [x] Verified liveness checking handles non-numeric client_ids gracefully
- [x] Verified CLI accepts `--client-id` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)