### PR TITLE
docs: Add event type conventions documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,25 @@ publish_event("help", "Review auth.ts?", channel="session:abc123")
 publish_event("api_ready", "API merged", channel="repo:my-project")
 ```
 
+## Event Type Conventions
+
+Use consistent event types for discoverability across sessions.
+
+| Event Type | Description | Example Payload |
+|------------|-------------|-----------------|
+| `rfc_created` | New RFC issue created | `"RFC created: #48 - Event bus integration"` |
+| `rfc_responded` | Response posted to RFC | `"RFC response posted: #48"` |
+| `parallel_work_started` | New worktree/session started | `"Started parallel work: issue-48 - Implement event bus"` |
+| `ci_completed` | CI finished (pass or fail) | `"CI passed on PR #42"` |
+| `message` | Generic message/announcement | `"Auth feature done, you can integrate now"` |
+| `help_needed` | Request for assistance | `"Need review on auth.ts approach"` |
+| `task_completed` | Significant task finished | `"Feature X is done and merged"` |
+
+**Naming conventions:**
+- Use `snake_case` for event types
+- Be specific: `rfc_created` not just `created`
+- Include context in payload: what happened and relevant identifiers (PR#, issue#)
+
 ## Design Decisions
 
 - **Polling over push**: MCP is request/response, so sessions poll with `get_events(since_id)`

--- a/src/event_bus/guide.md
+++ b/src/event_bus/guide.md
@@ -186,3 +186,38 @@ The notification alerts the **human** who routes the message to the correct sess
 - Local sessions with numeric client_ids (PIDs) are cleaned immediately on process death
 - The repo name is auto-detected from your working directory
 - SessionStart hooks can auto-register you on startup
+
+## Event Type Conventions
+
+Use consistent event types across commands and sessions for discoverability.
+
+### Standard Event Types
+
+| Event Type | Description | Example Payload |
+|------------|-------------|-----------------|
+| `rfc_created` | New RFC issue created | `"RFC created: #48 - Event bus integration"` |
+| `rfc_responded` | Response posted to RFC | `"RFC response posted: #48"` |
+| `parallel_work_started` | New worktree/session started | `"Started parallel work: issue-48 - Implement event bus"` |
+| `ci_completed` | CI finished (pass or fail) | `"CI passed on PR #42"` or `"CI failed on PR #42"` |
+| `message` | Generic message/announcement | `"Auth feature done, you can integrate now"` |
+| `help_needed` | Request for assistance | `"Need review on auth.ts approach"` |
+| `task_completed` | Significant task finished | `"Feature X is done and merged"` |
+
+### Naming Conventions
+
+- Use `snake_case` for event types
+- Be specific: `rfc_created` not just `created`
+- Include context in payload: what happened and any relevant identifiers (PR#, issue#)
+- Payloads are automatically JSON-escaped by the MCP layer - special characters are safe
+
+### Examples
+
+```python
+# Good: specific type with context in payload
+publish_event("ci_completed", "CI passed on PR #42", channel="repo:my-project")
+publish_event("rfc_created", "RFC created: #48 - Event bus integration")
+
+# Bad: vague type, no context
+publish_event("done", "finished")
+publish_event("update", "something happened")
+```


### PR DESCRIPTION
## Summary

- Add Event Type Conventions section to `guide.md` with standard event types table, naming conventions, and examples
- Add corresponding section to `CLAUDE.md` for developer reference
- Documents existing event types: `rfc_created`, `rfc_responded`, `parallel_work_started`, `ci_completed`, `message`, `help_needed`, `task_completed`

Closes #34

## Test plan

- [x] All 141 tests pass
- [x] Formatting and linting clean
- [ ] Review documentation for clarity and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)