### PR TITLE
fix: save cursor on early return in get_events resume path

### DIFF
--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -423,9 +423,12 @@ def get_events(
                 f"get_events: resume skipped, no cursor for session_id={session_id[:8]}..."
             )
             _dev_notify("get_events", f"resume skipped: no cursor for {session_id[:8]}...")
+            next_cursor = storage.get_cursor()
+            if session and next_cursor is not None:
+                storage.update_session_cursor(session_id, next_cursor)
             return {
                 "events": [],
-                "next_cursor": storage.get_cursor(),
+                "next_cursor": next_cursor,
             }
 
     storage.cleanup_stale_sessions()


### PR DESCRIPTION
## Summary
- Persist cursor on the early return path in `get_events` when `resume=True` encounters a session without a saved cursor
- Without this fix, sessions perpetually hit the "no cursor" branch and never see new events via `--resume`
- Added regression test verifying subsequent resume calls pick up new events

Fixes #102

## Test plan
- [x] New regression test `test_resume_saves_cursor_on_early_return` validates end-to-end behavior
- [x] All 294 existing tests pass
- [x] Format and lint clean (`ruff format --check`, `ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)