### PR TITLE
fix: Skip notifications on headless Linux servers

### DIFF
--- a/src/event_bus/helpers.py
+++ b/src/event_bus/helpers.py
@@ -121,6 +121,10 @@ def send_notification(title: str, message: str, sound: bool = False) -> bool:
             return True
 
         elif system == "Linux":
+            # Skip on headless servers (no display or D-Bus session)
+            if not os.environ.get("DISPLAY") and not os.environ.get("DBUS_SESSION_BUS_ADDRESS"):
+                return False  # Headless server, can't send notifications
+
             # Check for notify-send
             if shutil.which("notify-send"):
                 cmd = ["notify-send", title, message]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -100,11 +100,12 @@ class TestNotify:
         call_args = mock_run.call_args[0][0]
         assert "sound name" in call_args[2]
 
+    @patch.dict(os.environ, {"DISPLAY": ":0"})
     @patch("event_bus.helpers.platform.system")
     @patch("event_bus.helpers.shutil.which")
     @patch("event_bus.helpers.subprocess.run")
     def test_notify_linux(self, mock_run, mock_which, mock_system):
-        """Test notification on Linux."""
+        """Test notification on Linux with display."""
         mock_system.return_value = "Linux"
         mock_which.return_value = "/usr/bin/notify-send"
         mock_run.return_value = MagicMock()
@@ -115,6 +116,16 @@ class TestNotify:
         mock_run.assert_called_once()
         call_args = mock_run.call_args[0][0]
         assert call_args == ["notify-send", "Test", "Hello"]
+
+    @patch.dict(os.environ, {"DISPLAY": "", "DBUS_SESSION_BUS_ADDRESS": ""}, clear=False)
+    @patch("event_bus.helpers.platform.system")
+    def test_notify_linux_headless(self, mock_system):
+        """Test notification skipped on headless Linux."""
+        mock_system.return_value = "Linux"
+
+        result = notify(title="Test", message="Hello")
+
+        assert result["success"] is False
 
     @patch("event_bus.helpers.platform.system")
     def test_notify_unsupported_platform(self, mock_system):


### PR DESCRIPTION
## Summary
- Check for DISPLAY or DBUS_SESSION_BUS_ADDRESS before attempting notify-send on Linux
- Prevents noisy GDBus errors on headless VMs

## Test plan
- [x] Server runs without GDBus errors on headless Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)