### PR TITLE
fix: Surface server errors in CLI events and unregister commands

### DIFF
--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -159,6 +159,11 @@ def cmd_unregister(args):
         sys.exit(1)
 
     result = call_tool("unregister_session", arguments, url=args.url, debug=args.debug)
+
+    if "error" in result:
+        print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
     print(json.dumps(result, indent=2))
 
 
@@ -252,6 +257,14 @@ def cmd_events(args):
     result = call_tool(
         "get_events", arguments, url=args.url, timeout_ms=args.timeout, debug=args.debug
     )
+
+    # Check for server-side errors (e.g., session not found)
+    if "error" in result:
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
 
     # Result is now a dict with "events" and "next_cursor"
     events = result.get("events", [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI wrapper."""
 
+import json
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
@@ -515,6 +516,58 @@ class TestCmdEvents:
         call_args = mock_call.call_args[0][1]
         assert call_args["resume"] is True
         assert call_args["session_id"] == "test-session"
+
+
+class TestCmdEventsErrorSurfacing:
+    """Tests for CLI surfacing server-side errors in events command."""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_events_error_json_mode(self, mock_call, capsys):
+        """Test that --json mode outputs server error as JSON and exits non-zero."""
+        mock_call.return_value = {"error": "Session not found", "session_id": "bad-id"}
+
+        args = make_events_args(json=True, session_id="bad-id", resume=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli.cmd_events(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["error"] == "Session not found"
+        assert output["session_id"] == "bad-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_events_error_text_mode(self, mock_call, capsys):
+        """Test that text mode prints error to stderr and exits non-zero."""
+        mock_call.return_value = {"error": "Session not found", "session_id": "bad-id"}
+
+        args = make_events_args(session_id="bad-id", resume=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli.cmd_events(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Session not found" in captured.err
+
+
+class TestCmdUnregisterErrorSurfacing:
+    """Tests for CLI surfacing server-side errors in unregister command."""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_unregister_error_surfaces(self, mock_call, capsys):
+        """Test that unregister surfaces server errors to stderr."""
+        mock_call.return_value = {"error": "Session not found", "session_id": "bad-id"}
+
+        args = Namespace(session_id="bad-id", client_id=None, url=None, debug=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli.cmd_unregister(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Session not found" in captured.err
 
 
 class TestCmdNotify:


### PR DESCRIPTION
## Summary

- CLI `cmd_events` and `cmd_unregister` now detect and surface server-side `{"error": ...}` responses
- In `--json` mode: outputs the full error dict to stdout for machine consumption
- In text mode: prints error message to stderr
- Both modes exit with status code 1 on error
- 3 new tests covering both modes and both commands

## Context

Discovered during live testing of #115 — the CLI `--resume --json` mode silently returned `{"events": [], "next_cursor": null}` instead of surfacing the server's `{"error": "Session not found"}` response.

Note: The venv bootstrap task from #117 was already fixed by PR #109 (migration to uv), so only the CLI error surfacing is addressed here.

Fixes #116, fixes #117

## Test plan

- [x] `test_events_error_json_mode` — JSON mode outputs error dict and exits 1
- [x] `test_events_error_text_mode` — text mode prints to stderr and exits 1
- [x] `test_unregister_error_surfaces` — unregister surfaces errors to stderr
- [x] All 304 tests pass, lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)