### PR TITLE
feat: Add Linux systemd support for service installation

### DIFF
--- a/scripts/claude-event-bus.service
+++ b/scripts/claude-event-bus.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Claude Event Bus - Cross-session MCP communication
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=__PROJECT_DIR__
+Environment=PYTHONPATH=__PROJECT_DIR__/src
+Environment=EVENT_BUS_ICON=__PROJECT_DIR__/assets/icon.png
+ExecStart=__VENV_PYTHON__ -m event_bus.server
+Restart=always
+RestartSec=5
+StandardOutput=append:__HOME__/.claude/contrib/event-bus/event-bus.log
+StandardError=append:__HOME__/.claude/contrib/event-bus/event-bus.err
+
+[Install]
+WantedBy=default.target

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,28 +3,43 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-LABEL="com.evansenter.claude-event-bus"
-PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
 cd "$PROJECT_DIR"
 source .venv/bin/activate
 
-# Stop LaunchAgent if running (to free port 8080)
-LAUNCHAGENT_WAS_RUNNING=false
-if launchctl list 2>/dev/null | grep -q "$LABEL"; then
-    echo "Stopping LaunchAgent for dev mode..."
-    launchctl unload "$PLIST" 2>/dev/null
-    LAUNCHAGENT_WAS_RUNNING=true
-    osascript -e 'display notification "Stopped for dev mode" with title "Evan Bus"' 2>/dev/null
+SERVICE_WAS_RUNNING=false
+
+# Stop service if running (to free port 8080)
+if [[ "$(uname)" == "Darwin" ]]; then
+    LABEL="com.evansenter.claude-event-bus"
+    PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+    if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+        echo "Stopping LaunchAgent for dev mode..."
+        launchctl unload "$PLIST" 2>/dev/null
+        SERVICE_WAS_RUNNING=true
+        osascript -e 'display notification "Stopped for dev mode" with title "Event Bus"' 2>/dev/null
+    fi
+else
+    SERVICE_NAME="claude-event-bus"
+    if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+        echo "Stopping systemd service for dev mode..."
+        systemctl --user stop "$SERVICE_NAME"
+        SERVICE_WAS_RUNNING=true
+    fi
 fi
 
-# Restart LaunchAgent on exit
+# Restart service on exit
 cleanup() {
-    if [[ "$LAUNCHAGENT_WAS_RUNNING" == "true" && -f "$PLIST" ]]; then
+    if [[ "$SERVICE_WAS_RUNNING" == "true" ]]; then
         echo ""
-        echo "Restarting LaunchAgent..."
-        launchctl load "$PLIST"
-        osascript -e 'display notification "LaunchAgent restarted" with title "Evan Bus"' 2>/dev/null
+        if [[ "$(uname)" == "Darwin" ]]; then
+            echo "Restarting LaunchAgent..."
+            launchctl load "$PLIST"
+            osascript -e 'display notification "LaunchAgent restarted" with title "Event Bus"' 2>/dev/null
+        else
+            echo "Restarting systemd service..."
+            systemctl --user start "$SERVICE_NAME"
+        fi
     fi
 }
 trap cleanup EXIT

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Install the event bus as a Linux systemd user service (auto-starts on login)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_PYTHON="$PROJECT_DIR/.venv/bin/python"
+SERVICE_TEMPLATE="$SCRIPT_DIR/claude-event-bus.service"
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_DEST="$SERVICE_DIR/claude-event-bus.service"
+SERVICE_NAME="claude-event-bus"
+
+# Check venv exists
+if [[ ! -f "$VENV_PYTHON" ]]; then
+    echo "Error: Virtual environment not found at $PROJECT_DIR/.venv"
+    echo "Run: python3 -m venv .venv && source .venv/bin/activate && pip install -e ."
+    exit 1
+fi
+
+# Create directories if needed
+mkdir -p "$SERVICE_DIR"
+mkdir -p "$HOME/.claude/contrib/event-bus"
+
+# Stop existing service if running
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo "Stopping existing service..."
+    systemctl --user stop "$SERVICE_NAME"
+fi
+
+# Generate service file with correct paths
+echo "Installing systemd service..."
+sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__PROJECT_DIR__|$PROJECT_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$SERVICE_TEMPLATE" > "$SERVICE_DEST"
+
+# Reload systemd and start service
+systemctl --user daemon-reload
+echo "Starting service..."
+systemctl --user enable --now "$SERVICE_NAME"
+
+# Verify it's running
+sleep 1
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo ""
+    echo "Event bus installed and running!"
+    echo "  Logs: ~/.claude/contrib/event-bus/event-bus.log"
+    echo "  Errors: ~/.claude/contrib/event-bus/event-bus.err"
+    echo "  Status: systemctl --user status $SERVICE_NAME"
+    echo ""
+
+    # Also install CLI for use in hooks/scripts
+    echo "Installing CLI..."
+    "$SCRIPT_DIR/install-cli.sh"
+    echo ""
+    echo "To uninstall: $SCRIPT_DIR/uninstall-systemd.sh"
+else
+    echo "Error: Service failed to start. Check logs:"
+    echo "  journalctl --user -u $SERVICE_NAME"
+    echo "  ~/.claude/contrib/event-bus/event-bus.err"
+    exit 1
+fi

--- a/scripts/uninstall-systemd.sh
+++ b/scripts/uninstall-systemd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Uninstall the event bus systemd user service (preserves database)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_DEST="$HOME/.config/systemd/user/claude-event-bus.service"
+SERVICE_NAME="claude-event-bus"
+
+# Stop and disable service if running
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo "Stopping service..."
+    systemctl --user stop "$SERVICE_NAME"
+fi
+
+if systemctl --user is-enabled "$SERVICE_NAME" &>/dev/null; then
+    echo "Disabling service..."
+    systemctl --user disable "$SERVICE_NAME"
+fi
+
+# Remove service file
+if [[ -f "$SERVICE_DEST" ]]; then
+    echo "Removing service file..."
+    rm "$SERVICE_DEST"
+    systemctl --user daemon-reload
+fi
+
+# Uninstall CLI
+"$SCRIPT_DIR/uninstall-cli.sh"
+
+echo ""
+echo "Event bus uninstalled."
+echo "Note: Database preserved at ~/.claude/contrib/event-bus/data.db"


### PR DESCRIPTION
## Summary
- Add cross-platform service management that detects OS
- Use systemd user service on Linux, LaunchAgent on macOS
- `make install`, `make uninstall`, `make restart` now work on both platforms

## Changes
**New files:**
- `scripts/claude-event-bus.service` - systemd unit template
- `scripts/install-systemd.sh` - installs and enables systemd user service  
- `scripts/uninstall-systemd.sh` - stops and removes systemd service

**Modified:**
- `Makefile` - OS detection for install/uninstall/restart targets
- `scripts/dev.sh` - cross-platform service stop/restart for dev mode

## Test plan
- [x] `make install` on Linux → service starts via systemd
- [x] `systemctl --user status claude-event-bus` → active (running)
- [x] `make restart` → service restarts cleanly
- [x] All 254 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)