### PR TITLE
Concurrency hardening, CLI webhook fix, signal levels, and RFC #121 substrate

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
       - name: Check formatting
         run: uv run ruff format --check src tests
       - name: Lint
@@ -36,6 +36,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --python ${{ matrix.python-version }} --extra dev
+        run: uv sync --python ${{ matrix.python-version }}
       - name: Run tests
         run: uv run pytest -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,15 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 - `make install-server` - Idempotent, restarts service automatically
 - Schema migrations via `@migration` decorator (increment `SCHEMA_VERSION` when adding)
 
+### WAL mode:
+The database runs in WAL mode: `data.db-wal` and `data.db-shm` are **part of
+the database**. Never copy or move `data.db` alone (a plain `cp` can silently
+miss recently committed events sitting in the WAL) - use `sqlite3 .backup`,
+which is WAL-aware and safe against a running server.
+
 ### Before schema changes:
 ```bash
-cp ~/.claude/contrib/agent-event-bus/data.db ~/.claude/contrib/agent-event-bus/data.db.backup-$(date +%Y%m%d-%H%M%S)
+sqlite3 ~/.claude/contrib/agent-event-bus/data.db ".backup $HOME/.claude/contrib/agent-event-bus/data.db.backup-$(date +%Y%m%d-%H%M%S)"
 ```
 
 ## Commands
@@ -145,6 +151,7 @@ CLI and MCP expose the same functionality:
 - **Session cleanup**: 24-hour timeout + PID liveness checks for local sessions
 - **Auto-heartbeat**: `publish_event` and `get_events` refresh heartbeat
 - **Cursor auto-tracking**: `get_events(session_id=X)` persists cursor; `resume=True` uses it
+- **Non-consuming narrowed reads**: `channel`/`event_types`/`correlation_id` filters never advance the session cursor (their SQL-filtered max would mark non-matching events as seen); `min_level` filters post-bookkeeping and does
 - **High-water cursors**: `next_cursor` is the batch MAX id in both orders; feeding it back never re-serves events
 - **UUID session IDs**: `session_id` is UUID; `display_id` is human-readable ("brave-trex")
 - **Client deduplication**: `(machine, client_id)` enables session resumption

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,11 @@ src/agent_event_bus/
 
 ## MCP Tools
 
-`register_session`, `list_sessions`, `list_channels`, `publish_event`, `get_events`, `unregister_session`, `notify`
+`register_session`, `list_sessions`, `list_channels`, `publish_event`, `get_events`, `unregister_session`, `notify`, `register_webhook`, `list_webhooks`, `unregister_webhook`
 
 **Usage guide**: `agent-event-bus://guide` resource. Keep it updated when changing APIs.
+
+**Concurrency invariant**: FastMCP runs tool functions on the server's event loop, so every tool is an async wrapper that offloads its sync `*_impl` body via `_run_sync` (worker thread). Never put blocking work (SQLite, subprocess) directly in a tool function - it freezes the whole server (#112). `GET /health` bypasses MCP for liveness checks.
 
 ### Tool Docstrings
 
@@ -143,8 +145,11 @@ CLI and MCP expose the same functionality:
 - **Session cleanup**: 24-hour timeout + PID liveness checks for local sessions
 - **Auto-heartbeat**: `publish_event` and `get_events` refresh heartbeat
 - **Cursor auto-tracking**: `get_events(session_id=X)` persists cursor; `resume=True` uses it
+- **High-water cursors**: `next_cursor` is the batch MAX id in both orders; feeding it back never re-serves events
 - **UUID session IDs**: `session_id` is UUID; `display_id` is human-readable ("brave-trex")
 - **Client deduplication**: `(machine, client_id)` enables session resumption
