### PR TITLE
fix: Remove --track-state CLI flag in favor of server-side --resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ CLI and MCP expose the same functionality:
 
 - CLI: kebab-case args (`--session-id`), short commands
 - MCP: snake_case params, descriptive `verb_noun` pattern
-- CLI-only: `--timeout`, `--json`, `--exclude-types`, `--track-state`
+- CLI-only: `--timeout`, `--json`, `--exclude-types`
 
 **When modifying API**: Update CLI help, MCP docstrings, and `guide.md` together.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,6 @@ def make_events_args(**overrides):
         limit=None,
         exclude=None,
         timeout=10000,
-        track_state=None,
         json=False,
         url=None,
         order="desc",


### PR DESCRIPTION
## Summary

- Remove `--track-state` CLI flag (client-side file-based cursor storage)
- Add validation that `--resume` requires `--session-id`
- Update documentation and tests

The CLI had two mechanisms for cursor persistence which was confusing. Server-side `--resume` provides the same functionality with better semantics (server manages state, no file management needed).

## Test plan

- [x] All 240 tests pass
- [x] `--resume` without `--session-id` shows error and exits with code 1
- [x] `--resume` with `--session-id` works correctly
- [x] No references to `track-state` or `track_state` remain in codebase

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)