### PR TITLE
docs: Fix documentation accuracy issues from audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ MCP server for cross-session Claude Code communication. Sessions register, publi
 ### Safe operations:
 - `make uninstall` - Preserves database
 - `make reinstall` - Just reinstalls package
-- Schema migrations via `@migration` decorator
+- Schema migrations via `@migration` decorator (increment `SCHEMA_VERSION` when adding)
 
 ### Before schema changes:
 ```bash
@@ -39,7 +39,7 @@ pytest tests/test_server.py::TestRegisterSession -v
 
 ### When to Restart
 
-Code changes to `server.py`, `storage.py`, `helpers.py`, `cli.py` require restart.
+Code changes to `server.py`, `storage.py`, `helpers.py` require restart.
 `guide.md` is read fresh each request. Dev mode auto-reloads.
 
 ## Architecture
@@ -57,15 +57,7 @@ src/event_bus/
 
 ## MCP Tools
 
-| Tool | Purpose |
-|------|---------|
-| `register_session` | Register session, get session_id + cursor |
-| `list_sessions` | List active sessions |
-| `list_channels` | List channels with subscriber counts |
-| `publish_event` | Publish to channel |
-| `get_events` | Poll events (supports `resume=True`) |
-| `unregister_session` | Clean up on exit |
-| `notify` | System notification |
+`register_session`, `list_sessions`, `list_channels`, `publish_event`, `get_events`, `unregister_session`, `notify`
 
 **Usage guide**: `event-bus://guide` resource. Keep it updated when changing APIs.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MCP server for cross-session Claude Code communication and coordination.
 
 ## Overview
 
-When running multiple Claude Code sessions (via `/parallel-work` or separate terminals), each session is isolated. This MCP server provides an event bus for sessions to:
+When running multiple Claude Code sessions (in separate terminals or worktrees), each session is isolated. This MCP server provides an event bus for sessions to:
 
 - **Announce presence** - Know what other sessions are active
 - **Broadcast status** - Share progress updates and task completion

--- a/src/event_bus/guide.md
+++ b/src/event_bus/guide.md
@@ -3,7 +3,7 @@
 ## What is this?
 
 The Event Bus enables communication between Claude Code sessions. When running multiple
-CC sessions (e.g., via `/parallel-work` or separate terminals), this MCP server lets sessions:
+CC sessions (e.g., in separate terminals or worktrees), this MCP server lets sessions:
 
 - See what other sessions are active
 - Coordinate work (signal when APIs are ready, request help)
@@ -27,8 +27,8 @@ CC sessions (e.g., via `/parallel-work` or separate terminals), this MCP server 
 
 ### 1. Register on startup
 ```
-register_session(name="auth-feature", client_id="my-unique-id")
-→ {session_id: "my-unique-id", display_id: "brave-tiger", cursor: "42", ...}
+register_session(name="auth-feature", client_id="cc-session-abc")
+→ {session_id: "cc-session-abc", display_id: "brave-tiger", cursor: "42", ...}
 ```
 - `session_id` is your unique identifier (your `client_id`, or a UUID if not provided)
 - `display_id` is human-readable ("brave-tiger") - for display only


### PR DESCRIPTION
## Summary

- Add SCHEMA_VERSION increment reminder for migrations
- Remove cli.py from restart list (CLI is just a client)
- Condense MCP Tools table to single line (Claude sees schemas in system prompt)
- Fix session_id example in guide.md to be more realistic
- Remove /parallel-work references (external dotfiles command)

## Test plan

- [x] Documentation reads correctly
- [x] No broken references

🤖 Generated with [Claude Code](https://claude.com/claude-code)