### PR TITLE
docs: Update CLAUDE.md and README.md for logging changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ make check
 |------|-------------|
 | `register_session` | Register this session with the event bus |
 | `list_sessions` | List all active sessions |
+| `list_channels` | List active channels with subscriber counts |
 | `publish_event` | Publish event to a channel (broadcast, repo, session) |
 | `get_events` | Poll for events (filtered by subscriptions) |
 | `unregister_session` | Clean up session on exit |


### PR DESCRIPTION
## Summary
- Remove deprecated `--track-state` CLI option references
- Add Logging section documenting `~/.claude/event-bus.log`
- Update middleware.py description (logs always, not just dev mode)
- Update DEV_MODE description (adds console logging, not enables logging)
- Add `list_channels` to README MCP Tools table

## Context
Aligns documentation with the logging improvements from PR #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)