### PR TITLE
docs: Add MCP tool setup for remote machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,20 @@ Then restart: `make restart`
 **Client machine (remote):**
 
 ```bash
-# Set remote URL for CLI
-export EVENT_BUS_URL="http://<tailscale-ip>:8080/mcp"
+# Add MCP server pointing to home machine
+claude mcp add --transport http --scope user event-bus http://<tailscale-ip>:8080/mcp
 
-# Test connection
-event-bus-cli sessions
+# Verify connection
+claude mcp list
+# event-bus: http://<tailscale-ip>:8080/mcp (HTTP) - ✓ Connected
 ```
 
-See #75 for MCP tool integration on remote machines.
+New Claude Code sessions will have full `mcp__event-bus__*` tool access to the central server.
+
+For CLI usage (in hooks/scripts), also set:
+```bash
+export EVENT_BUS_URL="http://<tailscale-ip>:8080/mcp"
+```
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Update Multi-Machine Setup section with complete MCP tool instructions
- Add `claude mcp add` command for HTTP transport
- Remove reference to #75, include solution directly

Tested: Confirmed working on remote machine via Tailscale.

Closes #75

## Test plan
- [x] Docs only, no code changes
- [x] Verified MCP HTTP transport works on remote machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)