+- **Structured payload (RFC #121)**: `payload` stays free-form; optional `title`/`tags`/`correlation_id`/`signal_level` ride alongside (soft validation - warn, never reject)
+- **Signal levels (#129)**: lifecycle < info < actionable, derived server-side from event_type (DMs always actionable; explicit `signal_level` wins); filter with `min_level`
 
 ## Operations
 

--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,20 @@ clean:
 	rm -rf build/ dist/ *.egg-info .pytest_cache .ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-# Create/sync virtual environment (requires uv)
+# Create/sync virtual environment without dev tools (requires uv)
 venv:
-	uv sync
+	uv sync --no-dev
 
 # Install with dev dependencies (for development)
 dev:
-	uv sync --extra dev
+	uv sync
 
 # Server installation: runs the event bus service locally (idempotent)
 # Use this on the machine that will host the event bus
 # Re-run to pick up code changes (restarts service automatically)
 install-server:
 	@echo "Installing server..."
-	uv sync
+	uv sync --no-dev
 	@echo ""
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		echo "Installing LaunchAgent (macOS)..."; \
@@ -75,7 +75,7 @@ install-client:
 		exit 1; \
 	fi
 	@echo "Installing client (connecting to $(REMOTE_URL))..."
-	uv sync
+	uv sync --no-dev
 	@echo ""
 	@echo "Installing CLI..."
 	./scripts/install-cli.sh

--- a/README.md
+++ b/README.md
@@ -151,9 +151,14 @@ Webhooks receive a POST with JSON body:
   "payload": "Finished building feature X",
   "session_id": "abc-123",
   "timestamp": "2026-01-31T08:00:00",
-  "channel": "repo:my-project"
+  "channel": "repo:my-project",
+  "correlation_id": null,
+  "signal_level": "info"
 }
 ```
+
+`correlation_id` and `signal_level` are always present (`signal_level` is
+server-derived); `title` and `tags` appear only when the event carries them.
 
 If a `secret` is configured, requests include an `X-Event-Bus-Signature` header:
 
@@ -210,7 +215,10 @@ Requires `terminal-notifier` for custom icon: `brew install terminal-notifier`
 
 ## Data
 
-All data in `~/.claude/contrib/agent-event-bus/`: `data.db`, `agent-event-bus.log`, `agent-event-bus.err`
+All data in `~/.claude/contrib/agent-event-bus/`: `data.db` (plus its WAL
+sidecars `data.db-wal` and `data.db-shm`, which are **part of the database**),
+`agent-event-bus.log`, `agent-event-bus.err`. Never copy `data.db` alone -
+use `sqlite3 data.db ".backup <dest>"` for a consistent backup.
 
 ## Related
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "uvicorn>=0.30.0",
     "requests>=2.31.0",
     "httpx>=0.27.0",
+    # Imported directly by server.py (not just via fastmcp): anyio.to_thread
+    # is the load-bearing primitive of the #112 fix, starlette backs /health
+    "anyio>=4.0.0",
+    "starlette>=0.37.0",
 ]
 
 # PEP 735 dependency group: uv syncs this by default, so a bare `uv run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 
-[project.optional-dependencies]
+# PEP 735 dependency group: uv syncs this by default, so a bare `uv run
+# pytest` on a fresh clone gets the project + dev tools instead of falling
+# through to a globally installed pytest that can't import the package.
+[dependency-groups]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -240,8 +240,11 @@ def cmd_publish(args):
 
 def cmd_events(args):
     """Get recent events."""
-    # Validate --resume requires --session-id
-    if args.resume and not args.session_id:
+    # Use explicit --session-id, fall back to env var (matches cmd_publish)
+    session_id = args.session_id or os.environ.get("AGENT_EVENT_BUS_SESSION_ID")
+
+    # Validate --resume requires a session id (flag or env var)
+    if args.resume and not session_id:
         print("Error: --resume requires --session-id", file=sys.stderr)
         sys.exit(1)
 
@@ -251,8 +254,8 @@ def cmd_events(args):
         arguments["cursor"] = cursor
     if args.limit is not None:
         arguments["limit"] = args.limit
-    if args.session_id:
-        arguments["session_id"] = args.session_id
+    if session_id:
+        arguments["session_id"] = session_id
     if args.channel:
         arguments["channel"] = args.channel
     if args.resume:
@@ -430,7 +433,10 @@ def main():
     # events
     p_events = subparsers.add_parser("events", help="Get recent events")
     p_events.add_argument("--cursor", help="Cursor from previous call (for pagination)")
-    p_events.add_argument("--session-id", help="Your session ID (for cursor tracking)")
+    p_events.add_argument(
+        "--session-id",
+        help="Your session ID for cursor tracking (default: $AGENT_EVENT_BUS_SESSION_ID)",
+    )
     p_events.add_argument("--limit", type=int, help="Maximum number of events to return")
     p_events.add_argument(
         "--exclude",

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -297,9 +297,10 @@ def cmd_events(args):
             print(f"Error: {result['error']}", file=sys.stderr)
         sys.exit(1)
 
-    # Result is now a dict with "events" and "next_cursor"
+    # Result is now a dict with "events", "next_cursor", and "has_more"
     events = result.get("events", [])
     next_cursor = result.get("next_cursor")
+    has_more = result.get("has_more", False)
 
     # Apply --exclude filter (client-side for flexibility)
     if args.exclude:
@@ -308,7 +309,7 @@ def cmd_events(args):
 
     # Output format
     if args.json:
-        output = {"events": events, "next_cursor": next_cursor}
+        output = {"events": events, "next_cursor": next_cursor, "has_more": has_more}
         print(json.dumps(output))
     else:
         if not events:

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -11,6 +11,9 @@ Usage:
                          [--exclude T1,T2] [--timeout MS] [--json] [--order asc|desc]
                          [--channel CHANNEL] [--resume] [--peek]
     agent-event-bus-cli notify --title TITLE --message MSG [--sound]
+    agent-event-bus-cli webhook register --url URL [--channel CH] [--event-types T1,T2] [--secret S]
+    agent-event-bus-cli webhook list [--all]
+    agent-event-bus-cli webhook unregister WEBHOOK_ID
 
 Examples:
     # Register a session
@@ -314,7 +317,11 @@ def cmd_notify(args):
 
 def cmd_webhook_register(args):
     """Register a webhook."""
-    arguments = {"url": args.url}
+    # args.webhook_url is the endpoint to register; args.url stays the bus URL.
+    # These must not share an argparse dest: the subparser's value would
+    # overwrite the global --url and the MCP call would be POSTed to the
+    # webhook target instead of the bus.
+    arguments = {"url": args.webhook_url}
     if args.channel:
         arguments["channel"] = args.channel
     if args.event_types:
@@ -322,7 +329,7 @@ def cmd_webhook_register(args):
     if args.secret:
         arguments["secret"] = args.secret
 
-    result = call_tool("register_webhook", arguments, url=args.bus_url, debug=args.debug)
+    result = call_tool("register_webhook", arguments, url=args.url, debug=args.debug)
     print(json.dumps(result, indent=2))
     if "webhook_id" in result:
         print(f"\nWebhook registered: #{result['webhook_id']}", file=sys.stderr)
@@ -331,7 +338,7 @@ def cmd_webhook_register(args):
 def cmd_webhook_list(args):
     """List registered webhooks."""
     arguments = {"active_only": not args.all}
-    result = call_tool("list_webhooks", arguments, url=args.bus_url, debug=args.debug)
+    result = call_tool("list_webhooks", arguments, url=args.url, debug=args.debug)
 
     if not result:
         print("No webhooks registered")
@@ -356,7 +363,7 @@ def cmd_webhook_unregister(args):
     result = call_tool(
         "unregister_webhook",
         {"webhook_id": args.webhook_id},
-        url=args.bus_url,
+        url=args.url,
         debug=args.debug,
     )
     if result.get("success"):
@@ -479,23 +486,27 @@ def main():
 
     # webhook register
     p_wh_register = webhook_subparsers.add_parser("register", help="Register a webhook")
-    p_wh_register.add_argument("--url", required=True, help="Webhook URL to POST events to")
+    # dest must differ from the global --url (bus address) or argparse
+    # overwrites it with the webhook target
+    p_wh_register.add_argument(
+        "--url", dest="webhook_url", required=True, help="Webhook URL to POST events to"
+    )
     p_wh_register.add_argument(
         "--channel", help="Filter to channel (supports prefix, e.g., 'session:')"
     )
     p_wh_register.add_argument("--event-types", help="Comma-separated event types to filter")
     p_wh_register.add_argument("--secret", help="Shared secret for HMAC signing")
-    p_wh_register.set_defaults(func=cmd_webhook_register, bus_url=None)
+    p_wh_register.set_defaults(func=cmd_webhook_register)
 
     # webhook list
     p_wh_list = webhook_subparsers.add_parser("list", help="List webhooks")
     p_wh_list.add_argument("--all", action="store_true", help="Include inactive webhooks")
-    p_wh_list.set_defaults(func=cmd_webhook_list, bus_url=None)
+    p_wh_list.set_defaults(func=cmd_webhook_list)
 
     # webhook unregister
     p_wh_unregister = webhook_subparsers.add_parser("unregister", help="Remove a webhook")
     p_wh_unregister.add_argument("webhook_id", type=int, help="Webhook ID to remove")
-    p_wh_unregister.set_defaults(func=cmd_webhook_unregister, bus_url=None)
+    p_wh_unregister.set_defaults(func=cmd_webhook_unregister)
 
     args = parser.parse_args()
 
@@ -509,8 +520,6 @@ def main():
         if args.webhook_command is None:
             p_webhook.print_help()
             sys.exit(1)
-        # Pass the main URL to webhook subcommands
-        args.bus_url = args.url
 
     args.func(args)
 

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -275,6 +275,8 @@ def cmd_events(args):
         arguments["event_types"] = [t.strip() for t in args.include.split(",")]
     if getattr(args, "correlation_id", None):
         arguments["correlation_id"] = args.correlation_id
+    if getattr(args, "min_level", None):
+        arguments["min_level"] = args.min_level
 
     result = call_tool(
         "get_events", arguments, url=args.url, timeout_ms=args.timeout, debug=args.debug
@@ -502,6 +504,11 @@ def main():
         help="Comma-separated event types to include (e.g., task_completed,ci_completed)",
     )
     p_events.add_argument("--correlation-id", help="Filter to one correlation thread")
+    p_events.add_argument(
+        "--min-level",
+        choices=["lifecycle", "info", "actionable"],
+        help="Drop events below this signal level (server-side; replaces client denylists)",
+    )
     p_events.set_defaults(func=cmd_events)
 
     # notify

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -233,6 +233,15 @@ def cmd_publish(args):
     session_id = args.session_id or os.environ.get("AGENT_EVENT_BUS_SESSION_ID")
     if session_id:
         arguments["session_id"] = session_id
+    # Optional structured payload fields (RFC #121)
+    if getattr(args, "title", None):
+        arguments["title"] = args.title
+    if getattr(args, "tags", None):
+        arguments["tags"] = [t.strip() for t in args.tags.split(",")]
+    if getattr(args, "correlation_id", None):
+        arguments["correlation_id"] = args.correlation_id
+    if getattr(args, "signal_level", None):
+        arguments["signal_level"] = args.signal_level
 
     result = call_tool("publish_event", arguments, url=args.url, debug=args.debug)
     print(json.dumps(result, indent=2))
@@ -264,6 +273,8 @@ def cmd_events(args):
         arguments["peek"] = True
     if args.include:
         arguments["event_types"] = [t.strip() for t in args.include.split(",")]
+    if getattr(args, "correlation_id", None):
+        arguments["correlation_id"] = args.correlation_id
 
     result = call_tool(
         "get_events", arguments, url=args.url, timeout_ms=args.timeout, debug=args.debug
@@ -296,8 +307,13 @@ def cmd_events(args):
             return
         for e in events:
             print(f"[{e['id']}] {e['event_type']} ({e['channel']})")
+            if e.get("title"):
+                print(f"    title: {e['title']}")
             print(f"    {e['payload']}")
-            print(f"    from: {e['session_id']} at {e['timestamp']}")
+            from_line = f"    from: {e['session_id']} at {e['timestamp']}"
+            if e.get("correlation_id"):
+                from_line += f" corr:{e['correlation_id']}"
+            print(from_line)
             print()
 
 
@@ -428,6 +444,14 @@ def main():
     p_publish.add_argument(
         "--session-id", help="Your session ID (default: $AGENT_EVENT_BUS_SESSION_ID)"
     )
+    p_publish.add_argument("--title", help="Optional short headline for the payload")
+    p_publish.add_argument("--tags", help="Comma-separated tags for downstream filtering")
+    p_publish.add_argument("--correlation-id", help="Thread ID linking a request to its response")
+    p_publish.add_argument(
+        "--signal-level",
+        choices=["lifecycle", "info", "actionable"],
+        help="Signal level override (default: derived from event type)",
+    )
     p_publish.set_defaults(func=cmd_publish)
 
     # events
@@ -477,6 +501,7 @@ def main():
         "--include",
         help="Comma-separated event types to include (e.g., task_completed,ci_completed)",
     )
+    p_events.add_argument("--correlation-id", help="Filter to one correlation thread")
     p_events.set_defaults(func=cmd_events)
 
     # notify

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -7,9 +7,12 @@ Usage:
     agent-event-bus-cli sessions
     agent-event-bus-cli channels
     agent-event-bus-cli publish --type TYPE --payload PAYLOAD [--channel CHANNEL] [--session-id ID]
+                         [--title TITLE] [--tags T1,T2] [--correlation-id ID]
+                         [--signal-level lifecycle|info|actionable]
     agent-event-bus-cli events [--cursor CURSOR] [--session-id ID] [--limit N] [--include T1,T2]
                          [--exclude T1,T2] [--timeout MS] [--json] [--order asc|desc]
-                         [--channel CHANNEL] [--resume] [--peek]
+                         [--channel CHANNEL] [--resume] [--peek] [--correlation-id ID]
+                         [--min-level lifecycle|info|actionable]
     agent-event-bus-cli notify --title TITLE --message MSG [--sound]
     agent-event-bus-cli webhook register --url URL [--channel CH] [--event-types T1,T2] [--secret S]
     agent-event-bus-cli webhook list [--all]
@@ -507,7 +510,8 @@ def main():
     )
     p_events.add_argument(
         "--channel",
-        help="Filter to a specific channel (e.g., 'repo:my-project', 'all')",
+        help="Filter to a specific channel (e.g., 'repo:my-project', 'all') "
+        "(non-consuming: does not advance the session cursor)",
     )
     p_events.add_argument(
         "--resume",
@@ -521,9 +525,14 @@ def main():
     )
     p_events.add_argument(
         "--include",
-        help="Comma-separated event types to include (e.g., task_completed,ci_completed)",
+        help="Comma-separated event types to include (e.g., task_completed,ci_completed) "
+        "(non-consuming: does not advance the session cursor)",
     )
-    p_events.add_argument("--correlation-id", help="Filter to one correlation thread")
+    p_events.add_argument(
+        "--correlation-id",
+        help="Filter to one correlation thread "
+        "(non-consuming: does not advance the session cursor)",
+    )
     p_events.add_argument(
         "--min-level",
         choices=["lifecycle", "info", "actionable"],

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -315,22 +315,28 @@ def cmd_events(args):
         if not events:
             print("No events")
         for e in events:
-            print(f"[{e['id']}] {e['event_type']} ({e['channel']})")
+            header = f"[{e['id']}] {e['event_type']} ({e['channel']})"
+            if e.get("signal_level"):
+                header += f" [{e['signal_level']}]"
+            print(header)
             if e.get("title"):
                 print(f"    title: {e['title']}")
             print(f"    {e['payload']}")
             from_line = f"    from: {e['session_id']} at {e['timestamp']}"
             if e.get("correlation_id"):
                 from_line += f" corr:{e['correlation_id']}"
+            if e.get("tags"):
+                from_line += f" tags:{','.join(e['tags'])}"
             print(from_line)
             print()
         if has_more:
-            # The default desc order serves the newest slice; without this
-            # hint a large backlog gets silently truncated on screen
-            print(
-                "More events available; use --order asc with --cursor to drain the backlog.",
-                file=sys.stderr,
-            )
+            # Without this hint a large backlog gets silently truncated on
+            # screen; the actionable next step depends on the order
+            if args.order == "asc":
+                hint = f"More events available; re-poll with --cursor {next_cursor}."
+            else:
+                hint = "More events available; use --order asc with --cursor to drain the backlog."
+            print(hint, file=sys.stderr)
 
 
 def cmd_notify(args):

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -54,6 +54,13 @@ Examples:
     agent-event-bus-cli events --include task_completed,ci_completed
     agent-event-bus-cli events --include gotcha_discovered,pattern_found --exclude session_registered
 
+    # Drop lifecycle noise server-side (lifecycle < info < actionable)
+    agent-event-bus-cli events --min-level info
+
+    # Thread a request to its responses with a correlation id
+    agent-event-bus-cli publish --type task_request --payload "Review PR #42?" --correlation-id review-42
+    agent-event-bus-cli events --correlation-id review-42 --order asc
+
     # Send notification
     agent-event-bus-cli notify --title "Build Complete" --message "All tests passed"
 """

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -241,13 +241,13 @@ def cmd_publish(args):
     if session_id:
         arguments["session_id"] = session_id
     # Optional structured payload fields (RFC #121)
-    if getattr(args, "title", None):
+    if args.title:
         arguments["title"] = args.title
-    if getattr(args, "tags", None):
+    if args.tags:
         arguments["tags"] = [t.strip() for t in args.tags.split(",")]
-    if getattr(args, "correlation_id", None):
+    if args.correlation_id:
         arguments["correlation_id"] = args.correlation_id
-    if getattr(args, "signal_level", None):
+    if args.signal_level:
         arguments["signal_level"] = args.signal_level
 
     result = call_tool("publish_event", arguments, url=args.url, debug=args.debug)
@@ -276,13 +276,13 @@ def cmd_events(args):
         arguments["channel"] = args.channel
     if args.resume:
         arguments["resume"] = True
-    if getattr(args, "peek", False):
+    if args.peek:
         arguments["peek"] = True
     if args.include:
         arguments["event_types"] = [t.strip() for t in args.include.split(",")]
-    if getattr(args, "correlation_id", None):
+    if args.correlation_id:
         arguments["correlation_id"] = args.correlation_id
-    if getattr(args, "min_level", None):
+    if args.min_level:
         arguments["min_level"] = args.min_level
 
     result = call_tool(
@@ -314,7 +314,6 @@ def cmd_events(args):
     else:
         if not events:
             print("No events")
-            return
         for e in events:
             print(f"[{e['id']}] {e['event_type']} ({e['channel']})")
             if e.get("title"):
@@ -325,6 +324,13 @@ def cmd_events(args):
                 from_line += f" corr:{e['correlation_id']}"
             print(from_line)
             print()
+        if has_more:
+            # The default desc order serves the newest slice; without this
+            # hint a large backlog gets silently truncated on screen
+            print(
+                "More events available; use --order asc with --cursor to drain the backlog.",
+                file=sys.stderr,
+            )
 
 
 def cmd_notify(args):

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -105,6 +105,12 @@ Narrowing filters (`channel`, `event_types`, `correlation_id`) are
 didn't match your filter stay unread for the next normal poll. (`min_level`
 is the exception - noise it hides still counts as seen.)
 
+The flip side: a filtered poll is a *pure read* - with `resume=True` it
+returns the same matching events on every call, forever. Don't build a
+notification loop on `--include ... --resume`. To make progress, page
+manually with `cursor`/`next_cursor`, or consume unfiltered and narrow with
+`min_level` (which advances the cursor) or client-side `--exclude`.
+
 ### Filter by Signal Level
 
 Every event carries a server-derived `signal_level`, so consumers don't need

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -124,11 +124,17 @@ session cursor - they count as seen.
 ### Manual Cursor (if needed)
 ```
 get_events(cursor="42", order="asc")
-→ {events: [...], next_cursor: "55"}
+→ {events: [...], next_cursor: "55", has_more: false}
 ```
 Pass `next_cursor` to subsequent calls. But `resume=True` is simpler.
 `next_cursor` is always the newest event ID in the batch (regardless of
 `order`), so feeding it back never returns the same event twice.
+
+`has_more: true` means the batch filled `limit` and the window may hold
+more. With `order="asc"`, keep feeding `next_cursor` back to drain the
+backlog. With `order="desc"` the page is the *newest* slice, so older
+backlog events are skipped by the next cursor call — use `order="asc"`
+when you must not miss events.
 
 ### Peeking (non-consuming reads)
 `peek=True` reads pending events **without advancing the session cursor**, so the

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -100,6 +100,11 @@ Useful for focused polling (e.g., only discoveries):
 get_events(event_types=["gotcha_discovered", "pattern_found", "improvement_suggested"])
 ```
 
+Narrowing filters (`channel`, `event_types`, `correlation_id`) are
+**non-consuming**: they never advance your session cursor, so events that
+didn't match your filter stay unread for the next normal poll. (`min_level`
+is the exception - noise it hides still counts as seen.)
+
 ### Filter by Signal Level
 
 Every event carries a server-derived `signal_level`, so consumers don't need
@@ -224,7 +229,9 @@ See `docs/TAILSCALE_SETUP.md` for full setup instructions.
 ## Health Check
 
 `GET /health` answers `{"status": "ok"}` without touching the MCP handler or
-storage - use it for monitoring. If `/health` responds but tool calls hang,
+storage - use it for monitoring. It sits behind the same auth as everything
+else: reachable from localhost, or remotely via `tailscale serve` (which
+injects the identity headers). If `/health` responds but tool calls hang,
 the worker pool is saturated; if `/health` itself hangs, the event loop is
 blocked.
 
@@ -253,10 +260,13 @@ When events match, your endpoint receives a POST with:
     "session_id": "abc123",
     "timestamp": "2026-01-31T12:00:00",
     "channel": "repo:my-project",
-    "correlation_id": null
+    "correlation_id": null,
+    "signal_level": "info"
 }
 ```
-Structured fields (`title`, `tags`, `signal_level`) are included when the
+`correlation_id` and `signal_level` are always present - `signal_level` is
+server-derived, matching what `get_events` reports for the same event, so
+webhook consumers can filter on it. `title` and `tags` appear only when the
 event carries them.
 
 ### HMAC Signature Verification

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -106,7 +106,9 @@ didn't match your filter stay unread for the next normal poll. (`min_level`
 is the exception - noise it hides still counts as seen.)
 
 The flip side: a filtered poll is a *pure read* - with `resume=True` it
-returns the same matching events on every call, forever. Don't build a
+returns the same matching events on every call, forever. And on a session
+that has never polled unfiltered (no saved cursor yet), a narrowed resume
+returns nothing at all: the read starts from the tip. Don't build a
 notification loop on `--include ... --resume`. To make progress, page
 manually with `cursor`/`next_cursor`, or consume unfiltered and narrow with
 `min_level` (which advances the cursor) or client-side `--exclude`.

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -16,8 +16,8 @@ CC sessions (e.g., in separate terminals or worktrees), this MCP server lets ses
 | `register_session(name, client_id?)` | Register yourself, get session_id + cursor |
 | `list_sessions()` | See active sessions |
 | `list_channels()` | See active channels |
-| `publish_event(type, payload, channel?)` | Send event |
-| `get_events(session_id?, resume?, order?, event_types?)` | Poll for events |
+| `publish_event(type, payload, channel?, correlation_id?, ...)` | Send event |
+| `get_events(session_id?, resume?, order?, event_types?, min_level?)` | Poll for events |
 | `unregister_session(session_id?)` | Clean up on exit |
 | `notify(title, message, sound?)` | System notification |
 | `register_webhook(url, channel?, event_types?, secret?)` | Register HTTP endpoint for push notifications |
@@ -100,12 +100,35 @@ Useful for focused polling (e.g., only discoveries):
 get_events(event_types=["gotcha_discovered", "pattern_found", "improvement_suggested"])
 ```
 
+### Filter by Signal Level
+
+Every event carries a server-derived `signal_level`, so consumers don't need
+to maintain their own denylists of noisy event types:
+
+| Level | Meaning | Examples |
+|-------|---------|----------|
+| `lifecycle` | Registration/watching churn | `session_registered`, `ci_watching`, `task_started` |
+| `info` | Ambient broadcasts worth seeing | `gotcha_discovered`, `pattern_found` (and any unlisted type) |
+| `actionable` | Aimed at someone | `help_needed`, `blocker_found`, `ci_failed`, any DM (`session:` channel) |
+
+```
+get_events(min_level="info")        # drop lifecycle churn
+get_events(min_level="actionable")  # only things aimed at someone
+```
+CLI: `agent-event-bus-cli events --min-level info`
+
+Publishers can override the derived level with `signal_level` on
+`publish_event`. Events filtered out by `min_level` still advance your
+session cursor - they count as seen.
+
 ### Manual Cursor (if needed)
 ```
 get_events(cursor="42", order="asc")
 → {events: [...], next_cursor: "55"}
 ```
 Pass `next_cursor` to subsequent calls. But `resume=True` is simpler.
+`next_cursor` is always the newest event ID in the batch (regardless of
+`order`), so feeding it back never returns the same event twice.
 
 ### Peeking (non-consuming reads)
 `peek=True` reads pending events **without advancing the session cursor**, so the
@@ -121,6 +144,41 @@ get_events(session_id=session_id, resume=True, peek=True)
 get_events(session_id=session_id, resume=True, order="asc")
 ```
 CLI: `agent-event-bus-cli events --session-id ID --resume --peek`
+
+## Structured Payload Fields
+
+`payload` stays a free-form string, but `publish_event` accepts optional
+structured fields (all additive, all backward-compatible):
+
+| Field | Purpose |
+|-------|---------|
+| `title` | Short headline so consumers can scan without parsing the payload |
+| `tags` | List of strings for downstream filtering/analytics |
+| `correlation_id` | Thread ID linking a request to its response(s) |
+| `signal_level` | Override the derived level: `lifecycle`, `info`, `actionable` |
+
+These come back on `get_events` results (`correlation_id` and
+`signal_level` always; `title`/`tags` when present) and in webhook payloads.
+
+### Request/response threading
+```
+publish_event("task_request", "Review PR #42?", correlation_id="review-42",
+              channel=f"session:{target_id}")
+
+# The responder echoes the correlation_id:
+publish_event("task_response", "LGTM, one nit inline", correlation_id="review-42")
+
+# Either side reads the whole thread:
+get_events(correlation_id="review-42", order="asc")
+```
+CLI: `agent-event-bus-cli events --correlation-id review-42`
+
+### Link, don't inline
+
+The bus is for coordination signals, not artifact transfer. If a payload is
+more than a couple of paragraphs, store the artifact elsewhere (a memory
+file, an issue, a note) and publish a `title` + summary + link instead.
+This is a guideline, not an enforced cap.
 
 ## Common Patterns
 
@@ -157,6 +215,13 @@ For multi-machine setups via Tailscale:
 
 See `docs/TAILSCALE_SETUP.md` for full setup instructions.
 
+## Health Check
+
+`GET /health` answers `{"status": "ok"}` without touching the MCP handler or
+storage - use it for monitoring. If `/health` responds but tool calls hang,
+the worker pool is saturated; if `/health` itself hangs, the event loop is
+blocked.
+
 ## Webhooks (Push Notifications)
 
 Instead of polling, you can register HTTP endpoints to receive events via POST.
@@ -181,9 +246,12 @@ When events match, your endpoint receives a POST with:
     "payload": "PR #42 merged",
     "session_id": "abc123",
     "timestamp": "2026-01-31T12:00:00",
-    "channel": "repo:my-project"
+    "channel": "repo:my-project",
+    "correlation_id": null
 }
 ```
+Structured fields (`title`, `tags`, `signal_level`) are included when the
+event carries them.
 
 ### HMAC Signature Verification
 If you provide a `secret`, requests include `X-Event-Bus-Signature` header:
@@ -230,24 +298,27 @@ Webhooks retry up to 2 times with exponential backoff if the endpoint returns 4x
 2. **Use resume=True for polling** - Simplest incremental approach
 3. **Include session_id in get_events** - Enables cursor tracking + heartbeat
 4. **Use meaningful channels** - `repo:` or `session:` for context
-5. **Keep payloads short** - Coordination, not data transfer
-6. **Unregister on exit** - Keeps session list clean
+5. **Keep payloads lean** - Big artifacts get a `title` + summary + link ("link, don't inline")
+6. **Use correlation_id for request/response** - Don't invent per-protocol threading
+7. **Filter with min_level** - Instead of maintaining event-type denylists
+8. **Unregister on exit** - Keeps session list clean
 
 ## Event Type Conventions
 
 Use consistent event types for discoverability:
 
-| Event Type | When to Use |
-|------------|-------------|
-| `task_started` | Work begun on issue/task |
-| `task_completed` | Significant task finished |
-| `ci_completed` | CI finished (pass or fail) |
-| `help_needed` | Request for assistance |
-| `gotcha_discovered` | Non-obvious issue found |
-| `pattern_found` | Useful pattern discovered |
-| `test_flaky` | Flaky test identified |
-| `blocker_found` | Blocking issue discovered |
-| `error_broadcast` | Rate limits, outages |
+| Event Type | When to Use | Signal Level |
+|------------|-------------|--------------|
+| `task_started` | Work begun on issue/task | lifecycle |
+| `task_completed` | Significant task finished | info |
+| `ci_completed` | CI finished (pass or fail) | info |
+| `ci_failed` | CI failure needing attention | actionable |
+| `help_needed` | Request for assistance | actionable |
+| `gotcha_discovered` | Non-obvious issue found | info |
+| `pattern_found` | Useful pattern discovered | info |
+| `test_flaky` | Flaky test identified | info |
+| `blocker_found` | Blocking issue discovered | actionable |
+| `error_broadcast` | Rate limits, outages | actionable |
 
 **Naming**: Use `snake_case`, be specific (`ci_completed` not `done`), include context in payload.
 

--- a/src/agent_event_bus/helpers.py
+++ b/src/agent_event_bus/helpers.py
@@ -8,6 +8,11 @@ import subprocess
 
 logger = logging.getLogger("agent-event-bus")
 
+# Notification subprocesses (terminal-notifier/osascript/notify-send) can hang
+# indefinitely; a bounded timeout keeps a stuck notifier from wedging the
+# worker that called it (issue #112).
+NOTIFY_TIMEOUT = 5.0  # seconds
+
 
 def _sanitize_name(name: str) -> str:
     """Sanitize a name by replacing problematic characters."""
@@ -103,7 +108,7 @@ def send_notification(title: str, message: str, sound: bool = False) -> bool:
                 if icon_path and os.path.exists(icon_path):
                     cmd.extend(["-appIcon", icon_path])
 
-                subprocess.run(cmd, check=True, capture_output=True)
+                subprocess.run(cmd, check=True, capture_output=True, timeout=NOTIFY_TIMEOUT)
                 return True
 
             # Fallback to osascript (no custom icon support)
@@ -117,6 +122,7 @@ def send_notification(title: str, message: str, sound: bool = False) -> bool:
                 ["osascript", "-e", script],
                 check=True,
                 capture_output=True,
+                timeout=NOTIFY_TIMEOUT,
             )
             return True
 
@@ -128,7 +134,7 @@ def send_notification(title: str, message: str, sound: bool = False) -> bool:
             # Check for notify-send
             if shutil.which("notify-send"):
                 cmd = ["notify-send", title, message]
-                subprocess.run(cmd, check=True, capture_output=True)
+                subprocess.run(cmd, check=True, capture_output=True, timeout=NOTIFY_TIMEOUT)
                 return True
             else:
                 return False  # notify-send not available
@@ -136,6 +142,9 @@ def send_notification(title: str, message: str, sound: bool = False) -> bool:
         else:
             return False  # Unsupported platform
 
+    except subprocess.TimeoutExpired as e:
+        logger.error(f"Notification command timed out after {NOTIFY_TIMEOUT}s: {e.cmd}")
+        return False
     except subprocess.CalledProcessError as e:
         # Include stderr/stdout for debugging
         stderr = e.stderr.decode() if e.stderr else "no stderr"

--- a/src/agent_event_bus/middleware.py
+++ b/src/agent_event_bus/middleware.py
@@ -6,6 +6,8 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+import anyio.to_thread
+
 if TYPE_CHECKING:
     from agent_event_bus.storage import SQLiteStorage
 
@@ -411,10 +413,16 @@ class RequestLoggingMiddleware:
 
         await self.app(scope, receive_wrapper, send_wrapper)
 
-        # Log after request completes
+        # Log after the response has been sent. The formatting helpers hit
+        # SQLite (display-id lookups) and the logger blocks on disk, so the
+        # whole block runs in a worker thread to keep the event loop free
+        # (#112 invariant - same class of fix as the tool bodies).
         request_body = b"".join(body_parts)
         response_body = b"".join(response_parts)
+        await anyio.to_thread.run_sync(self._log_tool_call, request_body, response_body)
 
+    def _log_tool_call(self, request_body: bytes, response_body: bytes) -> None:
+        """Parse and log one MCP tool call (runs in a worker thread)."""
         try:
             req_json = json.loads(request_body) if request_body else {}
             req_method = req_json.get("method", "?")

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -83,6 +83,41 @@ WEBHOOK_MAX_RETRIES = 2  # Number of retries for failed webhooks
 # are stored as-is with a warning, never rejected.
 VALID_SIGNAL_LEVELS = ("lifecycle", "info", "actionable")
 
+# Signal-level ordering for min_level filtering (#129): one canonical noise
+# policy on the server so clients subscribe by level instead of each
+# maintaining a denylist of low-signal event types.
+SIGNAL_LEVEL_ORDER = {"lifecycle": 0, "info": 1, "actionable": 2}
+
+# event_type -> derived level. Anything not listed is "info".
+EVENT_TYPE_SIGNAL_LEVELS = {
+    # lifecycle: registration/watching/rerun churn
+    "session_registered": "lifecycle",
+    "session_unregistered": "lifecycle",
+    "ci_watching": "lifecycle",
+    "ci_rerun": "lifecycle",
+    "task_started": "lifecycle",
+    "parallel_work_started": "lifecycle",
+    # actionable: things aimed at someone
+    "help_needed": "actionable",
+    "blocker_found": "actionable",
+    "ci_failed": "actionable",
+    "error_broadcast": "actionable",
+}
+
+
+def _get_signal_level(event: Event) -> str:
+    """Effective signal level for an event.
+
+    An explicit publish-time signal_level wins; DMs (session: channels) are
+    always actionable; otherwise the level derives from event_type.
+    """
+    if event.meta and event.meta.get("signal_level") in SIGNAL_LEVEL_ORDER:
+        return event.meta["signal_level"]
+    if event.channel.startswith("session:"):
+        return "actionable"
+    return EVENT_TYPE_SIGNAL_LEVELS.get(event.event_type, "info")
+
+
 # Initialize MCP server
 mcp = FastMCP("agent-event-bus")
 
@@ -497,6 +532,7 @@ def _event_to_dict(e: Event) -> dict:
         "timestamp": e.timestamp.isoformat(),
         "channel": e.channel,
         "correlation_id": e.correlation_id,
+        "signal_level": _get_signal_level(e),
     }
     if e.meta:
         if "title" in e.meta:
@@ -516,6 +552,7 @@ def _get_events_impl(
     event_types: list[str] | None = None,
     peek: bool = False,
     correlation_id: str | None = None,
+    min_level: Literal["lifecycle", "info", "actionable"] | None = None,
 ) -> dict:
     """Sync implementation of get_events (runs in a worker thread)."""
     # Auto-refresh heartbeat when session polls
@@ -585,6 +622,16 @@ def _get_events_impl(
         high_water_mark = str(max(e.id for e in raw_events))
         storage.update_session_cursor(session_id, high_water_mark)
 
+    # Level filtering happens after cursor bookkeeping: filtered-out events
+    # still count as "seen" (they are noise by definition, not missed signal).
+    # A page may therefore return fewer than `limit` events; keep paging by
+    # next_cursor.
+    if min_level:
+        threshold = SIGNAL_LEVEL_ORDER[min_level]
+        raw_events = [
+            e for e in raw_events if SIGNAL_LEVEL_ORDER[_get_signal_level(e)] >= threshold
+        ]
+
     events = [_event_to_dict(e) for e in raw_events]
 
     _dev_notify("get_events", f"{len(events)} events (cursor={cursor})")
@@ -606,6 +653,7 @@ async def get_events(
     event_types: list[str] | None = None,
     peek: bool = False,
     correlation_id: str | None = None,
+    min_level: Literal["lifecycle", "info", "actionable"] | None = None,
 ) -> dict:
     """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
 
@@ -619,6 +667,7 @@ async def get_events(
         event_types: Filter by types, e.g., ["task_completed"]
         peek: Read without advancing the session cursor (non-consuming)
         correlation_id: Filter to one correlation thread
+        min_level: Drop events below this signal level (lifecycle < info < actionable)
     """
     return await _run_sync(
         _get_events_impl,
@@ -631,6 +680,7 @@ async def get_events(
         event_types=event_types,
         peek=peek,
         correlation_id=correlation_id,
+        min_level=min_level,
     )
 
 

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -79,6 +79,10 @@ MAX_PAYLOAD_PREVIEW = 50  # Max chars to show in notification previews
 WEBHOOK_TIMEOUT = 5.0  # Seconds to wait for webhook response
 WEBHOOK_MAX_RETRIES = 2  # Number of retries for failed webhooks
 
+# Known signal levels (RFC #121 / #129). Validation is soft: unknown values
+# are stored as-is with a warning, never rejected.
+VALID_SIGNAL_LEVELS = ("lifecycle", "info", "actionable")
+
 # Initialize MCP server
 mcp = FastMCP("agent-event-bus")
 
@@ -374,6 +378,10 @@ def _publish_event_impl(
     payload: str,
     session_id: str | None = None,
     channel: str = "all",
+    title: str | None = None,
+    tags: list[str] | None = None,
+    correlation_id: str | None = None,
+    signal_level: str | None = None,
 ) -> dict:
     """Sync implementation of publish_event (runs in a worker thread)."""
     # Auto-refresh heartbeat when session publishes
@@ -389,14 +397,28 @@ def _publish_event_impl(
                     f"Expected '{channel_type}:<value>'"
                 )
 
+    # Soft validation (RFC #121): warn on unknown signal levels, never reject
+    if signal_level and signal_level not in VALID_SIGNAL_LEVELS:
+        logger.warning(
+            f"Unknown signal_level '{signal_level}' (expected one of "
+            f"{', '.join(VALID_SIGNAL_LEVELS)}). Storing as-is."
+        )
+
     # Auto-notify on direct messages (DMs)
     _notify_dm_recipient(channel, payload, session_id)
 
+    meta = {
+        k: v
+        for k, v in {"title": title, "tags": tags, "signal_level": signal_level}.items()
+        if v is not None
+    }
     event = storage.add_event(
         event_type=event_type,
         payload=payload,
         session_id=session_id or "anonymous",
         channel=channel,
+        correlation_id=correlation_id,
+        meta=meta or None,
     )
 
     # Dispatch to matching webhooks (async, non-blocking)
@@ -407,12 +429,15 @@ def _publish_event_impl(
     )
     _dev_notify("publish_event", f"{event_type} [{channel}] {truncated}")
 
-    return {
+    result = {
         "event_id": event.id,
         "event_type": event_type,
         "payload": payload,
         "channel": channel,
     }
+    if correlation_id:
+        result["correlation_id"] = correlation_id
+    return result
 
 
 @mcp.tool()
@@ -421,6 +446,10 @@ async def publish_event(
     payload: str,
     session_id: str | None = None,
     channel: str = "all",
+    title: str | None = None,
+    tags: list[str] | None = None,
+    correlation_id: str | None = None,
+    signal_level: str | None = None,
 ) -> dict:
     """Publish an event. Auto-refreshes heartbeat. Returns event_id.
 
@@ -429,6 +458,10 @@ async def publish_event(
         payload: Event message
         session_id: Your session ID
         channel: "all", "session:{id}", "repo:{name}", or "machine:{name}"
+        title: Optional short headline for the payload
+        tags: Optional list of tags for downstream filtering
+        correlation_id: Optional thread ID linking a request to its response
+        signal_level: Optional "lifecycle", "info", or "actionable"
     """
     return await _run_sync(
         _publish_event_impl,
@@ -436,6 +469,10 @@ async def publish_event(
         payload=payload,
         session_id=session_id,
         channel=channel,
+        title=title,
+        tags=tags,
+        correlation_id=correlation_id,
+        signal_level=signal_level,
     )
 
 
@@ -450,6 +487,25 @@ def _get_implicit_channels(session_id: str | None) -> list[str] | None:
     return None
 
 
+def _event_to_dict(e: Event) -> dict:
+    """Convert an Event to its wire representation."""
+    d = {
+        "id": e.id,
+        "event_type": e.event_type,
+        "payload": e.payload,
+        "session_id": e.session_id,
+        "timestamp": e.timestamp.isoformat(),
+        "channel": e.channel,
+        "correlation_id": e.correlation_id,
+    }
+    if e.meta:
+        if "title" in e.meta:
+            d["title"] = e.meta["title"]
+        if "tags" in e.meta:
+            d["tags"] = e.meta["tags"]
+    return d
+
+
 def _get_events_impl(
     cursor: str | None = None,
     limit: int = 50,
@@ -459,6 +515,7 @@ def _get_events_impl(
     resume: bool = False,
     event_types: list[str] | None = None,
     peek: bool = False,
+    correlation_id: str | None = None,
 ) -> dict:
     """Sync implementation of get_events (runs in a worker thread)."""
     # Auto-refresh heartbeat when session polls
@@ -505,7 +562,12 @@ def _get_events_impl(
         channels = _get_implicit_channels(session_id)
 
     raw_events, next_cursor = storage.get_events(
-        cursor=cursor, limit=limit, channels=channels, order=order, event_types=event_types
+        cursor=cursor,
+        limit=limit,
+        channels=channels,
+        order=order,
+        event_types=event_types,
+        correlation_id=correlation_id,
     )
 
     # Persist high-water mark for session-based tracking (enables seamless resume)
@@ -523,17 +585,7 @@ def _get_events_impl(
         high_water_mark = str(max(e.id for e in raw_events))
         storage.update_session_cursor(session_id, high_water_mark)
 
-    events = [
-        {
-            "id": e.id,
-            "event_type": e.event_type,
-            "payload": e.payload,
-            "session_id": e.session_id,
-            "timestamp": e.timestamp.isoformat(),
-            "channel": e.channel,
-        }
-        for e in raw_events
-    ]
+    events = [_event_to_dict(e) for e in raw_events]
 
     _dev_notify("get_events", f"{len(events)} events (cursor={cursor})")
 
@@ -553,6 +605,7 @@ async def get_events(
     resume: bool = False,
     event_types: list[str] | None = None,
     peek: bool = False,
+    correlation_id: str | None = None,
 ) -> dict:
     """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
 
@@ -565,6 +618,7 @@ async def get_events(
         resume: Use saved cursor (requires session_id)
         event_types: Filter by types, e.g., ["task_completed"]
         peek: Read without advancing the session cursor (non-consuming)
+        correlation_id: Filter to one correlation thread
     """
     return await _run_sync(
         _get_events_impl,
@@ -576,6 +630,7 @@ async def get_events(
         resume=resume,
         event_types=event_types,
         peek=peek,
+        correlation_id=correlation_id,
     )
 
 
@@ -687,7 +742,12 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
         "session_id": event.session_id,
         "timestamp": event.timestamp.isoformat(),
         "channel": event.channel,
+        "correlation_id": event.correlation_id,
     }
+    if event.meta:
+        for key in ("title", "tags", "signal_level"):
+            if key in event.meta:
+                payload[key] = event.meta[key]
     payload_bytes = json.dumps(payload).encode()
 
     headers = {"Content-Type": "application/json"}

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -619,7 +619,13 @@ def _get_events_impl(
     # consuming poll (e.g. the UserPromptSubmit hook) still returns them. This
     # lets a Stop-hook drain inspect pending events and decide whether to act
     # without stealing them from the normal pull path.
-    if session_id and raw_events and not peek:
+    # Narrowing filters (channel, event_types, correlation_id) make the read
+    # non-consuming: the max id below is taken over the SQL-filtered batch,
+    # so advancing the cursor would mark every non-matching lower-id event
+    # as seen and silently drop it from a later resume. min_level filters
+    # after this bookkeeping, so level-filtered noise still counts as seen.
+    narrowed = bool(channel or event_types or correlation_id)
+    if session_id and raw_events and not peek and not narrowed:
         high_water_mark = str(max(e.id for e in raw_events))
         storage.update_session_cursor(session_id, high_water_mark)
 
@@ -658,6 +664,9 @@ async def get_events(
     min_level: Literal["lifecycle", "info", "actionable"] | None = None,
 ) -> dict:
     """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
+
+    Narrowed reads (channel/event_types/correlation_id) never advance the
+    session cursor; min_level does.
 
     Args:
         cursor: Position from register_session or previous call

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -579,6 +579,7 @@ def _get_events_impl(
             return {
                 "events": [],
                 "next_cursor": tip,
+                "has_more": False,
             }
         else:
             # Session doesn't exist
@@ -598,7 +599,7 @@ def _get_events_impl(
     else:
         channels = _get_implicit_channels(session_id)
 
-    raw_events, next_cursor = storage.get_events(
+    raw_events, next_cursor, has_more = storage.get_events(
         cursor=cursor,
         limit=limit,
         channels=channels,
@@ -639,6 +640,7 @@ def _get_events_impl(
     return {
         "events": events,
         "next_cursor": next_cursor,
+        "has_more": has_more,
     }
 
 
@@ -768,7 +770,10 @@ def _get_webhook_client() -> httpx.AsyncClient:
     The client's connection pool is bound to the loop it was created on;
     reusing it from a different loop hangs or errors. When the loop changes
     (e.g. dispatch fell back to a fresh thread's loop), a new client is
-    created and the stale one is left for GC.
+    created; the stale one can't be aclosed from here (its loop is usually
+    already dead) and is left for GC. That churn is bounded: production
+    dispatch stays on the server loop, and the thread fallback closes its
+    own client before its loop exits.
     """
     global _webhook_client, _webhook_client_loop
     loop = asyncio.get_running_loop()
@@ -793,9 +798,11 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
         "timestamp": event.timestamp.isoformat(),
         "channel": event.channel,
         "correlation_id": event.correlation_id,
+        # Derived level, matching what get_events reports for the same event
+        "signal_level": _get_signal_level(event),
     }
     if event.meta:
-        for key in ("title", "tags", "signal_level"):
+        for key in ("title", "tags"):
             if key in event.meta:
                 payload[key] = event.meta[key]
     payload_bytes = json.dumps(payload).encode()
@@ -840,7 +847,9 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
 
 async def _dispatch_webhooks(event: Event) -> None:
     """Dispatch event to all matching webhooks (async, fire-and-forget)."""
-    webhooks = storage.get_matching_webhooks(event)
+    # This coroutine runs on the server loop; the webhook lookup hits SQLite,
+    # so it must go to a worker thread like every other blocking call (#112)
+    webhooks = await anyio.to_thread.run_sync(storage.get_matching_webhooks, event)
     if not webhooks:
         return
 
@@ -882,8 +891,26 @@ def _handle_dispatch_task_exception(task: asyncio.Task, event_id: int) -> None:
 
 def _run_dispatch_in_thread(event: Event) -> None:
     """Run webhook dispatch in a new thread with its own event loop."""
+
+    async def dispatch_and_close() -> None:
+        global _webhook_client
+        try:
+            await _dispatch_webhooks(event)
+        finally:
+            # This throwaway loop is about to die; close the client it
+            # created so pooled sockets don't linger until GC. Only touch
+            # the global if it still belongs to this loop.
+            client = _webhook_client
+            if (
+                client is not None
+                and not client.is_closed
+                and _webhook_client_loop is asyncio.get_running_loop()
+            ):
+                _webhook_client = None
+                await client.aclose()
+
     try:
-        asyncio.run(_dispatch_webhooks(event))
+        asyncio.run(dispatch_and_close())
     except Exception as e:
         logger.error(f"Webhook dispatch failed for event {event.id}: {e}")
 

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -469,6 +469,11 @@ def _publish_event_impl(
         "event_type": event_type,
         "payload": payload,
         "channel": channel,
+        # Effective level, so publishers see what the server assigned - soft
+        # validation means an unknown signal_level is otherwise silently
+        # replaced by the derived value (the warning only reaches the server
+        # log, not the caller)
+        "signal_level": _get_signal_level(event),
     }
     if correlation_id:
         result["correlation_id"] = correlation_id

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -564,9 +564,10 @@ def _get_events_impl(
         session = storage.get_session(session_id)
         if session and session.last_cursor:
             cursor = session.last_cursor
-        elif session and peek:
-            # peek + resume on a cursor-less session: read from the tip without
-            # persisting it, so a non-consuming peek never advances the cursor.
+        elif session and (peek or channel or event_types or correlation_id):
+            # Non-consuming reads (peek or narrowed) on a cursor-less session:
+            # read from the tip without persisting it. Persisting here would
+            # let a narrowed resume mark the entire backlog as seen.
             cursor = storage.get_cursor()
         elif session:
             # Session exists but has no saved cursor - persist tip so next resume works

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -13,6 +13,7 @@ Provides tools for cross-session Claude Code communication:
 """
 
 import asyncio
+import functools
 import hashlib
 import hmac
 import json
@@ -25,8 +26,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
+import anyio.to_thread
 import httpx
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from agent_event_bus.helpers import (
     _dev_notify,
@@ -80,6 +84,23 @@ mcp = FastMCP("agent-event-bus")
 
 # SQLite-backed storage (persists across restarts)
 storage = SQLiteStorage()
+
+# The server's event loop, captured on the first tool call. Lets code running
+# in worker threads (webhook dispatch) schedule coroutines on the real loop.
+_server_loop: asyncio.AbstractEventLoop | None = None
+
+
+async def _run_sync(func, /, **kwargs):
+    """Run a sync tool implementation in a worker thread.
+
+    FastMCP executes tool functions directly on the event loop, so a blocking
+    call (SQLite under contention, a hung notification subprocess) freezes the
+    whole server (issue #112). Offloading to anyio's thread pool keeps the loop
+    free to accept and answer other requests.
+    """
+    global _server_loop
+    _server_loop = asyncio.get_running_loop()
+    return await anyio.to_thread.run_sync(functools.partial(func, **kwargs))
 
 
 @mcp.resource("agent-event-bus://guide", description="Usage guide and best practices")
@@ -185,21 +206,13 @@ def _notify_dm_recipient(
         logger.warning(f"Failed to notify session {target_id} of DM: {e}")
 
 
-@mcp.tool()
-def register_session(
+def _register_session_impl(
     name: str,
     machine: str | None = None,
     cwd: str | None = None,
     client_id: str | None = None,
 ) -> dict:
-    """Register with the event bus. Returns session_id and cursor for polling.
-
-    Args:
-        name: Session name (e.g., branch name, task)
-        machine: Defaults to hostname
-        cwd: Defaults to $PWD
-        client_id: Enables session resumption via (machine, client_id)
-    """
+    """Sync implementation of register_session (runs in a worker thread)."""
     storage.cleanup_stale_sessions()
 
     now = datetime.now()
@@ -283,8 +296,27 @@ def register_session(
 
 
 @mcp.tool()
-def list_sessions() -> list[dict]:
-    """List active sessions, ordered by most recently active."""
+async def register_session(
+    name: str,
+    machine: str | None = None,
+    cwd: str | None = None,
+    client_id: str | None = None,
+) -> dict:
+    """Register with the event bus. Returns session_id and cursor for polling.
+
+    Args:
+        name: Session name (e.g., branch name, task)
+        machine: Defaults to hostname
+        cwd: Defaults to $PWD
+        client_id: Enables session resumption via (machine, client_id)
+    """
+    return await _run_sync(
+        _register_session_impl, name=name, machine=machine, cwd=cwd, client_id=client_id
+    )
+
+
+def _list_sessions_impl() -> list[dict]:
+    """Sync implementation of list_sessions (runs in a worker thread)."""
     results = []
 
     for s in _get_live_sessions():
@@ -309,8 +341,13 @@ def list_sessions() -> list[dict]:
 
 
 @mcp.tool()
-def list_channels() -> list[dict]:
-    """List channels with subscriber counts."""
+async def list_sessions() -> list[dict]:
+    """List active sessions, ordered by most recently active."""
+    return await _run_sync(_list_sessions_impl)
+
+
+def _list_channels_impl() -> list[dict]:
+    """Sync implementation of list_channels (runs in a worker thread)."""
     channel_subscribers: dict[str, int] = {}
 
     for s in _get_live_sessions():
@@ -327,20 +364,18 @@ def list_channels() -> list[dict]:
 
 
 @mcp.tool()
-def publish_event(
+async def list_channels() -> list[dict]:
+    """List channels with subscriber counts."""
+    return await _run_sync(_list_channels_impl)
+
+
+def _publish_event_impl(
     event_type: str,
     payload: str,
     session_id: str | None = None,
     channel: str = "all",
 ) -> dict:
-    """Publish an event. Auto-refreshes heartbeat. Returns event_id.
-
-    Args:
-        event_type: e.g., 'task_completed', 'help_needed'
-        payload: Event message
-        session_id: Your session ID
-        channel: "all", "session:{id}", "repo:{name}", or "machine:{name}"
-    """
+    """Sync implementation of publish_event (runs in a worker thread)."""
     # Auto-refresh heartbeat when session publishes
     _auto_heartbeat(session_id)
 
@@ -380,6 +415,30 @@ def publish_event(
     }
 
 
+@mcp.tool()
+async def publish_event(
+    event_type: str,
+    payload: str,
+    session_id: str | None = None,
+    channel: str = "all",
+) -> dict:
+    """Publish an event. Auto-refreshes heartbeat. Returns event_id.
+
+    Args:
+        event_type: e.g., 'task_completed', 'help_needed'
+        payload: Event message
+        session_id: Your session ID
+        channel: "all", "session:{id}", "repo:{name}", or "machine:{name}"
+    """
+    return await _run_sync(
+        _publish_event_impl,
+        event_type=event_type,
+        payload=payload,
+        session_id=session_id,
+        channel=channel,
+    )
+
+
 def _get_implicit_channels(session_id: str | None) -> list[str] | None:
     """Get the channels a session is implicitly subscribed to.
 
@@ -391,8 +450,7 @@ def _get_implicit_channels(session_id: str | None) -> list[str] | None:
     return None
 
 
-@mcp.tool()
-def get_events(
+def _get_events_impl(
     cursor: str | None = None,
     limit: int = 50,
     session_id: str | None = None,
@@ -402,18 +460,7 @@ def get_events(
     event_types: list[str] | None = None,
     peek: bool = False,
 ) -> dict:
-    """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
-
-    Args:
-        cursor: Position from register_session or previous call
-        limit: Max events (default: 50)
-        session_id: Enables cursor auto-tracking
-        order: "desc" (newest first) or "asc"
-        channel: Filter to specific channel
-        resume: Use saved cursor (requires session_id)
-        event_types: Filter by types, e.g., ["task_completed"]
-        peek: Read without advancing the session cursor (non-consuming)
-    """
+    """Sync implementation of get_events (runs in a worker thread)."""
     # Auto-refresh heartbeat when session polls
     _auto_heartbeat(session_id)
 
@@ -497,13 +544,43 @@ def get_events(
 
 
 @mcp.tool()
-def unregister_session(session_id: str | None = None, client_id: str | None = None) -> dict:
-    """Unregister from event bus. session_id takes precedence if both given.
+async def get_events(
+    cursor: str | None = None,
+    limit: int = 50,
+    session_id: str | None = None,
+    order: Literal["asc", "desc"] = "desc",
+    channel: str | None = None,
+    resume: bool = False,
+    event_types: list[str] | None = None,
+    peek: bool = False,
+) -> dict:
+    """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
 
     Args:
-        session_id: Your session ID
-        client_id: Alternative - looks up by (machine, client_id)
+        cursor: Position from register_session or previous call
+        limit: Max events (default: 50)
+        session_id: Enables cursor auto-tracking
+        order: "desc" (newest first) or "asc"
+        channel: Filter to specific channel
+        resume: Use saved cursor (requires session_id)
+        event_types: Filter by types, e.g., ["task_completed"]
+        peek: Read without advancing the session cursor (non-consuming)
     """
+    return await _run_sync(
+        _get_events_impl,
+        cursor=cursor,
+        limit=limit,
+        session_id=session_id,
+        order=order,
+        channel=channel,
+        resume=resume,
+        event_types=event_types,
+        peek=peek,
+    )
+
+
+def _unregister_session_impl(session_id: str | None = None, client_id: str | None = None) -> dict:
+    """Sync implementation of unregister_session (runs in a worker thread)."""
     # Look up session by client_id if provided
     if client_id and not session_id:
         machine = socket.gethostname()
@@ -541,14 +618,18 @@ def unregister_session(session_id: str | None = None, client_id: str | None = No
 
 
 @mcp.tool()
-def notify(title: str, message: str, sound: bool = False) -> dict:
-    """Send a system notification.
+async def unregister_session(session_id: str | None = None, client_id: str | None = None) -> dict:
+    """Unregister from event bus. session_id takes precedence if both given.
 
     Args:
-        title: Short title
-        message: Body text
-        sound: Play sound (default: False)
+        session_id: Your session ID
+        client_id: Alternative - looks up by (machine, client_id)
     """
+    return await _run_sync(_unregister_session_impl, session_id=session_id, client_id=client_id)
+
+
+def _notify_impl(title: str, message: str, sound: bool = False) -> dict:
+    """Sync implementation of notify (runs in a worker thread)."""
     success = send_notification(title, message, sound)
     return {
         "success": success,
@@ -557,17 +638,38 @@ def notify(title: str, message: str, sound: bool = False) -> dict:
     }
 
 
+@mcp.tool()
+async def notify(title: str, message: str, sound: bool = False) -> dict:
+    """Send a system notification.
+
+    Args:
+        title: Short title
+        message: Body text
+        sound: Play sound (default: False)
+    """
+    return await _run_sync(_notify_impl, title=title, message=message, sound=sound)
+
+
 # Webhook support
 
 # Module-level HTTP client for webhook dispatch (connection pooling)
 _webhook_client: httpx.AsyncClient | None = None
+_webhook_client_loop: asyncio.AbstractEventLoop | None = None
 
 
 def _get_webhook_client() -> httpx.AsyncClient:
-    """Get or create the shared webhook HTTP client."""
-    global _webhook_client
-    if _webhook_client is None or _webhook_client.is_closed:
+    """Get or create the shared webhook HTTP client for the current event loop.
+
+    The client's connection pool is bound to the loop it was created on;
+    reusing it from a different loop hangs or errors. When the loop changes
+    (e.g. dispatch fell back to a fresh thread's loop), a new client is
+    created and the stale one is left for GC.
+    """
+    global _webhook_client, _webhook_client_loop
+    loop = asyncio.get_running_loop()
+    if _webhook_client is None or _webhook_client.is_closed or _webhook_client_loop is not loop:
         _webhook_client = httpx.AsyncClient(timeout=WEBHOOK_TIMEOUT)
+        _webhook_client_loop = loop
     return _webhook_client
 
 
@@ -677,35 +779,44 @@ def _run_dispatch_in_thread(event: Event) -> None:
 
 
 def _schedule_webhook_dispatch(event: Event) -> None:
-    """Schedule webhook dispatch in background (non-blocking)."""
+    """Schedule webhook dispatch in background (non-blocking).
+
+    Tool implementations run in worker threads (no running loop), so the
+    normal path hands the coroutine to the server loop captured by _run_sync.
+    The thread fallback only remains for direct sync calls (e.g. tests).
+    """
+    # Capture event.id in closure to avoid issues if event object changes
+    event_id = event.id
+
     try:
         loop = asyncio.get_running_loop()
-        task = loop.create_task(_dispatch_webhooks(event))
-        # Capture event.id in closure to avoid issues if event object changes
-        event_id = event.id
-        task.add_done_callback(lambda t: _handle_dispatch_task_exception(t, event_id))
     except RuntimeError:
-        # No running event loop (sync context) - run in background thread
-        # This shouldn't happen in normal MCP/uvicorn operation but handles edge cases
-        thread = threading.Thread(target=_run_dispatch_in_thread, args=(event,), daemon=True)
-        thread.start()
+        loop = None
+
+    if loop is not None:
+        task = loop.create_task(_dispatch_webhooks(event))
+        task.add_done_callback(lambda t: _handle_dispatch_task_exception(t, event_id))
+        return
+
+    server_loop = _server_loop
+    if server_loop is not None and server_loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(_dispatch_webhooks(event), server_loop)
+        # concurrent.futures.Future has the same cancelled()/exception() API
+        future.add_done_callback(lambda f: _handle_dispatch_task_exception(f, event_id))
+        return
+
+    # No event loop anywhere (direct sync context) - run in background thread
+    thread = threading.Thread(target=_run_dispatch_in_thread, args=(event,), daemon=True)
+    thread.start()
 
 
-@mcp.tool()
-def register_webhook(
+def _register_webhook_impl(
     url: str,
     channel: str | None = None,
     event_types: list[str] | None = None,
     secret: str | None = None,
 ) -> dict:
-    """Register a webhook to receive event notifications via HTTP POST.
-
-    Args:
-        url: HTTP(S) endpoint to POST events to
-        channel: Filter to specific channel (None = all). Supports prefix matching.
-        event_types: Filter to specific event types (None = all)
-        secret: Shared secret for HMAC signing (optional)
-    """
+    """Sync implementation of register_webhook (runs in a worker thread)."""
     webhook = storage.add_webhook(
         url=url,
         channel_filter=channel,
@@ -725,12 +836,27 @@ def register_webhook(
 
 
 @mcp.tool()
-def list_webhooks(active_only: bool = True) -> list[dict]:
-    """List registered webhooks.
+async def register_webhook(
+    url: str,
+    channel: str | None = None,
+    event_types: list[str] | None = None,
+    secret: str | None = None,
+) -> dict:
+    """Register a webhook to receive event notifications via HTTP POST.
 
     Args:
-        active_only: If True, only return active webhooks (default: True)
+        url: HTTP(S) endpoint to POST events to
+        channel: Filter to specific channel (None = all). Supports prefix matching.
+        event_types: Filter to specific event types (None = all)
+        secret: Shared secret for HMAC signing (optional)
     """
+    return await _run_sync(
+        _register_webhook_impl, url=url, channel=channel, event_types=event_types, secret=secret
+    )
+
+
+def _list_webhooks_impl(active_only: bool = True) -> list[dict]:
+    """Sync implementation of list_webhooks (runs in a worker thread)."""
     webhooks = storage.list_webhooks(active_only=active_only)
 
     results = [
@@ -751,12 +877,17 @@ def list_webhooks(active_only: bool = True) -> list[dict]:
 
 
 @mcp.tool()
-def unregister_webhook(webhook_id: int) -> dict:
-    """Remove a webhook registration.
+async def list_webhooks(active_only: bool = True) -> list[dict]:
+    """List registered webhooks.
 
     Args:
-        webhook_id: ID of the webhook to remove
+        active_only: If True, only return active webhooks (default: True)
     """
+    return await _run_sync(_list_webhooks_impl, active_only=active_only)
+
+
+def _unregister_webhook_impl(webhook_id: int) -> dict:
+    """Sync implementation of unregister_webhook (runs in a worker thread)."""
     deleted = storage.delete_webhook(webhook_id)
 
     if deleted:
@@ -764,6 +895,27 @@ def unregister_webhook(webhook_id: int) -> dict:
         return {"success": True, "webhook_id": webhook_id}
     else:
         return {"success": False, "error": "Webhook not found", "webhook_id": webhook_id}
+
+
+@mcp.tool()
+async def unregister_webhook(webhook_id: int) -> dict:
+    """Remove a webhook registration.
+
+    Args:
+        webhook_id: ID of the webhook to remove
+    """
+    return await _run_sync(_unregister_webhook_impl, webhook_id=webhook_id)
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    """Liveness probe that bypasses the MCP handler (issue #112).
+
+    Runs entirely on the event loop with no storage access, so it answers
+    even when worker threads are saturated - a hung /health means the loop
+    itself is blocked.
+    """
+    return JSONResponse({"status": "ok", "service": "agent-event-bus"})
 
 
 def create_app():

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -265,6 +265,11 @@ class SQLiteStorage:
 
         Old: ~/.claude/event-bus.db or ~/.claude/contrib/event-bus/data.db
         New: ~/.claude/contrib/agent-event-bus/data.db
+
+        Moving only data.db is safe here ONLY because the old paths predate
+        WAL mode (single-file databases). Do not reuse this pattern for a
+        WAL-era path: data.db-wal / data.db-shm are part of the database and
+        would be left behind.
         """
         if self.db_path.exists():
             return  # Already at new location, nothing to do
@@ -295,10 +300,13 @@ class SQLiteStorage:
             # lock, which is the norm when several agents poll and publish at
             # once (issue #112). journal_mode is persistent per-database but
             # cheap to re-assert; busy_timeout is per-connection and must be
-            # set each time. Inside the try so a PRAGMA failure (e.g. WAL on
-            # a network filesystem) still closes the connection.
-            conn.execute("PRAGMA journal_mode=WAL")
+            # set each time - and set FIRST, so the one-time WAL conversion
+            # of a legacy DB queues briefly under contention instead of
+            # failing fast with SQLITE_BUSY. Inside the try so a PRAGMA
+            # failure (e.g. WAL on a network filesystem) still closes the
+            # connection.
             conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+            conn.execute("PRAGMA journal_mode=WAL")
             yield conn
             conn.commit()
         finally:

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -290,13 +290,15 @@ class SQLiteStorage:
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
         )
         conn.row_factory = sqlite3.Row
-        # WAL lets concurrent readers proceed while a writer holds the lock,
-        # which is the norm when several agents poll and publish at once
-        # (issue #112). journal_mode is persistent per-database but cheap to
-        # re-assert; busy_timeout is per-connection and must be set each time.
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         try:
+            # WAL lets concurrent readers proceed while a writer holds the
+            # lock, which is the norm when several agents poll and publish at
+            # once (issue #112). journal_mode is persistent per-database but
+            # cheap to re-assert; busy_timeout is per-connection and must be
+            # set each time. Inside the try so a PRAGMA failure (e.g. WAL on
+            # a network filesystem) still closes the connection.
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
             yield conn
             conn.commit()
         finally:
@@ -647,7 +649,7 @@ class SQLiteStorage:
         order: Literal["asc", "desc"] = "desc",
         event_types: list[str] | None = None,
         correlation_id: str | None = None,
-    ) -> tuple[list[Event], str | None]:
+    ) -> tuple[list[Event], str | None, bool]:
         """Get events with cursor-based pagination.
 
         Args:
@@ -659,8 +661,13 @@ class SQLiteStorage:
             correlation_id: Optional correlation thread to filter by (None = all).
 
         Returns:
-            Tuple of (events, next_cursor). Use next_cursor for subsequent calls.
-            next_cursor is the cursor value if there are events, None otherwise.
+            Tuple of (events, next_cursor, has_more). next_cursor is the batch
+            high-water mark (MAX id) in both orders. has_more=True means the
+            window matched at least `limit` events. With order="asc", keep
+            feeding next_cursor back to drain the backlog. With order="desc"
+            the batch is the NEWEST slice of the window, so older backlog
+            events are NOT reachable via next_cursor - drain with "asc" if you
+            must not miss events.
         """
         with self._connect() as conn:
             effective_order = "DESC" if order == "desc" else "ASC"
@@ -730,7 +737,11 @@ class SQLiteStorage:
             else:
                 next_cursor = cursor  # No new events, keep same cursor
 
-            return events, next_cursor
+            # A full page means the window may hold more than `limit` events
+            # (exactly-limit gives a false positive; one extra empty poll).
+            has_more = len(events) == limit
+
+            return events, next_cursor, has_more
 
     def get_cursor(self) -> str | None:
         """Get a cursor pointing to the most recent event.

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -1,5 +1,6 @@
 """SQLite storage backend for event bus persistence."""
 
+import json
 import logging
 import os
 import shutil
@@ -15,7 +16,7 @@ logger = logging.getLogger("agent-event-bus")
 
 # Schema version for migrations
 # Increment this when adding new migrations
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 # Migration function type: takes a connection, returns nothing
 MigrationFunc = Callable[[sqlite3.Connection], None]
@@ -121,6 +122,25 @@ def migrate_v3(conn: sqlite3.Connection) -> None:
     """)
 
 
+# Migration for structured payload fields (RFC #121)
+@migration(4, "structured_payload_fields")
+def migrate_v4(conn: sqlite3.Connection) -> None:
+    """Add correlation_id and payload_meta columns to events.
+
+    correlation_id gets its own indexed column so request/response threading
+    (#107, #97) can be filtered efficiently. The remaining optional structured
+    fields (title, tags, signal_level) share a single JSON payload_meta column.
+    """
+    cursor = conn.execute("PRAGMA table_info(events)")
+    existing_columns = {row[1] for row in cursor.fetchall()}
+
+    if "correlation_id" not in existing_columns:
+        conn.execute("ALTER TABLE events ADD COLUMN correlation_id TEXT")
+    if "payload_meta" not in existing_columns:
+        conn.execute("ALTER TABLE events ADD COLUMN payload_meta TEXT")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_events_correlation ON events(correlation_id)")
+
+
 # Register datetime adapters/converters (required for Python 3.12+)
 # See: https://docs.python.org/3/library/sqlite3.html#default-adapters-and-converters-deprecated
 
@@ -186,6 +206,8 @@ class Event:
     session_id: str
     timestamp: datetime
     channel: str = "all"  # Target channel for the event
+    correlation_id: str | None = None  # Threads a request to its response
+    meta: dict | None = None  # Optional structured fields: title, tags, signal_level
 
 
 @dataclass
@@ -360,7 +382,9 @@ class SQLiteStorage:
                     payload TEXT NOT NULL,
                     session_id TEXT NOT NULL,
                     timestamp TIMESTAMP NOT NULL,
-                    channel TEXT NOT NULL DEFAULT 'all'
+                    channel TEXT NOT NULL DEFAULT 'all',
+                    correlation_id TEXT,
+                    payload_meta TEXT
                 )
             """)
             # Add channel column if upgrading from older schema
@@ -372,6 +396,8 @@ class SQLiteStorage:
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_events_id ON events(id)
             """)
+            # idx_events_correlation is created by migration v4, which runs for
+            # fresh installs too (version 0 -> SCHEMA_VERSION)
             # Index for efficient session ordering by activity
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_sessions_heartbeat ON sessions(last_heartbeat)
@@ -552,17 +578,33 @@ class SQLiteStorage:
     # Event operations
 
     def add_event(
-        self, event_type: str, payload: str, session_id: str, channel: str = "all"
+        self,
+        event_type: str,
+        payload: str,
+        session_id: str,
+        channel: str = "all",
+        correlation_id: str | None = None,
+        meta: dict | None = None,
     ) -> Event:
         """Add a new event and return it with assigned ID."""
         now = datetime.now()
+        meta = meta or None  # Normalize empty dict to None
         with self._connect() as conn:
             cursor = conn.execute(
                 """
-                INSERT INTO events (event_type, payload, session_id, timestamp, channel)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO events
+                (event_type, payload, session_id, timestamp, channel, correlation_id, payload_meta)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (event_type, payload, session_id, now, channel),
+                (
+                    event_type,
+                    payload,
+                    session_id,
+                    now,
+                    channel,
+                    correlation_id,
+                    json.dumps(meta) if meta else None,
+                ),
             )
             event_id = cursor.lastrowid
 
@@ -573,7 +615,29 @@ class SQLiteStorage:
                 session_id=session_id,
                 timestamp=now,
                 channel=channel,
+                correlation_id=correlation_id,
+                meta=meta,
             )
+
+    def _row_to_event(self, row: sqlite3.Row) -> Event:
+        """Convert a database row to an Event object."""
+        keys = row.keys()
+        meta = None
+        if "payload_meta" in keys and row["payload_meta"]:
+            try:
+                meta = json.loads(row["payload_meta"])
+            except (json.JSONDecodeError, TypeError):
+                meta = None  # Corrupt meta is dropped, never fatal
+        return Event(
+            id=row["id"],
+            event_type=row["event_type"],
+            payload=row["payload"],
+            session_id=row["session_id"],
+            timestamp=row["timestamp"],
+            channel=row["channel"] if "channel" in keys else "all",
+            correlation_id=row["correlation_id"] if "correlation_id" in keys else None,
+            meta=meta,
+        )
 
     def get_events(
         self,
@@ -582,6 +646,7 @@ class SQLiteStorage:
         channels: list[str] | None = None,
         order: Literal["asc", "desc"] = "desc",
         event_types: list[str] | None = None,
+        correlation_id: str | None = None,
     ) -> tuple[list[Event], str | None]:
         """Get events with cursor-based pagination.
 
@@ -591,6 +656,7 @@ class SQLiteStorage:
             channels: Optional list of channels to filter by (None = all events).
             order: "desc" (newest first, default) or "asc" (oldest first).
             event_types: Optional list of event types to filter by (None = all types).
+            correlation_id: Optional correlation thread to filter by (None = all).
 
         Returns:
             Tuple of (events, next_cursor). Use next_cursor for subsequent calls.
@@ -634,6 +700,14 @@ class SQLiteStorage:
                     where_clause = f"WHERE {type_filter}"
                 params_base = (*params_base, *event_types)
 
+            if correlation_id:
+                corr_filter = "correlation_id = ?"
+                if where_clause:
+                    where_clause += f" AND {corr_filter}"
+                else:
+                    where_clause = f"WHERE {corr_filter}"
+                params_base = (*params_base, correlation_id)
+
             params = (*params_base, limit)
 
             query = f"""
@@ -644,17 +718,7 @@ class SQLiteStorage:
             """
             rows = conn.execute(query, params).fetchall()
 
-            events = [
-                Event(
-                    id=row["id"],
-                    event_type=row["event_type"],
-                    payload=row["payload"],
-                    session_id=row["session_id"],
-                    timestamp=row["timestamp"],
-                    channel=row["channel"] if "channel" in row.keys() else "all",
-                )
-                for row in rows
-            ]
+            events = [self._row_to_event(row) for row in rows]
 
             # Compute next_cursor from the events based on order
             # For DESC: next_cursor is the MIN id (oldest in this batch)

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -720,14 +720,13 @@ class SQLiteStorage:
 
             events = [self._row_to_event(row) for row in rows]
 
-            # Compute next_cursor from the events based on order
-            # For DESC: next_cursor is the MIN id (oldest in this batch)
-            # For ASC: next_cursor is the MAX id (newest in this batch)
+            # next_cursor is the high-water mark (MAX id) regardless of order.
+            # The query filters `id > cursor`, so feeding next_cursor back
+            # only ever returns events newer than this batch. (Returning MIN
+            # for desc - the old behavior - re-served the same newest events
+            # on every subsequent call.)
             if events:
-                if order == "desc":
-                    next_cursor = str(min(e.id for e in events))
-                else:
-                    next_cursor = str(max(e.id for e in events))
+                next_cursor = str(max(e.id for e in events))
             else:
                 next_cursor = cursor  # No new events, keep same cursor
 

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -213,6 +213,12 @@ OLD_CONTRIB_DB_PATH = Path.home() / ".claude" / "contrib" / "event-bus" / "data.
 # in list_sessions()
 SESSION_TIMEOUT = 86400  # 24 hours
 
+# How long a connection waits on a locked database before giving up.
+# Concurrent agents publish and poll simultaneously (issue #112); without an
+# explicit busy_timeout, writers under contention fail fast with
+# "database is locked" instead of queueing briefly.
+BUSY_TIMEOUT_MS = 5000
+
 
 class SQLiteStorage:
     """SQLite-backed storage for sessions and events."""
@@ -262,6 +268,12 @@ class SQLiteStorage:
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
         )
         conn.row_factory = sqlite3.Row
+        # WAL lets concurrent readers proceed while a writer holds the lock,
+        # which is the norm when several agents poll and publish at once
+        # (issue #112). journal_mode is persistent per-database but cheap to
+        # re-assert; busy_timeout is per-connection and must be set each time.
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         try:
             yield conn
             conn.commit()

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -747,7 +747,9 @@ class SQLiteStorage:
 
             # A full page means the window may hold more than `limit` events
             # (exactly-limit gives a false positive; one extra empty poll).
-            has_more = len(events) == limit
+            # limit=0 must not report more: its empty page never advances the
+            # cursor, so a keep-polling-while-has_more loop would spin forever.
+            has_more = limit > 0 and len(events) == limit
 
             return events, next_cursor, has_more
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,3 +125,28 @@ def make_events_args(**overrides):
     )
     defaults.update(overrides)
     return Namespace(**defaults)
+
+
+def make_publish_args(**overrides):
+    """Namespace matching the publish subparser's output - keep in sync.
+
+    Usage:
+        args = make_publish_args()  # All defaults
+        args = make_publish_args(title="T", tags="a,b")  # Override fields
+    """
+    from argparse import Namespace
+
+    defaults = dict(
+        type="test_event",
+        payload="hello",
+        channel=None,
+        session_id=None,
+        title=None,
+        tags=None,
+        correlation_id=None,
+        signal_level=None,
+        url=None,
+        debug=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def make_publish_args(**overrides):
     defaults = dict(
         type="test_event",
         payload="hello",
-        channel=None,
+        channel="all",  # The publish subparser defaults --channel to "all"
         session_id=None,
         title=None,
         tags=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,8 @@ def make_events_args(**overrides):
     """
     from argparse import Namespace
 
+    # Keep in sync with the events subparser in cli.main() - this Namespace
+    # stands in for real argparse output.
     defaults = dict(
         cursor=None,
         session_id=None,
@@ -117,6 +119,9 @@ def make_events_args(**overrides):
         resume=False,
         debug=False,
         include=None,
+        peek=False,
+        correlation_id=None,
+        min_level=None,
     )
     defaults.update(overrides)
     return Namespace(**defaults)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -975,3 +975,56 @@ class TestCmdEventsPeek:
 
                 args = mock_cmd.call_args[0][0]
                 assert args.peek is True
+
+
+class TestCmdEventsEnvAttribution:
+    """events falls back to $AGENT_EVENT_BUS_SESSION_ID like publish (#128)."""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_session_id_from_env(self, mock_call, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-id")
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args())
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["session_id"] == "env-session-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_explicit_session_id_overrides_env(self, mock_call, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-id")
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args(session_id="explicit-id"))
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["session_id"] == "explicit-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_no_env_no_flag_omits_session_id(self, mock_call, monkeypatch):
+        monkeypatch.delenv("AGENT_EVENT_BUS_SESSION_ID", raising=False)
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args())
+
+        call_args = mock_call.call_args[0][1]
+        assert "session_id" not in call_args
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_resume_satisfied_by_env_session_id(self, mock_call, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-id")
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args(resume=True))
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["resume"] is True
+        assert call_args["session_id"] == "env-session-id"
+
+    def test_resume_still_errors_without_any_session_id(self, monkeypatch, capsys):
+        monkeypatch.delenv("AGENT_EVENT_BUS_SESSION_ID", raising=False)
+
+        with pytest.raises(SystemExit):
+            cli.cmd_events(make_events_args(resume=True))
+
+        assert "requires --session-id" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,7 +246,7 @@ class TestCmdPublish:
 
         mock_call.assert_called_once_with(
             "publish_event",
-            {"event_type": "test_event", "payload": "hello"},
+            {"event_type": "test_event", "payload": "hello", "channel": "all"},
             url=None,
             debug=False,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -831,3 +831,147 @@ class TestCmdEventsWithChannel:
 
                 args = mock_cmd.call_args[0][0]
                 assert args.channel == "repo:my-repo"
+
+
+class TestWebhookCommands:
+    """Tests for CLI webhook subcommands.
+
+    Regression coverage: the webhook register subparser's --url (webhook
+    target) used to share an argparse dest with the global --url (bus
+    address), so the MCP registration call was POSTed to the webhook target
+    itself and never reached the bus.
+    """
+
+    def _run_main(self, argv, monkeypatch):
+        """Run cli.main() with argv, capturing call_tool invocations."""
+        import sys as _sys
+
+        monkeypatch.delenv("AGENT_EVENT_BUS_URL", raising=False)
+        calls = []
+
+        def fake_call_tool(tool_name, arguments, url=None, timeout_ms=None, debug=False):
+            calls.append({"tool": tool_name, "arguments": arguments, "posted_to": url})
+            if tool_name == "list_webhooks":
+                return []
+            return {"webhook_id": 1, "success": True}
+
+        with patch.object(_sys, "argv", ["agent-event-bus-cli", *argv]):
+            with patch.object(cli, "call_tool", fake_call_tool):
+                cli.main()
+        return calls
+
+    def test_register_posts_to_bus_not_webhook_target(self, monkeypatch):
+        calls = self._run_main(
+            ["webhook", "register", "--url", "http://target.example/hook"], monkeypatch
+        )
+
+        assert len(calls) == 1
+        assert calls[0]["tool"] == "register_webhook"
+        # The webhook target goes in the arguments...
+        assert calls[0]["arguments"]["url"] == "http://target.example/hook"
+        # ...and the MCP call itself goes to the bus, not the target
+        assert calls[0]["posted_to"] == cli.DEFAULT_URL
+
+    def test_register_respects_global_bus_url(self, monkeypatch):
+        calls = self._run_main(
+            [
+                "--url",
+                "http://bus.example:9999/mcp",
+                "webhook",
+                "register",
+                "--url",
+                "http://target.example/hook",
+            ],
+            monkeypatch,
+        )
+
+        assert calls[0]["posted_to"] == "http://bus.example:9999/mcp"
+        assert calls[0]["arguments"]["url"] == "http://target.example/hook"
+
+    def test_register_passes_filters_and_secret(self, monkeypatch):
+        calls = self._run_main(
+            [
+                "webhook",
+                "register",
+                "--url",
+                "http://target.example/hook",
+                "--channel",
+                "repo:",
+                "--event-types",
+                "task_completed, ci_completed",
+                "--secret",
+                "shh",
+            ],
+            monkeypatch,
+        )
+
+        args = calls[0]["arguments"]
+        assert args["channel"] == "repo:"
+        assert args["event_types"] == ["task_completed", "ci_completed"]
+        assert args["secret"] == "shh"
+
+    def test_list_posts_to_bus(self, monkeypatch):
+        calls = self._run_main(["webhook", "list"], monkeypatch)
+
+        assert calls[0]["tool"] == "list_webhooks"
+        assert calls[0]["arguments"] == {"active_only": True}
+        assert calls[0]["posted_to"] == cli.DEFAULT_URL
+
+    def test_list_all_includes_inactive(self, monkeypatch):
+        calls = self._run_main(["webhook", "list", "--all"], monkeypatch)
+
+        assert calls[0]["arguments"] == {"active_only": False}
+
+    def test_unregister_posts_to_bus(self, monkeypatch):
+        calls = self._run_main(["webhook", "unregister", "7"], monkeypatch)
+
+        assert calls[0]["tool"] == "unregister_webhook"
+        assert calls[0]["arguments"] == {"webhook_id": 7}
+        assert calls[0]["posted_to"] == cli.DEFAULT_URL
+
+
+class TestCmdEventsPeek:
+    """CLI-level tests for events --peek (issue #131)."""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_peek_passes_through(self, mock_call):
+        mock_call.return_value = {"events": [], "next_cursor": None}
+        args = make_events_args(session_id="abc", resume=True, peek=True)
+
+        cli.cmd_events(args)
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["peek"] is True
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_peek_false_omitted(self, mock_call):
+        mock_call.return_value = {"events": [], "next_cursor": None}
+        args = make_events_args(peek=False)
+
+        cli.cmd_events(args)
+
+        call_args = mock_call.call_args[0][1]
+        assert "peek" not in call_args
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_peek_attr_absent_defaults_off(self, mock_call):
+        """Namespaces built without a peek attribute (older callers) must not
+        crash and must not send peek - the getattr default path."""
+        mock_call.return_value = {"events": [], "next_cursor": None}
+        args = make_events_args()  # make_events_args does not define peek
+
+        cli.cmd_events(args)
+
+        call_args = mock_call.call_args[0][1]
+        assert "peek" not in call_args
+
+    def test_peek_flag_parses(self):
+        """--peek wires through argument parsing to cmd_events."""
+        import sys as _sys
+
+        with patch.object(_sys, "argv", ["cli", "events", "--peek"]):
+            with patch("agent_event_bus.cli.cmd_events") as mock_cmd:
+                cli.main()
+
+                args = mock_cmd.call_args[0][0]
+                assert args.peek is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,6 +233,24 @@ class TestCmdSessions:
         assert "my-repo" in captured.out
 
 
+def make_publish_args(**overrides):
+    """Namespace matching the publish subparser's output - keep in sync."""
+    defaults = dict(
+        type="test_event",
+        payload="hello",
+        channel=None,
+        session_id=None,
+        title=None,
+        tags=None,
+        correlation_id=None,
+        signal_level=None,
+        url=None,
+        debug=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
 class TestCmdPublish:
     """Tests for publish command."""
 
@@ -241,9 +259,7 @@ class TestCmdPublish:
         """Test basic publish."""
         mock_call.return_value = {"event_id": 1}
 
-        args = Namespace(
-            type="test_event", payload="hello", channel=None, session_id=None, url=None, debug=False
-        )
+        args = make_publish_args()
         cli.cmd_publish(args)
 
         mock_call.assert_called_once_with(
@@ -258,14 +274,7 @@ class TestCmdPublish:
         """Test publish with channel."""
         mock_call.return_value = {"event_id": 1}
 
-        args = Namespace(
-            type="test_event",
-            payload="hello",
-            channel="repo:my-repo",
-            session_id="abc123",
-            url=None,
-            debug=False,
-        )
+        args = make_publish_args(channel="repo:my-repo", session_id="abc123")
         cli.cmd_publish(args)
 
         call_args = mock_call.call_args[0][1]
@@ -278,9 +287,7 @@ class TestCmdPublish:
         """Test publish uses session_id from env var when not provided."""
         mock_call.return_value = {"event_id": 1}
 
-        args = Namespace(
-            type="test_event", payload="hello", channel=None, session_id=None, url=None, debug=False
-        )
+        args = make_publish_args()
         cli.cmd_publish(args)
 
         call_args = mock_call.call_args[0][1]
@@ -292,14 +299,7 @@ class TestCmdPublish:
         """Test explicit --session-id overrides env var."""
         mock_call.return_value = {"event_id": 1}
 
-        args = Namespace(
-            type="test_event",
-            payload="hello",
-            channel=None,
-            session_id="explicit-123",
-            url=None,
-            debug=False,
-        )
+        args = make_publish_args(session_id="explicit-123")
         cli.cmd_publish(args)
 
         call_args = mock_call.call_args[0][1]
@@ -953,18 +953,6 @@ class TestCmdEventsPeek:
         call_args = mock_call.call_args[0][1]
         assert "peek" not in call_args
 
-    @patch("agent_event_bus.cli.call_tool")
-    def test_peek_attr_absent_defaults_off(self, mock_call):
-        """Namespaces built without a peek attribute (older callers) must not
-        crash and must not send peek - the getattr default path."""
-        mock_call.return_value = {"events": [], "next_cursor": None}
-        args = make_events_args()  # make_events_args does not define peek
-
-        cli.cmd_events(args)
-
-        call_args = mock_call.call_args[0][1]
-        assert "peek" not in call_args
-
     def test_peek_flag_parses(self):
         """--peek wires through argument parsing to cmd_events."""
         import sys as _sys
@@ -1028,3 +1016,50 @@ class TestCmdEventsEnvAttribution:
             cli.cmd_events(make_events_args(resume=True))
 
         assert "requires --session-id" in capsys.readouterr().err
+
+
+class TestCmdEventsHasMoreHint:
+    """Human-readable output must surface has_more (the default desc order
+    silently truncates a large backlog otherwise)."""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_hint_printed_when_more_available(self, mock_call, capsys):
+        mock_call.return_value = {
+            "events": [
+                {
+                    "id": 1,
+                    "event_type": "note",
+                    "channel": "all",
+                    "payload": "p",
+                    "session_id": "s",
+                    "timestamp": "t",
+                }
+            ],
+            "next_cursor": "50",
+            "has_more": True,
+        }
+
+        cli.cmd_events(make_events_args())
+
+        captured = capsys.readouterr()
+        assert "More events available" in captured.err
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_hint_with_empty_filtered_page(self, mock_call, capsys):
+        # Reachable with --min-level: a full page of lifecycle churn filters
+        # to zero events but has_more is true
+        mock_call.return_value = {"events": [], "next_cursor": "50", "has_more": True}
+
+        cli.cmd_events(make_events_args(min_level="actionable"))
+
+        captured = capsys.readouterr()
+        assert "No events" in captured.out
+        assert "More events available" in captured.err
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_no_hint_without_more(self, mock_call, capsys):
+        mock_call.return_value = {"events": [], "next_cursor": None, "has_more": False}
+
+        cli.cmd_events(make_events_args())
+
+        assert capsys.readouterr().err == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_event_bus import cli
-from conftest import make_events_args
+from conftest import make_events_args, make_publish_args
 
 
 class TestCallTool:
@@ -231,24 +231,6 @@ class TestCmdSessions:
         assert "abc123" in captured.out
         assert "test-session" in captured.out
         assert "my-repo" in captured.out
-
-
-def make_publish_args(**overrides):
-    """Namespace matching the publish subparser's output - keep in sync."""
-    defaults = dict(
-        type="test_event",
-        payload="hello",
-        channel=None,
-        session_id=None,
-        title=None,
-        tags=None,
-        correlation_id=None,
-        signal_level=None,
-        url=None,
-        debug=False,
-    )
-    defaults.update(overrides)
-    return Namespace(**defaults)
 
 
 class TestCmdPublish:
@@ -1063,3 +1045,42 @@ class TestCmdEventsHasMoreHint:
         cli.cmd_events(make_events_args())
 
         assert capsys.readouterr().err == ""
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_asc_hint_points_at_cursor(self, mock_call, capsys):
+        mock_call.return_value = {"events": [], "next_cursor": "50", "has_more": True}
+
+        cli.cmd_events(make_events_args(order="asc"))
+
+        err = capsys.readouterr().err
+        assert "More events available" in err
+        assert "--cursor 50" in err
+
+
+class TestCmdEventsStructuredDisplay:
+    @patch("agent_event_bus.cli.call_tool")
+    def test_signal_level_and_tags_shown(self, mock_call, capsys):
+        mock_call.return_value = {
+            "events": [
+                {
+                    "id": 42,
+                    "event_type": "help_needed",
+                    "channel": "all",
+                    "payload": "p",
+                    "session_id": "s",
+                    "timestamp": "t",
+                    "signal_level": "actionable",
+                    "correlation_id": "rev-1",
+                    "tags": ["review", "urgent"],
+                }
+            ],
+            "next_cursor": "42",
+            "has_more": False,
+        }
+
+        cli.cmd_events(make_events_args())
+
+        out = capsys.readouterr().out
+        assert "[42] help_needed (all) [actionable]" in out
+        assert "corr:rev-1" in out
+        assert "tags:review,urgent" in out

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -190,3 +190,18 @@ class TestDispatchStorageOffLoop:
         # asyncio.run drove the loop on this thread; the lookup must not have
         # run there
         assert seen["thread"] is not threading.current_thread()
+
+
+class TestHealthEndpointAuth:
+    def test_health_sits_behind_tailscale_auth(self, monkeypatch):
+        """With auth enabled, /health requires localhost or Tailscale identity
+        headers - it is not an openly probeable endpoint."""
+        from starlette.testclient import TestClient
+
+        monkeypatch.delenv("AGENT_EVENT_BUS_AUTH_DISABLED", raising=False)
+
+        with TestClient(server.create_app()) as client:
+            # TestClient's IP is "testclient", not a trusted localhost address
+            assert client.get("/health").status_code == 401
+            resp = client.get("/health", headers={"tailscale-user-login": "user@example.com"})
+            assert resp.status_code == 200

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -170,3 +170,23 @@ class TestHealthEndpoint:
             body = resp.json()
             assert body["status"] == "ok"
             assert body["service"] == "agent-event-bus"
+
+
+class TestDispatchStorageOffLoop:
+    def test_webhook_lookup_runs_off_the_loop_thread(self, monkeypatch):
+        """_dispatch_webhooks runs on the server loop; its SQLite lookup must
+        be offloaded to a worker thread per the #112 invariant."""
+        seen = {}
+
+        def fake_matching(event):
+            seen["thread"] = threading.current_thread()
+            return []
+
+        monkeypatch.setattr(server.storage, "get_matching_webhooks", fake_matching)
+        event = Event(id=1, event_type="t", payload="p", session_id="s", timestamp=datetime.now())
+
+        asyncio.run(server._dispatch_webhooks(event))
+
+        # asyncio.run drove the loop on this thread; the lookup must not have
+        # run there
+        assert seen["thread"] is not threading.current_thread()

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,172 @@
+"""Tests for the issue #112 hardening: event-loop offloading, bounded
+notification subprocesses, SQLite concurrency pragmas, loop-safe webhook
+dispatch, and the /health liveness route."""
+
+import asyncio
+import inspect
+import subprocess
+import threading
+from datetime import datetime
+
+from agent_event_bus import helpers, server
+from agent_event_bus.storage import BUSY_TIMEOUT_MS, Event
+
+
+class TestAsyncToolWrappers:
+    """Tool functions must not block the server's event loop."""
+
+    def test_all_tools_are_async(self):
+        tools = [
+            server.register_session,
+            server.list_sessions,
+            server.list_channels,
+            server.publish_event,
+            server.get_events,
+            server.unregister_session,
+            server.notify,
+            server.register_webhook,
+            server.list_webhooks,
+            server.unregister_webhook,
+        ]
+        for tool in tools:
+            assert inspect.iscoroutinefunction(tool.fn), f"{tool.name} is not async"
+
+    def test_wrappers_pass_through_end_to_end(self):
+        async def main():
+            registered = await server.register_session.fn(
+                name="async-e2e",
+                machine="test-machine",
+                cwd="/home/user/project",
+                client_id="async-e2e-client",
+            )
+            sid = registered["session_id"]
+            published = await server.publish_event.fn(
+                event_type="task_completed", payload="done", session_id=sid
+            )
+            polled = await server.get_events.fn(
+                cursor=registered["cursor"], session_id=sid, order="asc"
+            )
+            return registered, published, polled
+
+        registered, published, polled = asyncio.run(main())
+
+        assert registered["name"] == "async-e2e"
+        assert published["event_id"] is not None
+        assert any(e["id"] == published["event_id"] for e in polled["events"])
+        # The wrapper captured the loop for cross-thread webhook dispatch
+        assert server._server_loop is not None
+
+
+class TestNotificationTimeout:
+    """A hung notifier subprocess must not wedge the caller."""
+
+    def test_timeout_returns_false(self, monkeypatch):
+        monkeypatch.setattr(helpers.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(helpers.shutil, "which", lambda name: "/usr/bin/terminal-notifier")
+
+        def fake_run(cmd, **kwargs):
+            assert kwargs.get("timeout") == helpers.NOTIFY_TIMEOUT
+            raise subprocess.TimeoutExpired(cmd, helpers.NOTIFY_TIMEOUT)
+
+        monkeypatch.setattr(helpers.subprocess, "run", fake_run)
+
+        assert helpers.send_notification("title", "message") is False
+
+    def test_all_subprocess_calls_pass_timeout(self, monkeypatch):
+        """Every notification path (terminal-notifier, osascript, notify-send)
+        must bound its subprocess."""
+        seen_timeouts = []
+
+        def fake_run(cmd, **kwargs):
+            seen_timeouts.append(kwargs.get("timeout"))
+
+            class Result:
+                returncode = 0
+
+            return Result()
+
+        monkeypatch.setattr(helpers.subprocess, "run", fake_run)
+        monkeypatch.setattr(helpers.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+        monkeypatch.setattr(helpers.platform, "system", lambda: "Darwin")
+        helpers.send_notification("t", "m")
+
+        monkeypatch.setattr(helpers.shutil, "which", lambda name: None)
+        helpers.send_notification("t", "m")  # osascript fallback
+
+        monkeypatch.setattr(helpers.platform, "system", lambda: "Linux")
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setattr(helpers.shutil, "which", lambda name: f"/usr/bin/{name}")
+        helpers.send_notification("t", "m")
+
+        assert len(seen_timeouts) == 3
+        assert all(t == helpers.NOTIFY_TIMEOUT for t in seen_timeouts)
+
+
+class TestSQLiteConcurrencyPragmas:
+    def test_wal_and_busy_timeout_set(self, storage):
+        with storage._connect() as conn:
+            mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode == "wal"
+            timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            assert timeout == BUSY_TIMEOUT_MS
+
+
+class TestLoopSafeWebhookDispatch:
+    def test_webhook_client_recreated_on_new_loop(self):
+        """Reusing an AsyncClient across event loops hangs; each loop must get
+        a fresh client."""
+
+        async def get_client():
+            return server._get_webhook_client()
+
+        client1 = asyncio.run(get_client())
+        client2 = asyncio.run(get_client())
+        assert client1 is not client2
+
+    def test_webhook_client_reused_on_same_loop(self):
+        async def get_twice():
+            return server._get_webhook_client(), server._get_webhook_client()
+
+        client1, client2 = asyncio.run(get_twice())
+        assert client1 is client2
+
+    def test_dispatch_from_worker_thread_runs_on_server_loop(self, monkeypatch):
+        """publish_event runs in a worker thread; its webhook dispatch must
+        land on the server loop, not spawn a throwaway thread."""
+        ran: dict = {}
+        done = threading.Event()
+
+        async def fake_dispatch(event):
+            ran["loop"] = asyncio.get_running_loop()
+            done.set()
+
+        monkeypatch.setattr(server, "_dispatch_webhooks", fake_dispatch)
+        event = Event(id=1, event_type="t", payload="p", session_id="s", timestamp=datetime.now())
+
+        async def main():
+            loop = asyncio.get_running_loop()
+            # _run_sync captures the loop, then runs the schedule call in a
+            # worker thread - exactly the publish_event code path.
+            await server._run_sync(lambda: server._schedule_webhook_dispatch(event))
+            for _ in range(500):
+                if done.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            return loop
+
+        loop = asyncio.run(main())
+        assert done.is_set()
+        assert ran["loop"] is loop
+
+
+class TestHealthEndpoint:
+    def test_health_bypasses_mcp(self):
+        from starlette.testclient import TestClient
+
+        with TestClient(server.create_app()) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "ok"
+            assert body["service"] == "agent-event-bus"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -666,3 +666,60 @@ class TestTailscaleAuthMiddleware:
 
         assert not mock_app.called
         assert responses[0]["status"] == 401
+
+
+class TestLoggingOffLoop:
+    """Request logging hits SQLite (display-id lookups) and the disk-backed
+    logger; per the #112 invariant it must run in a worker thread."""
+
+    def test_tool_call_logging_runs_off_the_loop_thread(self, monkeypatch):
+        import asyncio
+        import json
+        import threading
+
+        from agent_event_bus import middleware as mw
+
+        seen = {}
+
+        def fake_lookup(session_id):
+            seen["thread"] = threading.current_thread()
+            return "brave-trex"
+
+        monkeypatch.setattr(mw, "_lookup_session_display_id", fake_lookup)
+
+        async def fake_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'event: message\ndata: {"result": {}}\n\n',
+                    "more_body": False,
+                }
+            )
+
+        app = mw.RequestLoggingMiddleware(fake_app)
+        request_body = json.dumps(
+            {
+                "method": "tools/call",
+                "params": {"name": "get_events", "arguments": {"session_id": "abc-123"}},
+            }
+        ).encode()
+
+        async def main():
+            scope = {"type": "http", "path": "/mcp", "method": "POST"}
+            messages = [{"type": "http.request", "body": request_body, "more_body": False}]
+
+            async def receive():
+                return messages.pop(0) if messages else {"type": "http.disconnect"}
+
+            async def send(message):
+                pass
+
+            await app(scope, receive, send)
+
+        asyncio.run(main())
+
+        # The lookup ran (the log line was built) but not on the loop thread
+        assert "thread" in seen
+        assert seen["thread"] is not threading.current_thread()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -8,10 +8,10 @@ import pytest
 from agent_event_bus import server
 
 # Access the underlying functions from FunctionTool wrappers
-register_session = server.register_session.fn
-publish_event = server.publish_event.fn
-get_events = server.get_events.fn
-notify = server.notify.fn
+register_session = server._register_session_impl
+publish_event = server._publish_event_impl
+get_events = server._get_events_impl
+notify = server._notify_impl
 
 
 class TestNotify:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1483,3 +1483,19 @@ class TestNarrowedReadsDoNotConsumeCursor:
         get_events(session_id=sid, resume=True, order="asc")
 
         assert server.storage.get_session(sid).last_cursor == str(published["event_id"])
+
+    def test_narrowed_resume_on_cursorless_session_does_not_initialize(self):
+        """A fresh session has last_cursor=NULL; the resume-initialization
+        branch must not persist the tip for a narrowed read - that would mark
+        the entire backlog (DMs included) as seen."""
+        reg = register_session(name="narrow-init", client_id="narrow-init-client")
+        sid = reg["session_id"]
+        assert server.storage.get_session(sid).last_cursor is None
+
+        publish_event(event_type="help_needed", payload="dm", channel=f"session:{sid}")
+
+        result = get_events(session_id=sid, resume=True, correlation_id="rev-99", order="asc")
+        assert result["events"] == []
+
+        # The narrowed resume read from the tip without persisting it
+        assert server.storage.get_session(sid).last_cursor is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -566,7 +566,7 @@ class TestUnregisterSession:
         unregister_session(session_id)
 
         # Check for unregister event
-        events, _ = server.storage.get_events(cursor=cursor, order="asc")
+        events, _, _ = server.storage.get_events(cursor=cursor, order="asc")
         event_types = [e.event_type for e in events]
         assert "session_unregistered" in event_types
 
@@ -1398,3 +1398,27 @@ class TestLogFileEnvVar:
         env["AGENT_EVENT_BUS_TESTING"] = "1"
         expected = os.path.expanduser("~/.claude/contrib/agent-event-bus/agent-event-bus.log")
         assert self._resolved_log_file(env) == expected
+
+
+class TestGetEventsHasMore:
+    """has_more passthrough on the get_events response."""
+
+    def test_false_when_batch_fits(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="note", payload="only one")
+
+        result = get_events(cursor=start, order="asc")
+        assert result["has_more"] is False
+
+    def test_true_then_drains_with_asc(self):
+        start = server.storage.get_cursor()
+        for i in range(5):
+            publish_event(event_type="note", payload=str(i))
+
+        result = get_events(cursor=start, order="asc", limit=3)
+        assert result["has_more"] is True
+        assert [e["payload"] for e in result["events"]] == ["0", "1", "2"]
+
+        result2 = get_events(cursor=result["next_cursor"], order="asc", limit=3)
+        assert [e["payload"] for e in result2["events"]] == ["3", "4"]
+        assert result2["has_more"] is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1422,3 +1422,64 @@ class TestGetEventsHasMore:
         result2 = get_events(cursor=result["next_cursor"], order="asc", limit=3)
         assert [e["payload"] for e in result2["events"]] == ["3", "4"]
         assert result2["has_more"] is False
+
+
+class TestNarrowedReadsDoNotConsumeCursor:
+    """Narrowing filters (channel/event_types/correlation_id) must not advance
+    the session cursor - the filtered batch's max id would mark non-matching
+    events as seen and drop them from a later resume."""
+
+    def _seed_session(self, name):
+        """Register a session and establish a consuming cursor position."""
+        reg = register_session(name=name, client_id=f"{name}-client")
+        sid = reg["session_id"]
+        seed = publish_event(event_type="note", payload="seed", session_id=sid)
+        get_events(session_id=sid, cursor=reg["cursor"], order="asc")
+        return sid, seed["event_id"]
+
+    def test_correlation_read_leaves_backlog_unread(self):
+        sid, seed_id = self._seed_session("narrow-corr")
+
+        publish_event(event_type="help_needed", payload="unrelated backlog")
+        publish_event(event_type="task_completed", payload="tagged", correlation_id="rev-42")
+
+        result = get_events(session_id=sid, correlation_id="rev-42", order="desc")
+        assert [e["payload"] for e in result["events"]] == ["tagged"]
+
+        # Cursor untouched by the narrowed read...
+        assert server.storage.get_session(sid).last_cursor == str(seed_id)
+
+        # ...so resume still surfaces the event that didn't match the filter
+        resumed = get_events(session_id=sid, resume=True, order="asc")
+        assert [e["payload"] for e in resumed["events"]] == ["unrelated backlog", "tagged"]
+
+    def test_event_type_read_leaves_backlog_unread(self):
+        sid, seed_id = self._seed_session("narrow-types")
+
+        publish_event(event_type="help_needed", payload="unrelated backlog")
+        publish_event(event_type="narrow_wanted_type", payload="wanted")
+
+        # Unique type: the suite shares one events table
+        result = get_events(session_id=sid, event_types=["narrow_wanted_type"], order="desc")
+        assert [e["payload"] for e in result["events"]] == ["wanted"]
+
+        assert server.storage.get_session(sid).last_cursor == str(seed_id)
+
+    def test_channel_read_leaves_backlog_unread(self):
+        sid, seed_id = self._seed_session("narrow-channel")
+
+        publish_event(event_type="note", payload="broadcast backlog")
+        publish_event(event_type="note", payload="repo scoped", channel="repo:narrow-test")
+
+        result = get_events(session_id=sid, channel="repo:narrow-test", order="desc")
+        assert [e["payload"] for e in result["events"]] == ["repo scoped"]
+
+        assert server.storage.get_session(sid).last_cursor == str(seed_id)
+
+    def test_unfiltered_read_still_consumes(self):
+        sid, seed_id = self._seed_session("narrow-none")
+
+        published = publish_event(event_type="note", payload="new")
+        get_events(session_id=sid, resume=True, order="asc")
+
+        assert server.storage.get_session(sid).last_cursor == str(published["event_id"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,11 +13,11 @@ from agent_event_bus import server
 from agent_event_bus.storage import Session, SQLiteStorage
 
 # Access the underlying functions from FunctionTool wrappers
-register_session = server.register_session.fn
-list_sessions = server.list_sessions.fn
-publish_event = server.publish_event.fn
-get_events = server.get_events.fn
-unregister_session = server.unregister_session.fn
+register_session = server._register_session_impl
+list_sessions = server._list_sessions_impl
+publish_event = server._publish_event_impl
+get_events = server._get_events_impl
+unregister_session = server._unregister_session_impl
 
 
 class TestRegisterSession:
@@ -1103,7 +1103,7 @@ class TestUnregisterByClientId:
 
 
 # Access list_channels from FunctionTool wrapper
-list_channels = server.list_channels.fn
+list_channels = server._list_channels_impl
 
 
 class TestListChannels:

--- a/tests/test_signal_levels.py
+++ b/tests/test_signal_levels.py
@@ -1,0 +1,138 @@
+"""Tests for server-side signal-level tagging and min_level filtering (#129)."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+from agent_event_bus import cli, server
+from agent_event_bus.storage import Event
+from conftest import make_events_args
+
+publish_event = server._publish_event_impl
+get_events = server._get_events_impl
+register_session = server._register_session_impl
+
+
+def make_event(event_type="note", channel="all", meta=None):
+    return Event(
+        id=1,
+        event_type=event_type,
+        payload="p",
+        session_id="s",
+        timestamp=datetime.now(),
+        channel=channel,
+        meta=meta,
+    )
+
+
+class TestSignalLevelDerivation:
+    def test_lifecycle_types(self):
+        for event_type in (
+            "session_registered",
+            "session_unregistered",
+            "ci_watching",
+            "ci_rerun",
+            "task_started",
+            "parallel_work_started",
+        ):
+            assert server._get_signal_level(make_event(event_type)) == "lifecycle"
+
+    def test_actionable_types(self):
+        for event_type in ("help_needed", "blocker_found", "ci_failed", "error_broadcast"):
+            assert server._get_signal_level(make_event(event_type)) == "actionable"
+
+    def test_unknown_types_default_to_info(self):
+        assert server._get_signal_level(make_event("gotcha_discovered")) == "info"
+        assert server._get_signal_level(make_event("some_ad_hoc_type")) == "info"
+
+    def test_dms_are_always_actionable(self):
+        event = make_event("session_registered", channel="session:abc")
+        assert server._get_signal_level(event) == "actionable"
+
+    def test_explicit_level_overrides_derivation(self):
+        event = make_event("session_registered", meta={"signal_level": "actionable"})
+        assert server._get_signal_level(event) == "actionable"
+
+    def test_unknown_explicit_level_falls_back_to_derived(self):
+        event = make_event("session_registered", meta={"signal_level": "shouting"})
+        assert server._get_signal_level(event) == "lifecycle"
+
+
+class TestMinLevelFiltering:
+    def test_min_level_info_drops_lifecycle(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="session_registered", payload="churn")
+        publish_event(event_type="gotcha_discovered", payload="useful")
+        publish_event(event_type="help_needed", payload="urgent")
+
+        result = get_events(cursor=start, order="asc", min_level="info")
+        assert [e["payload"] for e in result["events"]] == ["useful", "urgent"]
+
+    def test_min_level_actionable_keeps_only_actionable(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="session_registered", payload="churn")
+        publish_event(event_type="gotcha_discovered", payload="useful")
+        publish_event(event_type="help_needed", payload="urgent")
+
+        result = get_events(cursor=start, order="asc", min_level="actionable")
+        assert [e["payload"] for e in result["events"]] == ["urgent"]
+
+    def test_no_min_level_returns_everything(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="session_registered", payload="churn")
+        publish_event(event_type="gotcha_discovered", payload="useful")
+
+        result = get_events(cursor=start, order="asc")
+        assert len(result["events"]) == 2
+
+    def test_events_carry_signal_level(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="help_needed", payload="urgent")
+
+        result = get_events(cursor=start, order="asc")
+        assert result["events"][0]["signal_level"] == "actionable"
+
+    def test_filtered_events_still_advance_session_cursor(self):
+        """Noise filtered by min_level counts as seen - a later resume must
+        not replay it."""
+        registered = register_session(name="filter-test", client_id="filter-test-client")
+        sid = registered["session_id"]
+
+        published = publish_event(event_type="session_registered", payload="lifecycle noise")
+
+        result = get_events(
+            cursor=registered["cursor"], session_id=sid, order="asc", min_level="actionable"
+        )
+        assert result["events"] == []
+
+        session = server.storage.get_session(sid)
+        assert session.last_cursor == str(published["event_id"])
+
+
+class TestCLIMinLevel:
+    @patch("agent_event_bus.cli.call_tool")
+    def test_min_level_passthrough(self, mock_call):
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args(min_level="actionable"))
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["min_level"] == "actionable"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_min_level_absent_omitted(self, mock_call):
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args())
+
+        call_args = mock_call.call_args[0][1]
+        assert "min_level" not in call_args
+
+    def test_min_level_flag_parses(self):
+        import sys as _sys
+
+        with patch.object(_sys, "argv", ["cli", "events", "--min-level", "info"]):
+            with patch("agent_event_bus.cli.cmd_events") as mock_cmd:
+                cli.main()
+
+                args = mock_cmd.call_args[0][0]
+                assert args.min_level == "info"

--- a/tests/test_signal_levels.py
+++ b/tests/test_signal_levels.py
@@ -136,3 +136,23 @@ class TestCLIMinLevel:
 
                 args = mock_cmd.call_args[0][0]
                 assert args.min_level == "info"
+
+
+class TestPublishEchoesEffectiveLevel:
+    """The publish result reports the server-assigned level - soft validation
+    is otherwise silent toward the caller."""
+
+    def test_derived_level_echoed(self):
+        result = publish_event(event_type="help_needed", payload="p")
+        assert result["signal_level"] == "actionable"
+
+    def test_explicit_level_echoed(self):
+        result = publish_event(
+            event_type="session_registered", payload="p", signal_level="actionable"
+        )
+        assert result["signal_level"] == "actionable"
+
+    def test_unknown_level_echoes_derived_fallback(self):
+        """An MCP caller sending an unknown level sees what actually shipped."""
+        result = publish_event(event_type="note", payload="p", signal_level="urgent")
+        assert result["signal_level"] == "info"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -382,7 +382,7 @@ class TestEventOperations:
                 session_id="session-123",
             )
 
-        events, next_cursor = storage.get_events()
+        events, next_cursor, _ = storage.get_events()
         assert len(events) == 5
         assert next_cursor is not None
 
@@ -398,7 +398,7 @@ class TestEventOperations:
             event_ids.append(event.id)
 
         # Get events after the third one (cursor is string)
-        events, next_cursor = storage.get_events(cursor=str(event_ids[2]), order="asc")
+        events, next_cursor, _ = storage.get_events(cursor=str(event_ids[2]), order="asc")
         assert len(events) == 2
         assert events[0].event_type == "event_3"
         assert events[1].event_type == "event_4"
@@ -412,7 +412,7 @@ class TestEventOperations:
                 session_id="session-123",
             )
 
-        events, next_cursor = storage.get_events(limit=3)
+        events, next_cursor, _ = storage.get_events(limit=3)
         assert len(events) == 3
 
     def test_get_cursor(self, storage):
@@ -439,15 +439,15 @@ class TestEventOperations:
             )
 
         # Malformed cursor should reset to start (return all events)
-        events, _ = storage.get_events(cursor="not-a-number")
+        events, _, _ = storage.get_events(cursor="not-a-number")
         assert len(events) == 3
 
         # Empty cursor works normally
-        events, _ = storage.get_events(cursor="")
+        events, _, _ = storage.get_events(cursor="")
         assert len(events) == 3
 
         # Valid cursor works normally
-        events, _ = storage.get_events(cursor="1", order="asc")
+        events, _, _ = storage.get_events(cursor="1", order="asc")
         assert len(events) == 2  # Events after id=1
 
 
@@ -464,7 +464,7 @@ class TestEventChannelFiltering:
         storage.add_event("other", "msg5", "s1", channel="session:xyz")
 
         # Filter for specific channels
-        events, _ = storage.get_events(channels=["all", "session:abc", "repo:myrepo"])
+        events, _, _ = storage.get_events(channels=["all", "session:abc", "repo:myrepo"])
         assert len(events) == 3
         types = {e.event_type for e in events}
         assert types == {"broadcast", "direct", "repo"}
@@ -476,7 +476,7 @@ class TestEventChannelFiltering:
         storage.add_event("e3", "msg3", "s1", channel="repo:myrepo")
 
         # No channel filter = all events
-        events, _ = storage.get_events(channels=None)
+        events, _, _ = storage.get_events(channels=None)
         assert len(events) == 3
 
 
@@ -492,7 +492,7 @@ class TestEventTypeFiltering:
         storage.add_event("task_completed", "another task", "s1")
 
         # Filter for specific event types
-        events, _ = storage.get_events(event_types=["task_completed", "ci_completed"])
+        events, _, _ = storage.get_events(event_types=["task_completed", "ci_completed"])
         assert len(events) == 3
         types = {e.event_type for e in events}
         assert types == {"task_completed", "ci_completed"}
@@ -503,10 +503,10 @@ class TestEventTypeFiltering:
         storage.add_event("ci_completed", "CI 1", "s1")
         storage.add_event("task_completed", "task 2", "s1")
 
-        events, _ = storage.get_events(event_types=["gotcha_discovered"])
+        events, _, _ = storage.get_events(event_types=["gotcha_discovered"])
         assert len(events) == 0
 
-        events, _ = storage.get_events(event_types=["task_completed"])
+        events, _, _ = storage.get_events(event_types=["task_completed"])
         assert len(events) == 2
         assert all(e.event_type == "task_completed" for e in events)
 
@@ -517,7 +517,7 @@ class TestEventTypeFiltering:
         storage.add_event("e3", "msg3", "s1")
 
         # No event_types filter = all events
-        events, _ = storage.get_events(event_types=None)
+        events, _, _ = storage.get_events(event_types=None)
         assert len(events) == 3
 
     def test_get_events_combined_filters(self, storage):
@@ -528,7 +528,7 @@ class TestEventTypeFiltering:
         storage.add_event("gotcha_discovered", "gotcha", "s1", channel="repo:myrepo")
 
         # Filter by both channel and event type
-        events, _ = storage.get_events(
+        events, _, _ = storage.get_events(
             channels=["repo:myrepo"], event_types=["task_completed", "ci_completed"]
         )
         assert len(events) == 2
@@ -582,7 +582,7 @@ class TestDatabaseInitialization:
             channel="repo:myrepo",
         )
 
-        events, _ = storage.get_events()
+        events, _, _ = storage.get_events()
         assert len(events) == 1
         assert events[0].channel == "repo:myrepo"
 
@@ -889,7 +889,7 @@ class TestNextCursorHighWater:
     def test_desc_next_cursor_is_high_water(self, storage):
         ids = self._add_events(storage, 5)
 
-        events, next_cursor = storage.get_events(order="desc")
+        events, next_cursor, _ = storage.get_events(order="desc")
         assert next_cursor == str(max(ids))
 
     def test_desc_polling_with_next_cursor_never_duplicates(self, storage):
@@ -897,21 +897,59 @@ class TestNextCursorHighWater:
         every follow-up call; feeding next_cursor back must yield only new
         events."""
         self._add_events(storage, 3)
-        _, cursor = storage.get_events(order="desc")
+        _, cursor, _ = storage.get_events(order="desc")
 
         # No new events: nothing comes back
-        events, cursor2 = storage.get_events(cursor=cursor, order="desc")
+        events, cursor2, _ = storage.get_events(cursor=cursor, order="desc")
         assert events == []
         assert cursor2 == cursor
 
         # A new event: exactly that event comes back
         new_id = storage.add_event(event_type="fresh", payload="new", session_id="s1").id
-        events, cursor3 = storage.get_events(cursor=cursor, order="desc")
+        events, cursor3, _ = storage.get_events(cursor=cursor, order="desc")
         assert [e.id for e in events] == [new_id]
         assert cursor3 == str(new_id)
 
     def test_asc_next_cursor_unchanged(self, storage):
         ids = self._add_events(storage, 5)
 
-        events, next_cursor = storage.get_events(order="asc")
+        events, next_cursor, _ = storage.get_events(order="asc")
         assert next_cursor == str(max(ids))
+
+
+class TestBacklogPaging:
+    """has_more semantics when the unseen backlog exceeds limit."""
+
+    def _add_events(self, storage, n):
+        return [
+            storage.add_event(event_type=f"event_{i}", payload=f"payload {i}", session_id="s1").id
+            for i in range(n)
+        ]
+
+    def test_desc_backlog_beyond_limit_sets_has_more_and_skips(self, storage):
+        ids = self._add_events(storage, 7)
+
+        events, next_cursor, has_more = storage.get_events(limit=5, order="desc")
+        assert [e.id for e in events] == list(reversed(ids[-5:]))
+        assert has_more is True
+        assert next_cursor == str(max(ids))
+
+        # Documented desc trade-off: the page is the newest slice, so feeding
+        # next_cursor back skips the two oldest backlog events. Drain with
+        # order="asc" when no event may be missed.
+        events2, _, has_more2 = storage.get_events(cursor=next_cursor, limit=5, order="desc")
+        assert events2 == []
+        assert has_more2 is False
+
+    def test_asc_drains_backlog_across_pages(self, storage):
+        ids = self._add_events(storage, 7)
+
+        seen = []
+        cursor = None
+        for _ in range(10):
+            events, cursor, has_more = storage.get_events(cursor=cursor, limit=5, order="asc")
+            seen.extend(e.id for e in events)
+            if not has_more:
+                break
+
+        assert seen == ids

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -875,3 +875,43 @@ class TestDbLocationMigration:
         row = cursor.fetchone()
         conn.close()
         assert row is None, "New DB should not have old_marker table (wasn't overwritten)"
+
+
+class TestNextCursorHighWater:
+    """next_cursor must never re-serve events, regardless of order."""
+
+    def _add_events(self, storage, n):
+        return [
+            storage.add_event(event_type=f"event_{i}", payload=f"payload {i}", session_id="s1").id
+            for i in range(n)
+        ]
+
+    def test_desc_next_cursor_is_high_water(self, storage):
+        ids = self._add_events(storage, 5)
+
+        events, next_cursor = storage.get_events(order="desc")
+        assert next_cursor == str(max(ids))
+
+    def test_desc_polling_with_next_cursor_never_duplicates(self, storage):
+        """The old MIN-for-desc cursor returned the same newest events on
+        every follow-up call; feeding next_cursor back must yield only new
+        events."""
+        self._add_events(storage, 3)
+        _, cursor = storage.get_events(order="desc")
+
+        # No new events: nothing comes back
+        events, cursor2 = storage.get_events(cursor=cursor, order="desc")
+        assert events == []
+        assert cursor2 == cursor
+
+        # A new event: exactly that event comes back
+        new_id = storage.add_event(event_type="fresh", payload="new", session_id="s1").id
+        events, cursor3 = storage.get_events(cursor=cursor, order="desc")
+        assert [e.id for e in events] == [new_id]
+        assert cursor3 == str(new_id)
+
+    def test_asc_next_cursor_unchanged(self, storage):
+        ids = self._add_events(storage, 5)
+
+        events, next_cursor = storage.get_events(order="asc")
+        assert next_cursor == str(max(ids))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -953,3 +953,12 @@ class TestBacklogPaging:
                 break
 
         assert seen == ids
+
+    def test_limit_zero_does_not_report_more(self, storage):
+        """limit=0 returns an empty page that never advances the cursor; a
+        keep-polling-while-has_more loop would spin forever if it were True."""
+        self._add_events(storage, 3)
+
+        events, cursor, has_more = storage.get_events(limit=0)
+        assert events == []
+        assert has_more is False

--- a/tests/test_structured_payload.py
+++ b/tests/test_structured_payload.py
@@ -1,0 +1,288 @@
+"""Tests for the RFC #121 substrate: optional structured payload fields
+(title, tags, signal_level), first-class correlation_id, and the v4 schema
+migration."""
+
+import sqlite3
+from argparse import Namespace
+from datetime import datetime
+from unittest.mock import patch
+
+from agent_event_bus import cli, server
+
+publish_event = server._publish_event_impl
+get_events = server._get_events_impl
+
+
+class TestStorageStructuredFields:
+    def test_add_event_roundtrips_correlation_and_meta(self, storage):
+        created = storage.add_event(
+            event_type="task_request",
+            payload="please review",
+            session_id="s1",
+            correlation_id="thread-42",
+            meta={"title": "Review request", "tags": ["review", "urgent"]},
+        )
+        assert created.correlation_id == "thread-42"
+
+        events, _ = storage.get_events(order="asc")
+        assert len(events) == 1
+        assert events[0].correlation_id == "thread-42"
+        assert events[0].meta == {"title": "Review request", "tags": ["review", "urgent"]}
+
+    def test_plain_events_have_no_meta(self, storage):
+        storage.add_event(event_type="note", payload="hi", session_id="s1")
+
+        events, _ = storage.get_events(order="asc")
+        assert events[0].correlation_id is None
+        assert events[0].meta is None
+
+    def test_empty_meta_normalized_to_none(self, storage):
+        created = storage.add_event(event_type="note", payload="hi", session_id="s1", meta={})
+        assert created.meta is None
+
+        events, _ = storage.get_events(order="asc")
+        assert events[0].meta is None
+
+    def test_filter_by_correlation_id(self, storage):
+        storage.add_event(
+            event_type="task_request", payload="a", session_id="s1", correlation_id="t-1"
+        )
+        storage.add_event(event_type="unrelated", payload="b", session_id="s2")
+        storage.add_event(
+            event_type="task_response", payload="c", session_id="s2", correlation_id="t-1"
+        )
+        storage.add_event(
+            event_type="task_request", payload="d", session_id="s1", correlation_id="t-2"
+        )
+
+        events, _ = storage.get_events(order="asc", correlation_id="t-1")
+        assert [e.payload for e in events] == ["a", "c"]
+
+    def test_correlation_filter_composes_with_type_filter(self, storage):
+        storage.add_event(
+            event_type="task_request", payload="a", session_id="s1", correlation_id="t-1"
+        )
+        storage.add_event(
+            event_type="task_response", payload="b", session_id="s2", correlation_id="t-1"
+        )
+
+        events, _ = storage.get_events(
+            order="asc", correlation_id="t-1", event_types=["task_response"]
+        )
+        assert [e.payload for e in events] == ["b"]
+
+    def test_corrupt_payload_meta_is_dropped_not_fatal(self, storage):
+        storage.add_event(event_type="note", payload="hi", session_id="s1")
+        with storage._connect() as conn:
+            conn.execute("UPDATE events SET payload_meta = 'not-json{'")
+
+        events, _ = storage.get_events(order="asc")
+        assert events[0].meta is None
+
+
+class TestMigrationV4:
+    def test_migrates_v3_database(self, temp_db):
+        """A pre-v4 database gains the new columns and keeps its events."""
+        # Build a v3-shaped database by hand
+        conn = sqlite3.connect(temp_db)
+        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO schema_version (version) VALUES (3)")
+        conn.execute("""
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                display_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                machine TEXT NOT NULL,
+                cwd TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                registered_at TIMESTAMP NOT NULL,
+                last_heartbeat TIMESTAMP NOT NULL,
+                client_id TEXT,
+                last_cursor TEXT,
+                deleted_at TIMESTAMP
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                timestamp TIMESTAMP NOT NULL,
+                channel TEXT NOT NULL DEFAULT 'all'
+            )
+        """)
+        conn.execute(
+            "INSERT INTO events (event_type, payload, session_id, timestamp) VALUES (?, ?, ?, ?)",
+            ("legacy", "old event", "old-session", datetime.now().isoformat()),
+        )
+        conn.commit()
+        conn.close()
+
+        from agent_event_bus.storage import SQLiteStorage
+
+        storage = SQLiteStorage(db_path=temp_db)
+
+        # Old events survive and read back with None structured fields
+        events, _ = storage.get_events(order="asc")
+        assert len(events) == 1
+        assert events[0].payload == "old event"
+        assert events[0].correlation_id is None
+        assert events[0].meta is None
+
+        # New columns and index exist
+        with storage._connect() as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(events)")}
+            assert "correlation_id" in columns
+            assert "payload_meta" in columns
+            indexes = {row[1] for row in conn.execute("PRAGMA index_list(events)")}
+            assert "idx_events_correlation" in indexes
+
+    def test_fresh_database_gets_same_schema(self, storage):
+        with storage._connect() as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(events)")}
+            assert "correlation_id" in columns
+            assert "payload_meta" in columns
+            indexes = {row[1] for row in conn.execute("PRAGMA index_list(events)")}
+            assert "idx_events_correlation" in indexes
+
+
+class TestServerStructuredPublish:
+    def test_publish_and_get_structured_fields(self):
+        # The suite shares one events table; anchor at the current tip so
+        # only this test's events are in play.
+        start = server.storage.get_cursor()
+        published = publish_event(
+            event_type="task_request",
+            payload="please review PR 42",
+            title="Review request",
+            tags=["review"],
+            correlation_id="thread-1",
+        )
+        assert published["correlation_id"] == "thread-1"
+
+        result = get_events(cursor=start, order="asc")
+        event = next(e for e in result["events"] if e["id"] == published["event_id"])
+        assert event["correlation_id"] == "thread-1"
+        assert event["title"] == "Review request"
+        assert event["tags"] == ["review"]
+
+    def test_plain_publish_has_null_correlation(self):
+        start = server.storage.get_cursor()
+        published = publish_event(event_type="note", payload="hi")
+        assert "correlation_id" not in published
+
+        result = get_events(cursor=start, order="asc")
+        event = next(e for e in result["events"] if e["id"] == published["event_id"])
+        assert event["correlation_id"] is None
+        assert "title" not in event
+        assert "tags" not in event
+
+    def test_get_events_correlation_filter(self):
+        start = server.storage.get_cursor()
+        publish_event(event_type="task_request", payload="a", correlation_id="t-1")
+        publish_event(event_type="noise", payload="b")
+        publish_event(event_type="task_response", payload="c", correlation_id="t-1")
+
+        result = get_events(cursor=start, order="asc", correlation_id="t-1")
+        assert [e["payload"] for e in result["events"]] == ["a", "c"]
+
+    def test_unknown_signal_level_warns_but_stores(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            published = publish_event(event_type="note", payload="hi", signal_level="shouting")
+
+        assert any("Unknown signal_level" in r.message for r in caplog.records)
+        # Stored as-is (soft validation)
+        raw_events, _ = server.storage.get_events(order="desc", limit=5)
+        event = next(e for e in raw_events if e.id == published["event_id"])
+        assert event.meta == {"signal_level": "shouting"}
+
+
+class TestCLIStructuredFlags:
+    @patch("agent_event_bus.cli.call_tool")
+    def test_publish_passes_structured_fields(self, mock_call):
+        mock_call.return_value = {"event_id": 1}
+        args = Namespace(
+            type="task_request",
+            payload="please review",
+            channel="all",
+            session_id=None,
+            title="Review request",
+            tags="review, urgent",
+            correlation_id="thread-1",
+            signal_level="actionable",
+            url=None,
+            debug=False,
+        )
+
+        cli.cmd_publish(args)
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["title"] == "Review request"
+        assert call_args["tags"] == ["review", "urgent"]
+        assert call_args["correlation_id"] == "thread-1"
+        assert call_args["signal_level"] == "actionable"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_publish_omits_absent_structured_fields(self, mock_call):
+        mock_call.return_value = {"event_id": 1}
+        args = Namespace(
+            type="note",
+            payload="hi",
+            channel="all",
+            session_id=None,
+            title=None,
+            tags=None,
+            correlation_id=None,
+            signal_level=None,
+            url=None,
+            debug=False,
+        )
+
+        cli.cmd_publish(args)
+
+        call_args = mock_call.call_args[0][1]
+        for key in ("title", "tags", "correlation_id", "signal_level"):
+            assert key not in call_args
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_events_correlation_filter_passthrough(self, mock_call):
+        from conftest import make_events_args
+
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args(correlation_id="thread-1"))
+
+        call_args = mock_call.call_args[0][1]
+        assert call_args["correlation_id"] == "thread-1"
+
+    def test_publish_flags_parse(self):
+        import sys as _sys
+
+        argv = [
+            "cli",
+            "publish",
+            "--type",
+            "task_request",
+            "--payload",
+            "p",
+            "--title",
+            "T",
+            "--tags",
+            "a,b",
+            "--correlation-id",
+            "t-9",
+            "--signal-level",
+            "actionable",
+        ]
+        with patch.object(_sys, "argv", argv):
+            with patch("agent_event_bus.cli.cmd_publish") as mock_cmd:
+                cli.main()
+
+                args = mock_cmd.call_args[0][0]
+                assert args.title == "T"
+                assert args.tags == "a,b"
+                assert args.correlation_id == "t-9"
+                assert args.signal_level == "actionable"

--- a/tests/test_structured_payload.py
+++ b/tests/test_structured_payload.py
@@ -24,7 +24,7 @@ class TestStorageStructuredFields:
         )
         assert created.correlation_id == "thread-42"
 
-        events, _ = storage.get_events(order="asc")
+        events, _, _ = storage.get_events(order="asc")
         assert len(events) == 1
         assert events[0].correlation_id == "thread-42"
         assert events[0].meta == {"title": "Review request", "tags": ["review", "urgent"]}
@@ -32,7 +32,7 @@ class TestStorageStructuredFields:
     def test_plain_events_have_no_meta(self, storage):
         storage.add_event(event_type="note", payload="hi", session_id="s1")
 
-        events, _ = storage.get_events(order="asc")
+        events, _, _ = storage.get_events(order="asc")
         assert events[0].correlation_id is None
         assert events[0].meta is None
 
@@ -40,7 +40,7 @@ class TestStorageStructuredFields:
         created = storage.add_event(event_type="note", payload="hi", session_id="s1", meta={})
         assert created.meta is None
 
-        events, _ = storage.get_events(order="asc")
+        events, _, _ = storage.get_events(order="asc")
         assert events[0].meta is None
 
     def test_filter_by_correlation_id(self, storage):
@@ -55,7 +55,7 @@ class TestStorageStructuredFields:
             event_type="task_request", payload="d", session_id="s1", correlation_id="t-2"
         )
 
-        events, _ = storage.get_events(order="asc", correlation_id="t-1")
+        events, _, _ = storage.get_events(order="asc", correlation_id="t-1")
         assert [e.payload for e in events] == ["a", "c"]
 
     def test_correlation_filter_composes_with_type_filter(self, storage):
@@ -66,7 +66,7 @@ class TestStorageStructuredFields:
             event_type="task_response", payload="b", session_id="s2", correlation_id="t-1"
         )
 
-        events, _ = storage.get_events(
+        events, _, _ = storage.get_events(
             order="asc", correlation_id="t-1", event_types=["task_response"]
         )
         assert [e.payload for e in events] == ["b"]
@@ -76,7 +76,7 @@ class TestStorageStructuredFields:
         with storage._connect() as conn:
             conn.execute("UPDATE events SET payload_meta = 'not-json{'")
 
-        events, _ = storage.get_events(order="asc")
+        events, _, _ = storage.get_events(order="asc")
         assert events[0].meta is None
 
 
@@ -124,7 +124,7 @@ class TestMigrationV4:
         storage = SQLiteStorage(db_path=temp_db)
 
         # Old events survive and read back with None structured fields
-        events, _ = storage.get_events(order="asc")
+        events, _, _ = storage.get_events(order="asc")
         assert len(events) == 1
         assert events[0].payload == "old event"
         assert events[0].correlation_id is None
@@ -195,7 +195,7 @@ class TestServerStructuredPublish:
 
         assert any("Unknown signal_level" in r.message for r in caplog.records)
         # Stored as-is (soft validation)
-        raw_events, _ = server.storage.get_events(order="desc", limit=5)
+        raw_events, _, _ = server.storage.get_events(order="desc", limit=5)
         event = next(e for e in raw_events if e.id == published["event_id"])
         assert event.meta == {"signal_level": "shouting"}
 

--- a/tests/test_structured_payload.py
+++ b/tests/test_structured_payload.py
@@ -3,11 +3,11 @@
 migration."""
 
 import sqlite3
-from argparse import Namespace
 from datetime import datetime
 from unittest.mock import patch
 
 from agent_event_bus import cli, server
+from conftest import make_publish_args
 
 publish_event = server._publish_event_impl
 get_events = server._get_events_impl
@@ -204,17 +204,13 @@ class TestCLIStructuredFlags:
     @patch("agent_event_bus.cli.call_tool")
     def test_publish_passes_structured_fields(self, mock_call):
         mock_call.return_value = {"event_id": 1}
-        args = Namespace(
+        args = make_publish_args(
             type="task_request",
             payload="please review",
-            channel="all",
-            session_id=None,
             title="Review request",
             tags="review, urgent",
             correlation_id="thread-1",
             signal_level="actionable",
-            url=None,
-            debug=False,
         )
 
         cli.cmd_publish(args)
@@ -228,18 +224,7 @@ class TestCLIStructuredFlags:
     @patch("agent_event_bus.cli.call_tool")
     def test_publish_omits_absent_structured_fields(self, mock_call):
         mock_call.return_value = {"event_id": 1}
-        args = Namespace(
-            type="note",
-            payload="hi",
-            channel="all",
-            session_id=None,
-            title=None,
-            tags=None,
-            correlation_id=None,
-            signal_level=None,
-            url=None,
-            debug=False,
-        )
+        args = make_publish_args(type="note", payload="hi")
 
         cli.cmd_publish(args)
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -541,3 +541,82 @@ class TestWebhookIntegration:
 
             # Should return False, not raise
             assert result is False
+
+
+class TestWebhookStructuredPayload:
+    """Webhook payloads must carry the structured fields and the same derived
+    signal_level that get_events reports for the event."""
+
+    def _make_client(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=AsyncMock(status_code=200))
+        return mock_client
+
+    def _make_webhook(self):
+        return Webhook(
+            id=1,
+            url="https://example.com/hook",
+            channel_filter=None,
+            event_types=None,
+            created_at=datetime.now(),
+            active=True,
+            secret=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_payload_carries_structured_fields(self):
+        import json
+
+        from agent_event_bus.server import _dispatch_webhook
+
+        event = Event(
+            id=7,
+            event_type="task_request",
+            payload="review?",
+            session_id="s",
+            timestamp=datetime.now(),
+            channel="all",
+            correlation_id="t-1",
+            meta={"title": "T", "tags": ["a"], "signal_level": "shouting"},
+        )
+
+        with patch("agent_event_bus.server._get_webhook_client") as mock_get_client:
+            mock_client = self._make_client()
+            mock_get_client.return_value = mock_client
+
+            assert await _dispatch_webhook(self._make_webhook(), event) is True
+
+            body = json.loads(mock_client.post.call_args.kwargs["content"])
+            assert body["correlation_id"] == "t-1"
+            assert body["title"] == "T"
+            assert body["tags"] == ["a"]
+            # Derived level, matching get_events: the unknown explicit level
+            # "shouting" is normalized instead of forwarded verbatim
+            assert body["signal_level"] == "info"
+
+    @pytest.mark.asyncio
+    async def test_payload_signal_level_derived_without_explicit_level(self):
+        import json
+
+        from agent_event_bus.server import _dispatch_webhook
+
+        event = Event(
+            id=8,
+            event_type="help_needed",
+            payload="p",
+            session_id="s",
+            timestamp=datetime.now(),
+            channel="all",
+        )
+
+        with patch("agent_event_bus.server._get_webhook_client") as mock_get_client:
+            mock_client = self._make_client()
+            mock_get_client.return_value = mock_client
+
+            assert await _dispatch_webhook(self._make_webhook(), event) is True
+
+            body = json.loads(mock_client.post.call_args.kwargs["content"])
+            assert body["signal_level"] == "actionable"
+            assert body["correlation_id"] is None
+            assert "title" not in body
+            assert "tags" not in body

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -305,7 +305,7 @@ class TestWebhookMCPTools:
         """Test register_webhook MCP tool."""
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
+        register_webhook = server._register_webhook_impl
 
         result = register_webhook(
             url="https://example.com/hook",
@@ -324,7 +324,7 @@ class TestWebhookMCPTools:
         """Test register_webhook with minimal args."""
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
+        register_webhook = server._register_webhook_impl
 
         result = register_webhook(url="https://example.com/simple")
 
@@ -337,8 +337,8 @@ class TestWebhookMCPTools:
         """Test list_webhooks redacts secrets."""
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
-        list_webhooks = server.list_webhooks.fn
+        register_webhook = server._register_webhook_impl
+        list_webhooks = server._list_webhooks_impl
 
         register_webhook(url="https://a.com", secret="my-secret")
         register_webhook(url="https://b.com")  # No secret
@@ -360,8 +360,8 @@ class TestWebhookMCPTools:
         """Test list_webhooks active_only filter."""
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
-        list_webhooks = server.list_webhooks.fn
+        register_webhook = server._register_webhook_impl
+        list_webhooks = server._list_webhooks_impl
 
         register_webhook(url="https://active.com")
         wh2 = register_webhook(url="https://inactive.com")
@@ -378,8 +378,8 @@ class TestWebhookMCPTools:
         """Test unregister_webhook success."""
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
-        unregister_webhook = server.unregister_webhook.fn
+        register_webhook = server._register_webhook_impl
+        unregister_webhook = server._unregister_webhook_impl
 
         wh = register_webhook(url="https://delete-me.com")
         result = unregister_webhook(wh["webhook_id"])
@@ -391,7 +391,7 @@ class TestWebhookMCPTools:
         """Test unregister_webhook with invalid ID."""
         from agent_event_bus import server
 
-        unregister_webhook = server.unregister_webhook.fn
+        unregister_webhook = server._unregister_webhook_impl
 
         result = unregister_webhook(webhook_id=99999)
 
@@ -413,8 +413,8 @@ class TestWebhookIntegration:
 
         from agent_event_bus import server
 
-        register_webhook = server.register_webhook.fn
-        publish_event = server.publish_event.fn
+        register_webhook = server._register_webhook_impl
+        publish_event = server._publish_event_impl
 
         # Register a webhook
         register_webhook(url="https://example.com/hook")

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,11 @@ name = "agent-event-bus"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "requests" },
+    { name = "starlette" },
     { name = "uvicorn" },
 ]
 
@@ -22,9 +24,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "starlette", specifier = ">=0.37.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -24,13 +24,16 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
+]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
Batch of fixes and features from a full-codebase review, in focused commits (plus three review-response rounds).

## Bug fixes

**Server unresponsive under concurrent load (fixes #112).** Root cause: FastMCP executes sync tool functions directly on the uvicorn event loop, so any blocking call froze the entire server — and `send_notification` ran notifier subprocesses with **no timeout**, matching the reported symptoms exactly (process alive, requests hanging minutes, CLOSE_WAIT pileup). Tools are now async wrappers that offload their sync bodies to worker threads; notification subprocesses are bounded at 5s; SQLite gets WAL + `busy_timeout` so concurrent readers proceed during writes; webhook dispatch is loop-safe (worker threads hand coroutines to the captured server loop, the SQLite lookup itself is offloaded, and the shared `httpx.AsyncClient` is recreated when the loop changes); and `GET /health` provides a liveness probe that bypasses MCP (behind the same Tailscale auth as everything else).

**CLI `webhook register` never worked.** Its `--url` (webhook target) shared an argparse dest with the global `--url` (bus address), so the JSON-RPC registration call was POSTed to the webhook target itself. Confirmed by reproduction; there was no CLI webhook test coverage. Fixed with a distinct dest, plus the missing tests.

**`next_cursor` re-served events in desc order.** The query filters `id > cursor`, but desc responses returned the batch *minimum* — following the documented pagination loop returned the same newest events forever. Now the high-water mark in both orders, with `has_more` in the response and documentation that draining a backlog requires `order="asc"` (a desc page is the newest slice).

**Narrowed reads no longer consume the session cursor.** `channel`/`event_types`/`correlation_id` filters used to advance the cursor over the SQL-filtered batch, marking non-matching unread events as seen — combined with the #128 env-var default this silently ate session backlogs. This holds on the resume-initialization path too (a narrowed `resume=True` on a fresh session no longer snaps the cursor to the tip). `min_level` still consumes (it filters after cursor bookkeeping).

## Features

- **#128** — CLI `events` (like `publish`) defaults `--session-id` from `$AGENT_EVENT_BUS_SESSION_ID`, so subagent/hook publishes and polls stop being anonymous. Closes #128.
- **#129** — server-side signal levels (`lifecycle` < `info` < `actionable`) derived from event type; DMs always actionable; explicit `signal_level` wins. `get_events(min_level=...)` / `--min-level` replace per-consumer denylists. Closes #129.
- **RFC #121 substrate** — optional structured payload fields (`title`, `tags`, `signal_level`) and a first-class indexed `correlation_id`, additive and back-compat (schema migration v4; soft validation — warn, never reject). `get_events(correlation_id=...)` reads one thread; webhook payloads carry the structured fields and always include the derived `signal_level`, matching pollers. This is the threading primitive #107 and #97 build on. Refs #121, #107, #97.

## Housekeeping

- Dev deps moved to PEP 735 `[dependency-groups]` so a bare `uv run pytest` works on fresh clones; install targets use `--no-dev`. `anyio` and `starlette` declared as direct dependencies.
- Docs updated in lockstep per repo convention: `guide.md`, `CLAUDE.md` (webhook tools were missing from its tool list), CLI help.
- Issue #122's body was accidentally a duplicate of #121's; a reconstructed RFC has been filed there.

## Testing

`make check` green: 392 tests (317 existing + 75 new), format and lint clean. New coverage: async-wrapper end-to-end, notification timeouts, WAL pragmas, loop-safe dispatch, `/health` (including auth), CLI webhook commands, `--peek` CLI passthrough (closes #131), env attribution, v3→v4 migration on a hand-built legacy DB, correlation filtering, signal-level derivation/filtering, backlog paging with `has_more` (including the `limit=0` edge), and non-consuming narrowed reads (including the resume-init path).

**Note for deploy:** schema migration v4 runs on first start, and the same start flips the database to WAL mode. Back up first with a WAL-aware copy (plain `cp` of `data.db` alone is no longer safe once WAL is active):

```bash
sqlite3 ~/.claude/contrib/agent-event-bus/data.db ".backup $HOME/.claude/contrib/agent-event-bus/data.db.backup-$(date +%Y%m%d-%H%M%S)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R