### PR TITLE
feat: add --peek (non-consuming read) to get_events

### DIFF
--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -9,7 +9,7 @@ Usage:
     agent-event-bus-cli publish --type TYPE --payload PAYLOAD [--channel CHANNEL] [--session-id ID]
     agent-event-bus-cli events [--cursor CURSOR] [--session-id ID] [--limit N] [--include T1,T2]
                          [--exclude T1,T2] [--timeout MS] [--json] [--order asc|desc]
-                         [--channel CHANNEL] [--resume]
+                         [--channel CHANNEL] [--resume] [--peek]
     agent-event-bus-cli notify --title TITLE --message MSG [--sound]
 
 Examples:
@@ -43,6 +43,9 @@ Examples:
 
     # Resume from saved cursor (incremental polling - no duplicates)
     agent-event-bus-cli events --session-id abc123 --resume --order asc
+
+    # Peek: read new events without consuming them (cursor stays put)
+    agent-event-bus-cli events --session-id abc123 --resume --peek
 
     # Filter by event type
     agent-event-bus-cli events --include task_completed,ci_completed
@@ -251,6 +254,8 @@ def cmd_events(args):
         arguments["channel"] = args.channel
     if args.resume:
         arguments["resume"] = True
+    if args.peek:
+        arguments["peek"] = True
     if args.include:
         arguments["event_types"] = [t.strip() for t in args.include.split(",")]
 
@@ -449,6 +454,11 @@ def main():
         "--resume",
         action="store_true",
         help="Resume from saved cursor position (requires --session-id, ignored if --cursor provided)",
