### PR TITLE
fix: Hide UUIDs from logs, show human-readable display_ids

### DIFF
--- a/src/event_bus/server.py
+++ b/src/event_bus/server.py
@@ -513,10 +513,11 @@ def unregister_session(session_id: str | None = None, client_id: str | None = No
         session_id=session_id,
     )
 
-    dev_notify("unregister_session", f"{session.name} ({session_id})")
+    dev_notify("unregister_session", f"{session.name} ({session.display_id})")
     return {
         "success": True,
         "session_id": session_id,
+        "display_id": session.display_id,
         "active_sessions": storage.session_count(),
     }
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -79,7 +79,7 @@ class TestFormatList:
         assert _DIM in result
 
     def test_session_list(self):
-        """List with session_id shows names."""
+        """List with session_id shows names with formatting."""
         items = [
             {"session_id": "brave-tiger"},
             {"session_id": "happy-falcon"},
@@ -87,7 +87,8 @@ class TestFormatList:
         result = _format_list(items)
         assert "brave-tiger" in result
         assert "happy-falcon" in result
-        assert _CYAN in result
+        # Human-readable IDs use BOLD when not in DB (no lookup)
+        assert _BOLD in result
 
     def test_channel_list(self):
         """List with channel+subscribers shows channel names."""
@@ -110,10 +111,12 @@ class TestFormatResult:
     """Tests for _format_result function."""
 
     def test_session_id_result(self):
-        """Result with session_id shows session=name."""
+        """Result with session_id shows session=name with formatting."""
         result = _format_result({"session_id": "tender-hawk"})
-        assert "session=tender-hawk" in result
-        assert _CYAN in result
+        # Human-readable ID is formatted with BOLD when no DB lookup
+        assert "tender-hawk" in result
+        assert "session=" in result
+        assert _BOLD in result
 
     def test_events_result_empty(self):
         """Empty events result shows 0 events."""
@@ -219,7 +222,9 @@ class TestFormatResult:
             "isError": False,
         }
         result = _format_result(wrapped)
-        assert "session=test-session" in result
+        # Human-readable ID is formatted with BOLD when no DB lookup
+        assert "session=" in result
+        assert "test-session" in result
 
     def test_list_result(self):
         """List result delegates to _format_list."""


### PR DESCRIPTION
## Summary

- Fixed UUID leakage in middleware logging - now shows human-readable display_ids
- Fixed `_format_args` to handle `client_id` like `session_id` (dim/truncate UUIDs)
- Fixed `_format_result` to look up and show display_id instead of UUID
- Fixed `unregister_session` to return `display_id` in response
- Fixed schema_version multi-row bug causing migrations to re-run
- Fixed migration to not overwrite existing display_ids

## Test plan

- [x] `make check` passes
- [x] Manual testing confirms logs show `session=display-name` instead of UUIDs
- [x] `list_sessions` shows human-readable names: `fresh-ibis, clever-urchin, swift-dog`
- [x] `register_session` and `unregister_session` both show display_id in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)