+    )
+    p_events.add_argument(
+        "--peek",
+        action="store_true",
+        help="Read without advancing the session cursor (non-consuming; events stay unseen for the next poll)",
     )
     p_events.add_argument(
         "--include",

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -254,7 +254,7 @@ def cmd_events(args):
         arguments["channel"] = args.channel
     if args.resume:
         arguments["resume"] = True
-    if args.peek:
+    if getattr(args, "peek", False):
         arguments["peek"] = True
     if args.include:
         arguments["event_types"] = [t.strip() for t in args.include.split(",")]

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -107,6 +107,21 @@ get_events(cursor="42", order="asc")
 ```
 Pass `next_cursor` to subsequent calls. But `resume=True` is simpler.
 
+### Peeking (non-consuming reads)
+`peek=True` reads pending events **without advancing the session cursor**, so the
+same events are still returned by the next normal poll. Use it when something
+other than the main polling loop needs to inspect what's pending and decide
+whether to act — without stealing those events from the loop.
+```
+# Inspect pending events without consuming them
+get_events(session_id=session_id, resume=True, peek=True)
+→ {events: [...], next_cursor: "55"}   # cursor NOT advanced
+
+# A later normal poll still returns them and advances the cursor
+get_events(session_id=session_id, resume=True, order="asc")
+```
+CLI: `agent-event-bus-cli events --session-id ID --resume --peek`
+
 ## Common Patterns
 
 ### Signal when your work is ready

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -400,6 +400,7 @@ def get_events(
     channel: str | None = None,
     resume: bool = False,
     event_types: list[str] | None = None,
+    peek: bool = False,
 ) -> dict:
     """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
 
@@ -411,6 +412,7 @@ def get_events(
         channel: Filter to specific channel
         resume: Use saved cursor (requires session_id)
         event_types: Filter by types, e.g., ["task_completed"]
+        peek: Read without advancing the session cursor (non-consuming)
     """
     # Auto-refresh heartbeat when session polls
     _auto_heartbeat(session_id)
@@ -421,6 +423,10 @@ def get_events(
         session = storage.get_session(session_id)
         if session and session.last_cursor:
             cursor = session.last_cursor
+        elif session and peek:
+            # peek + resume on a cursor-less session: read from the tip without
+            # persisting it, so a non-consuming peek never advances the cursor.
+            cursor = storage.get_cursor()
         elif session:
             # Session exists but has no saved cursor - persist tip so next resume works
             tip = storage.get_cursor()
@@ -462,7 +468,11 @@ def get_events(
     # Note: Updates on any poll - any poll means the session has "seen" events up to this point.
     # Silently ignore unknown session_ids - callers may pass external session IDs
     # (like Claude Code's own UUIDs) that aren't registered with us.
-    if session_id and raw_events:
+    # peek=True reads without advancing: the events stay "unseen" so a later
+    # consuming poll (e.g. the UserPromptSubmit hook) still returns them. This
+    # lets a Stop-hook drain inspect pending events and decide whether to act
+    # without stealing them from the normal pull path.
+    if session_id and raw_events and not peek:
         high_water_mark = str(max(e.id for e in raw_events))
         storage.update_session_cursor(session_id, high_water_mark)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1000,6 +1000,60 @@ class TestSessionCursorTracking:
             assert f"event_{i}" in all_received, f"event_{i} was dropped"
 
 
+class TestPeek:
+    """Tests for peek mode: read without advancing the session cursor."""
+
+    def test_peek_does_not_advance_cursor(self):
+        """peek=True returns events but leaves the cursor untouched."""
+        reg = register_session(name="peek-test", machine="test-host", client_id="peek-1")
+        session_id = reg["session_id"]
+
+        # Establish a baseline cursor by consuming one event.
+        publish_event("task_completed", "Event 1")
+        get_events(session_id=session_id, resume=True, order="asc")
+        baseline = server.storage.get_session(session_id).last_cursor
+
+        # New event arrives; peek at it.
+        publish_event("help_needed", "Event 2")
+        peeked = get_events(session_id=session_id, resume=True, order="asc", peek=True)
+
+        # The event is returned...
+        assert any(e["event_type"] == "help_needed" for e in peeked["events"])
+        # ...but the cursor did NOT move.
+        assert server.storage.get_session(session_id).last_cursor == baseline
+
+    def test_peek_then_consume_returns_same_events(self):
+        """A peek is non-consuming: a subsequent normal poll still sees the events."""
+        reg = register_session(name="peek-consume", machine="test-host", client_id="peek-2")
+        session_id = reg["session_id"]
+
+        publish_event("task_completed", "Event 1")
+        get_events(session_id=session_id, resume=True, order="asc")
+
+        publish_event("help_needed", "Event 2")
+        peeked = get_events(session_id=session_id, resume=True, order="asc", peek=True)
+        consumed = get_events(session_id=session_id, resume=True, order="asc")
+
+        peeked_ids = [e["id"] for e in peeked["events"]]
+        consumed_ids = [e["id"] for e in consumed["events"]]
+        assert peeked_ids == consumed_ids
+        assert len(consumed_ids) >= 1
+
+        # After consuming, the cursor has advanced: a third poll is empty.
+        assert get_events(session_id=session_id, resume=True, order="asc")["events"] == []
+
+    def test_peek_on_cursorless_session_does_not_persist(self):
+        """peek + resume on a session with no saved cursor must not persist a cursor."""
+        reg = register_session(name="peek-cursorless", machine="test-host", client_id="peek-3")
+        session_id = reg["session_id"]
+        assert server.storage.get_session(session_id).last_cursor is None
+
+        get_events(session_id=session_id, resume=True, order="asc", peek=True)
+
+        # Still no persisted cursor — the peek left the session untouched.
+        assert server.storage.get_session(session_id).last_cursor is None
+
+
 class TestUnregisterByClientId:
     """Tests for unregister_session with client_id lookup."""
 


### PR DESCRIPTION
## What

Adds a non-consuming read mode to `get_events`:
- **MCP**: new `peek: bool = False` parameter on `get_events`
- **CLI**: new `--peek` flag on `agent-event-bus-cli events`

When `peek=True`, events are returned but the per-session cursor is **not advanced** — a later normal poll still sees them.

## Why

Enabler for the re-awakening work in **RFC #122**. A planned dotfiles **Stop-hook "event drain"** needs to inspect pending *directed* events (DMs to `session:<id>`, `help_needed` on the session's repo) when a turn ends and decide whether to keep working — **without stealing those events** from the `UserPromptSubmit` pull path, which shares the same server-side per-session cursor. `peek` gives that inspect-without-consume semantic; without it the two consumers race on one cursor.

## How

- `server.get_events`: skip `update_session_cursor` when `peek=True`. A cursor-less `resume` under `peek` reads from the tip **without persisting** it.
- `cli.py`: `--peek` passthrough + usage/examples.
- `guide.md`: "Peeking (non-consuming reads)" section.

## Tests

New `TestPeek`:
- `test_peek_does_not_advance_cursor`
- `test_peek_then_consume_returns_same_events`
- `test_peek_on_cursorless_session_does_not_persist`

**Local verification (run, not assumed):** `160 passed`; `ruff check` → All checks passed!; `ruff format --check` → 17 files already formatted.

## Related

- RFC #122 (re-awakening — first concrete enabler)
- Small fixes: #126 (notify), #128 (attribution), #129 (signal-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
