### PR TITLE
Webhook→injection re-awakening bridge prototype (RFC #122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_WAKE_DIR`)
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_WAKE_DIR`)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Log files | `agent-event-bus.log`, `agent-event-bus.err` |
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
-| Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` - transient, safe to hand-clear; the DB protection below does NOT extend to it) |
+| Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |
+| Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/` (or `/tmp/...` when unset) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Safe to remove when no bridge is running |
 
 **Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_WAKE_DIR`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Repo | `agent-event-bus` |
 | Python package | `agent_event_bus` |
 | MCP server name | `agent-event-bus` |
-| CLI commands | `agent-event-bus`, `agent-event-bus-cli`, `agent-event-bus-bridge` |
+| CLI commands | `agent-event-bus`, `agent-event-bus-cli`, `agent-event-bus-bridge` (bridge is venv-only for now - run via `uv run`) |
 | Resource URI | `agent-event-bus://guide` |
 | Data directory | `~/.claude/contrib/agent-event-bus/` |
 | Database | `~/.claude/contrib/agent-event-bus/data.db` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_WAKE_DIR`)
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_WAKE_DIR`)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Repo | `agent-event-bus` |
 | Python package | `agent_event_bus` |
 | MCP server name | `agent-event-bus` |
-| CLI commands | `agent-event-bus`, `agent-event-bus-cli` |
+| CLI commands | `agent-event-bus`, `agent-event-bus-cli`, `agent-event-bus-bridge` |
 | Resource URI | `agent-event-bus://guide` |
 | Data directory | `~/.claude/contrib/agent-event-bus/` |
 | Database | `~/.claude/contrib/agent-event-bus/data.db` |
@@ -88,6 +88,7 @@ src/agent_event_bus/
 ├── middleware.py  # Request logging → ~/.claude/contrib/agent-event-bus/agent-event-bus.log
 ├── session_ids.py # Dinosaur-themed display_id generation
 ├── cli.py         # CLI wrapper for shell scripts
+├── bridge.py      # Webhook→injection re-awakening bridge (RFC #122, experimental)
 └── guide.md       # Usage guide (agent-event-bus://guide resource)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`)
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_WAKE_DIR`)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Log files | `agent-event-bus.log`, `agent-event-bus.err` |
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
+| Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` - transient, safe to hand-clear; the DB protection below does NOT extend to it) |
 
 **Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_WAKE_DIR`)
 
@@ -66,7 +67,7 @@ make restart    # Lightweight service restart (no dependency sync)
 ./scripts/dev.sh  # Dev mode (foreground, auto-reload)
 ```
 
-**When to restart**: Code changes to `server.py`, `storage.py`, `helpers.py` require `make install-server` (or `make restart`). `guide.md` is read fresh each request. Dev mode auto-reloads.
+**When to restart**: Code changes to `server.py`, `storage.py`, `helpers.py` require `make install-server` (or `make restart`). `guide.md` is read fresh each request. Dev mode auto-reloads. The bridge is a separate process with no install target - after `bridge.py` changes, restart whatever runs `uv run agent-event-bus-bridge`.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | LaunchAgent | `com.evansenter.agent-event-bus.plist` |
 | systemd service | `agent-event-bus.service` |
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |
-| Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/` (or `/tmp/...` when unset) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Safe to remove when no bridge is running |
+| Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/`, else the system temp dir (`$TMPDIR`, or `/tmp` when unset; macOS: per-user `/var/folders/.../T`) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Create-and-verified private (not adopted). Safe to remove when no bridge is running |
 
 **Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_WAKE_DIR`)
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Push events to HTTP endpoints instead of polling. Webhooks are called asynchrono
 
 `agent-event-bus-bridge` is the experimental local consumer of this
 mechanism: a daemon that wakes idle sessions when an actionable DM arrives
-(RFC #122). See the "Re-awakening Bridge" section of the usage guide
+(RFC #122). Run it as `uv run agent-event-bus-bridge` from the checkout -
+unlike the CLI, nothing symlinks it onto PATH until the supervision story
+lands. See the "Re-awakening Bridge" section of the usage guide
 (`agent-event-bus://guide`).
 
 ### MCP

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ agent-event-bus-cli unregister --session-id "$SESSION_ID"
 
 Push events to HTTP endpoints instead of polling. Webhooks are called asynchronously when events are published.
 
+`agent-event-bus-bridge` is the experimental local consumer of this
+mechanism: a daemon that wakes idle sessions when an actionable DM arrives
+(RFC #122). See the "Re-awakening Bridge" section of the usage guide
+(`agent-event-bus://guide`).
+
 ### MCP
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
 [project.scripts]
 agent-event-bus = "agent_event_bus.server:main"
 agent-event-bus-cli = "agent_event_bus.cli:main"
+agent-event-bus-bridge = "agent_event_bus.bridge:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_event_bus"]

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -893,14 +893,26 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # ("http:///mcp") parses with no hostname and would read as loopback,
     # skipping the topology guard below - catch the misconfiguration here
     # instead of in a later connection error
-    parsed_bus = urllib.parse.urlsplit(config.bus_url)
+    # urlsplit itself raises ValueError("Invalid IPv6 URL") on an unbalanced
+    # bracket - one call earlier than the port guard below, same class of
+    # input, so it gets the same named-config-error treatment
+    try:
+        parsed_bus = urllib.parse.urlsplit(config.bus_url)
+    except ValueError as e:
+        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: {e}") from None
     if parsed_bus.scheme not in ("http", "https") or not parsed_bus.hostname:
         raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http(s)://host[:port]/path")
     # Same check for the hook URL - it is what BOTH topology guards below
     # read: a scheme-less value parses to hostname None, reads as loopback,
     # skips the guards, and registers a URL the bus can never POST to
     if config.hook_url is not None:
-        parsed_hook = urllib.parse.urlsplit(config.hook_url)
+        try:
+            parsed_hook = urllib.parse.urlsplit(config.hook_url)
+        except ValueError as e:
+            raise SystemExit(
+                f"Invalid hook URL {config.hook_url!r} "
+                f"(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): {e}"
+            ) from None
         # Require a hostname too: "http:///hook" parses to hostname None,
         # which reads as loopback and would skip every topology guard
         if parsed_hook.scheme not in ("http", "https") or not parsed_hook.hostname:
@@ -1034,21 +1046,38 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # binds ("localhost") are exempt the other way - the resolver decides
     # their family.
     try:
-        hook_is_v6 = (
-            ipaddress.ip_address(urllib.parse.urlsplit(bridge_hook_url(config)).hostname).version
-            == 6
-        )
+        hook_family = ipaddress.ip_address(
+            urllib.parse.urlsplit(bridge_hook_url(config)).hostname
+        ).version
     except ValueError:
-        hook_is_v6 = False
+        hook_family = None  # hostname - the resolver decides its family
     try:
-        bind_is_v4 = ipaddress.ip_address(bind_host(config)).version == 4
+        bind_ip = ipaddress.ip_address(bind_host(config))
     except ValueError:
-        bind_is_v4 = False
-    if hook_is_v6 and bind_is_v4:
+        bind_ip = None  # "localhost" - the resolver decides its family
+    if hook_family == 6 and bind_ip is not None and bind_ip.version == 4:
         logger.warning(
             f"Hook URL host is an IPv6 address but the listener binds "
             f"{bind_host(config)} (IPv4 only) - the bus can't reach it; "
             "set --bind to '::' (dual-stack) or an IPv6 address"
+        )
+    # The mirror direction: a v4 hook literal with a PINNED v6 bind (::1, a
+    # tailnet v6 address) is refused at TCP the same way, with every other
+    # guard quiet - e.g. --bind ::1 under the default loopback hook URL is
+    # all-loopback, so neither the exposure nor the quadrant checks fire.
+    # :: stays quiet: dual-stack picks up v4 too (_is_host_wildcard is what
+    # distinguishes it from a pinned address).
+    if (
+        hook_family == 4
+        and bind_ip is not None
+        and bind_ip.version == 6
+        and not bind_ip.is_unspecified
+    ):
+        logger.warning(
+            f"Hook URL host is an IPv4 address but the listener binds "
+            f"{bind_host(config)} (IPv6 only) - the bus can't reach it; "
+            "bind an IPv4 or dual-stack ('::') address, or advertise an "
+            "IPv6 hook URL"
         )
     return config
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -151,14 +151,15 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 # The unsafe-id rejection below is publisher-drivable (the bus warns on
-# malformed channels but never rejects them), so a per-event WARNING would
-# let any publisher choose how much the bridge writes to its log. Warn on
-# the first sighting of each distinct channel string, debug the rest.
-# Cleared at a cap rather than LRU-evicted: past that many distinct garbage
-# channels, one repeat warning per channel is the lesser noise. Unlocked -
+# malformed channels but never rejects them), and the channel string is
+# publisher-CHOSEN - so a bound keyed on the value (a dedup set) still lets
+# a publisher who varies the id force one warning per event. Bound by time
+# instead: at most one WARNING per interval regardless of content, repeats
+# at debug (DEV_MODE surfaces every offending string). A persistent
+# condition re-warns each interval instead of going dark forever. Unlocked -
 # a rare race just duplicates a warning.
-_warned_unsafe_channels: set[str] = set()
-_WARNED_UNSAFE_CHANNELS_CAP = 64
+_UNSAFE_WARN_INTERVAL_SECONDS = 60.0
+_unsafe_warn_state = {"last": -math.inf}
 
 
 def resolve_target_session(event: dict) -> str | None:
@@ -177,13 +178,12 @@ def resolve_target_session(event: dict) -> str | None:
         return None
     target = channel.split(":", 1)[1]
     if not SESSION_ID_PATTERN.fullmatch(target):
-        if channel in _warned_unsafe_channels:
-            logger.debug(f"Ignoring event with unsafe session id in channel {channel!r}")
-        else:
-            if len(_warned_unsafe_channels) >= _WARNED_UNSAFE_CHANNELS_CAP:
-                _warned_unsafe_channels.clear()
-            _warned_unsafe_channels.add(channel)
+        now = time.monotonic()
+        if now - _unsafe_warn_state["last"] >= _UNSAFE_WARN_INTERVAL_SECONDS:
+            _unsafe_warn_state["last"] = now
             logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
+        else:
+            logger.debug(f"Ignoring event with unsafe session id in channel {channel!r}")
         return None
     return target
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -233,7 +233,7 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
 # a hostile publisher, not a legitimate own registration. Loosening the
 # pattern is not the fix (the id still becomes a filename); validating
 # client_id bus-side at registration is, and belongs in its own change.
-# Same dead end round 26 documented for display_id, reached from the
+# Same dead end already documented for display_id, reached from the
 # client_id side.
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
@@ -711,7 +711,7 @@ class Injector:
             logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
             # A working wake re-arms THIS session's failure conditions only -
             # clearing globally would oscillate a broken session's warning
-            # under interleaved healthy deliveries (the round-38 shape).
+            # under interleaved healthy deliveries.
             # Under the lock: the comprehension iterates the set, and a
             # concurrent delivery's add would otherwise raise RuntimeError
             # out of the one method whose exceptions must never 500 the
@@ -811,7 +811,15 @@ def create_bridge_app(
     hook_host = urllib.parse.urlsplit(bridge_hook_url(config)).hostname
     allowed_hook_hosts = {"127.0.0.1", "localhost", "::1"}
     if hook_host:
-        allowed_hook_hosts.add(hook_host)
+        # Normalize an IPv6 literal the same way the bind address is below:
+        # urlsplit lowercases and de-brackets but does NOT compress, so an
+        # expanded hook-URL literal ([FD7A:...:0:0:0:0:1]) would otherwise
+        # miss the compressed Host a probe sends. A hostname compares
+        # verbatim (urlsplit already lowercased it).
+        try:
+            allowed_hook_hosts.add(str(ipaddress.ip_address(hook_host)))
+        except ValueError:
+            allowed_hook_hosts.add(hook_host)
     bind = bind_host(config)
     try:
         bind_ip = ipaddress.ip_address(bind)
@@ -1086,7 +1094,7 @@ class _HostAllowlistMiddleware:
     never applies and the request reaches us - but the browser fills Host
     from the page's URL, so a rebound request never carries a loopback
     literal or the hook URL host the bus was told to POST to. Enforcing this
-    inside the endpoints (the round-57 shape) left GET /hook -> 405 and
+    inside the endpoints (per-route) left GET /hook -> 405 and
     /anything -> 404 answerable BEFORE the endpoint ran, and 405-vs-404 still
     confirms a bridge is here - the exact existence signal extending the
     guard to /health was meant to deny. As middleware it runs before the
@@ -1153,8 +1161,8 @@ def bind_host(config: BridgeConfig) -> str:
     loopback hook URL (the local bus is the sole caller), else all
     interfaces. validate_config requires the HMAC secret whenever the
     effective bind OR the hook URL is non-loopback - on every path, not
-    just the CLI (the refusal moved there in round 41 so it travels with a
-    hand-built config onto the embedding paths)."""
+    just the CLI (the refusal lives here so it travels with a hand-built
+    config onto the embedding paths, not only through argparse)."""
     if config.bind:
         return config.bind
     hook_host = urllib.parse.urlsplit(bridge_hook_url(config)).hostname

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -19,8 +19,11 @@ Injection backends:
          session-side (e.g. a SessionStart hook publishing $TMUX_PANE) must
          maintain.
 
-Loop prevention: a per-session cooldown (default 30s) bounds injections; an
-event that arrives during cooldown is spooled instead, so nothing is lost.
+Loop prevention: in the tmux backend a per-session cooldown (default 30s)
+bounds injections; an event that arrives during cooldown is spooled instead,
+so nothing is lost. In the default spool backend the cooldown never engages -
+a spool line only becomes a wake when the drain hook acts on it, so bounding
+that belongs to the drain hook.
 
 Run:  agent-event-bus-bridge [--backend tmux] [--port 8082] ...
 The bridge registers its own webhook on the bus at startup (HMAC-signed when
@@ -204,12 +207,13 @@ class Injector:
 
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken: "tmux",
-        "spool" (spool backend working as designed), "spool-cooldown", or
-        "spool-tmux-failed" (tmux backend, wake missed or failed). The
-        distinct failure value is the one in-band signal - it rides the 200
-        response's `action` field - that separates "tmux is broken on this
-        box" from the spool backend's normal path, since the unmapped-pane
-        arm logs only at debug.
+        "spool" (spool backend working as designed), "spool-cooldown",
+        "spool-unmapped" (tmux backend, no pane mapping - the NORMAL outcome
+        for a session on another machine, since webhooks have no machine
+        scoping), or "spool-tmux-failed" (tmux backend, the send-keys
+        attempt itself failed - the arm that means tmux on this box is
+        broken). The distinction rides the 200 response's `action` field,
+        the one in-band signal, since the unmapped arm logs only at debug.
 
         The cooldown bounds successful injections only: spool writes are
         durable bookkeeping, not wakes, and a failed tmux attempt must not
@@ -225,6 +229,17 @@ class Injector:
 
         if self.config.backend != "tmux":
             return "spool"
+
+        # Pane lookup BEFORE the cooldown machinery: on a multi-machine bus
+        # the unmapped arm is the normal outcome, not a failure, so there is
+        # no reservation to take or roll back. Debug, not info: per-event
+        # INFO on an arm every foreign-machine DM lands on is permanent
+        # noise - matches the below-actionable filter arm and _tmux_pane's
+        # silent missing-file case.
+        pane = self._tmux_pane(session_id)
+        if pane is None:
+            logger.debug(f"No tmux pane mapping for {session_id[:8]}...; spooled only")
+            return "spool-unmapped"
 
         with self._lock:
             now = time.monotonic()
@@ -244,8 +259,10 @@ class Injector:
             self._last_wake[session_id] = now
 
         # tmux runs outside the lock (bounded at TMUX_TIMEOUT, but other
-        # sessions' deliveries shouldn't wait on it)
-        if self._tmux_wake(session_id):
+        # sessions' deliveries shouldn't wait on it). The pane can go stale
+        # between the lookup above and here - send-keys just fails, which is
+        # the arm below.
+        if self._tmux_wake(session_id, pane):
             return "tmux"
         with self._lock:
             # Roll back the reservation so the failure doesn't burn the
@@ -316,16 +333,8 @@ class Injector:
         pane = panes.get(session_id)
         return pane if isinstance(pane, str) and pane else None
 
-    def _tmux_wake(self, session_id: str) -> bool:
-        """Type the wake prompt into the session's pane. False on any miss."""
-        pane = self._tmux_pane(session_id)
-        if pane is None:
-            # Debug, not info: webhooks have no machine scoping, so every DM
-            # aimed at a session on another machine lands here - per-event
-            # INFO would be permanent noise. Matches the below-actionable
-            # filter arm and _tmux_pane's silent missing-file case.
-            logger.debug(f"No tmux pane mapping for {session_id[:8]}...; spooled only")
-            return False
+    def _tmux_wake(self, session_id: str, pane: str) -> bool:
+        """Type the wake prompt into the given pane. False on failure."""
         try:
             subprocess.run(
                 ["tmux", "send-keys", "-t", pane, WAKE_PROMPT, "Enter"],
@@ -690,7 +699,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--cooldown",
         # Raw string default, cast in config_from_args - see _to_number
         default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_COOLDOWN") or str(DEFAULT_COOLDOWN_SECONDS),
-        help="Minimum seconds between wakes per session (loop prevention)",
+        help="Minimum seconds between tmux wakes per session (tmux backend "
+        "only; the spool backend's loop prevention belongs to the drain hook)",
     )
     parser.add_argument(
         "--wake-dir",
@@ -841,14 +851,21 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # otherwise the same silent-inertness failure the guards above close.
     # SplitResult.port raises for a malformed port - keep that a named
     # config error like every other input.
+    hook_split = urllib.parse.urlsplit(bridge_hook_url(config))
     try:
-        hook_port = urllib.parse.urlsplit(bridge_hook_url(config)).port
+        hook_port = hook_split.port
     except ValueError:
         raise SystemExit(
             f"Invalid hook URL {bridge_hook_url(config)!r} "
             "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): bad port"
         ) from None
-    if hook_port is not None and hook_port != config.port:
+    if hook_port is None:
+        # A missing port is not "no opinion" - the bus POSTs to the scheme
+        # default, so a forgotten :8082 is exactly the mismatch this warning
+        # names (https behind a TLS terminator forwarding to --port is the
+        # legitimate case, same as the other mismatches)
+        hook_port = 443 if hook_split.scheme == "https" else 80
+    if hook_port != config.port:
         logger.warning(
             f"Hook URL advertises port {hook_port} but the listener binds {config.port} - "
             "correct only if something forwards between them"

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -33,6 +33,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import subprocess
 import threading
 import time
@@ -79,6 +80,14 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
     return hmac.compare_digest(f"sha256={expected}", signature_header)
 
 
+# Session ids are UUIDs or display ids ("brave-trex"); nothing else. The
+# channel string is publisher-controlled wire input and the id becomes a spool
+# filename, so path separators, "..", and any other unexpected byte must never
+# reach the filesystem - the bus warns on malformed channels but does not
+# reject them.
+SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
+
+
 def resolve_target_session(event: dict) -> str | None:
     """Which session should this event wake?
 
@@ -88,9 +97,14 @@ def resolve_target_session(event: dict) -> str | None:
     are left for normal polling.
     """
     channel = event.get("channel") or ""
-    if channel.startswith("session:") and len(channel) > len("session:"):
-        return channel.split(":", 1)[1]
-    return None
+    if not channel.startswith("session:"):
+        return None
+    target = channel.split(":", 1)[1]
+    if not SESSION_ID_PATTERN.fullmatch(target):
+        if target:
+            logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
+        return None
+    return target
 
 
 class Injector:
@@ -118,16 +132,27 @@ class Injector:
             if self.config.backend != "tmux":
                 return "spool"
 
+            now = time.monotonic()
             last = self._last_wake.get(session_id)
-            if last is not None and (time.monotonic() - last) < self.config.cooldown_seconds:
+            if last is not None and (now - last) < self.config.cooldown_seconds:
                 return "spool-cooldown"
+            # Reserve the window before releasing the lock: two concurrent
+            # deliveries for the same session must not both pass the check
+            # and double-inject
+            self._last_wake[session_id] = now
 
         # tmux runs outside the lock (bounded at 5s, but other sessions'
         # deliveries shouldn't wait on it)
         if self._tmux_wake(session_id):
-            with self._lock:
-                self._last_wake[session_id] = time.monotonic()
             return "tmux"
+        with self._lock:
+            # Roll back the reservation so the failure doesn't burn the
+            # window - unless a later delivery already re-claimed it
+            if self._last_wake.get(session_id) == now:
+                if last is None:
+                    del self._last_wake[session_id]
+                else:
+                    self._last_wake[session_id] = last
         return "spool"
 
     def _spool(self, session_id: str, event: dict) -> None:
@@ -139,6 +164,11 @@ class Injector:
         self.config.wake_dir.mkdir(parents=True, exist_ok=True)
         self.config.wake_dir.chmod(0o700)
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
+        # Defense in depth behind resolve_target_session's charset check: a
+        # traversal or absolute component in a wire-supplied id must never
+        # produce a write outside the wake dir
+        if spool_file.resolve().parent != self.config.wake_dir.resolve():
+            raise ValueError(f"Spool path escapes wake dir: {session_id!r}")
         with spool_file.open("a") as f:
             f.write(json.dumps(event) + "\n")
 
@@ -167,7 +197,11 @@ class Injector:
             )
             logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
             return True
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        except (subprocess.SubprocessError, OSError) as e:
+            # SubprocessError covers CalledProcessError/TimeoutExpired;
+            # OSError covers a missing or non-executable tmux binary. An
+            # exception escaping here would 500 the webhook and make the bus
+            # retry an event that is already durably spooled (duplicate lines)
             logger.warning(f"tmux wake failed for {session_id[:8]}... ({e}); spooled only")
             return False
 
@@ -246,10 +280,11 @@ def register_with_bus(config: BridgeConfig) -> int | None:
         "register_webhook",
         {
             "url": hook_url,
-            # No server-side filter: payloads carry the derived signal_level,
-            # and the bridge filters to actionable locally. (Webhook filters
-            # only cover channel/event_types; "actionable" spans both DMs and
-            # specific broadcast types.)
+            # v1 acts only on session:<id> DMs, so let the bus drop broadcast
+            # traffic server-side (channel filters prefix-match). When v2
+            # widens to broadcast actionable events, remove this filter - the
+            # bridge still filters on signal_level locally either way.
+            "channel": "session:",
             **({"secret": config.secret} if config.secret else {}),
         },
         url=config.bus_url,
@@ -270,10 +305,34 @@ def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
         logger.warning(f"Could not unregister webhook #{webhook_id} (bus unreachable)")
 
 
-def main():
-    """Run the bridge daemon."""
-    import uvicorn
+def register_with_retry(
+    config: BridgeConfig,
+    state: dict,
+    stop: threading.Event,
+    initial_delay: float = 1.0,
+    max_delay: float = 30.0,
+) -> None:
+    """Keep trying to register until the bus is reachable (or stop is set).
 
+    The bridge and the bus are typically launched by the same supervisor, so
+    "bus not up yet" is the normal case at boot - call_tool's SystemExit on
+    connection errors must not kill the daemon. Runs in a background thread
+    started from the app's startup hook, so the listener binds (essentially)
+    first and webhook deliveries have a live port to hit.
+    """
+    delay = initial_delay
+    while not stop.is_set():
+        try:
+            state["webhook_id"] = register_with_bus(config)
+            return
+        except SystemExit:
+            logger.warning(f"Bus unreachable at {config.bus_url}; retrying in {delay:.0f}s")
+        if stop.wait(delay):
+            return
+        delay = min(delay * 2, max_delay)
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="agent-event-bus re-awakening bridge (RFC #122)")
     parser.add_argument(
         "--bus-url",
@@ -304,11 +363,12 @@ def main():
         default=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
         help="Directory for spool files and panes.json",
     )
-    args = parser.parse_args()
+    return parser
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
-    config = BridgeConfig(
+def config_from_args(args: argparse.Namespace) -> BridgeConfig:
+    """Build the runtime config from parsed args plus environment."""
+    return BridgeConfig(
         bus_url=args.bus_url,
         port=args.port,
         backend=args.backend,
@@ -321,14 +381,35 @@ def main():
         wake_dir=args.wake_dir,
     )
 
-    webhook_id = register_with_bus(config)
+
+def main():
+    """Run the bridge daemon."""
+    import uvicorn
+
+    args = build_parser().parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    config = config_from_args(args)
+
+    state: dict = {}
+    stop = threading.Event()
+    app = create_bridge_app(config)
+    # Register from a startup hook: uvicorn binds right after startup
+    # completes, so the thread's first attempt races the bind by microseconds
+    # at most (and the bus retries deliveries anyway)
+    app.add_event_handler(
+        "startup",
+        lambda: threading.Thread(
+            target=register_with_retry, args=(config, state, stop), daemon=True
+        ).start(),
+    )
     try:
         # Localhost only: the bus is the sole intended caller, and HMAC (when
         # a secret is set) authenticates it
-        uvicorn.run(create_bridge_app(config), host="127.0.0.1", port=config.port)
+        uvicorn.run(app, host="127.0.0.1", port=config.port)
     finally:
-        if webhook_id is not None:
-            unregister_from_bus(config, webhook_id)
+        stop.set()
+        if state.get("webhook_id") is not None:
+            unregister_from_bus(config, state["webhook_id"])
 
 
 if __name__ == "__main__":

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -433,17 +433,19 @@ def register_with_bus(config: BridgeConfig) -> int:
     hook_url = bridge_hook_url(config)
 
     existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
-    if isinstance(existing, list):
-        for wh in existing:
-            # Guard the element shape too: an AttributeError here would
-            # escape register_with_retry and kill the registration thread
-            if not isinstance(wh, dict):
-                continue
-            if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
-                call_tool(
-                    "unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url
-                )
-                logger.info(f"Removed stale bridge webhook #{wh['webhook_id']}")
+    if not isinstance(existing, list):
+        # Proceeding without the dedupe would stack the duplicate deliveries
+        # this sweep exists to prevent - retryable failure, like the no-id
+        # case below
+        raise SystemExit(f"list_webhooks returned unexpected result: {existing!r}")
+    for wh in existing:
+        # Guard the element shape too: an AttributeError here would
+        # escape register_with_retry and kill the registration thread
+        if not isinstance(wh, dict):
+            continue
+        if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
+            call_tool("unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url)
+            logger.info(f"Removed stale bridge webhook #{wh['webhook_id']}")
 
     result = call_tool(
         "register_webhook",

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -353,10 +353,15 @@ def create_bridge_app(
                 registration_stop.set()
                 # Off the event loop: a join that waits on an in-flight
                 # call_tool POST would otherwise freeze signal handling for
-                # up to the timeout (#112 invariant, shutdown edition)
-                await anyio.to_thread.run_sync(
-                    functools.partial(registration_thread.join, REGISTRATION_JOIN_TIMEOUT)
-                )
+                # up to the timeout (#112 invariant, shutdown edition).
+                # Shielded because run_sync is itself a cancellation
+                # checkpoint - and this finally exists precisely for the
+                # cancelled-shutdown path; unshielded, the join would be
+                # skipped exactly when it matters
+                with anyio.CancelScope(shield=True):
+                    await anyio.to_thread.run_sync(
+                        functools.partial(registration_thread.join, REGISTRATION_JOIN_TIMEOUT)
+                    )
 
     def process(body: bytes, signature: str | None) -> tuple[dict, int]:
         """Sync webhook handling (runs in a worker thread - the file appends
@@ -432,13 +437,20 @@ def create_bridge_app(
             payload["registered"] = registration_state.get("webhook_id") is not None
         return JSONResponse(payload)
 
-    return Starlette(
+    app = Starlette(
         routes=[
             Route("/hook", hook_endpoint, methods=["POST"]),
             Route("/health", health, methods=["GET"]),
         ],
         lifespan=lifespan,
     )
+    # POST /hook/ must be a loud 404 (bus retries and logs it), not a 307:
+    # the bus's httpx client doesn't follow redirects and counts any status
+    # under 400 as delivered, so the default slash-redirect would make a
+    # trailing-slash hook URL read as a perfectly healthy webhook while the
+    # bridge processes nothing.
+    app.router.redirect_slashes = False
+    return app
 
 
 def bridge_hook_url(config: BridgeConfig) -> str:
@@ -500,7 +512,22 @@ def register_with_bus(config: BridgeConfig) -> int:
         if not isinstance(wh, dict):
             continue
         if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
-            call_tool("unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url)
+            removal = call_tool(
+                "unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url
+            )
+            # unregister_webhook reports logical failure in-band (a
+            # success-False dict) rather than raising, and call_tool only
+            # raises on transport errors - proceeding after a failed removal
+            # would re-create the duplicate deliveries the sweep exists to
+            # prevent. Already-gone ("Webhook not found") is the goal state.
+            ok = isinstance(removal, dict) and (
+                removal.get("success") or removal.get("error") == "Webhook not found"
+            )
+            if not ok:
+                raise SystemExit(
+                    f"unregister_webhook #{wh['webhook_id']} returned "
+                    f"unexpected result: {removal!r}"
+                )
             logger.info(f"Removed stale bridge webhook #{wh['webhook_id']}")
 
     result = call_tool(

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -45,6 +45,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -78,9 +79,21 @@ logger = logging.getLogger("agent-event-bus-bridge")
 DEFAULT_BRIDGE_PORT = 8082
 DEFAULT_COOLDOWN_SECONDS = 30.0
 DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wake"
-# Fixed home for the hook-URL singleton lock, independent of --wake-dir (two
-# bridges with different wake dirs but the same hook URL must still contend).
-DEFAULT_LOCK_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "bridge-locks"
+# Home for the hook-URL singleton lock. MACHINE-scoped and uid-scoped, NOT
+# HOME-anchored: the webhook row it guards is global to the bus, so the lock
+# must contend for every process on this machine that could register the
+# same URL - a Path.home()-based path only contends within one HOME, so the
+# same uid under two HOMEs (a systemd unit vs a login shell) would both
+# acquire and both sweep. XDG_RUNTIME_DIR (per-user tmpfs) when set, else the
+# system temp dir; the uid-named subdir makes it HOME-independent and keeps a
+# shared /tmp safe (we own it, 0o700). Cross-USER on one loopback bus (a
+# different uid reaching the same bus, which the loopback-trusting auth
+# allows) stays out of scope for v1 - a different uid gets a different dir -
+# and is called out in the guide.
+DEFAULT_LOCK_DIR = (
+    Path(os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir())
+    / f"agent-event-bus-bridge-{os.getuid()}"
+)
 
 # tmux send-keys is bounded like the notifier subprocesses in helpers.py -
 # a hung tmux must not wedge the bridge. Sized under the bus's
@@ -1780,23 +1793,22 @@ def _acquire_singleton_locks(config: BridgeConfig) -> list[int]:
       leaving the running bridge listening, reporting registered:true, and
       deaf. This is keyed on the hook URL (not the wake dir) because that is
       what the sweep contends on: two instances with different --wake-dir
-      and the same port still collide. The lock lives in a FIXED dir
-      independent of --wake-dir, keyed by a hash of the URL and the uid (so
-      a different user's same-URL lock - which they couldn't open under
-      0o600 anyway - never blocks this one).
+      and the same port still collide. The lock lives in DEFAULT_LOCK_DIR
+      (machine + uid scoped, HOME-independent - see its definition).
     - WAKE DIR: two bridges sharing a wake dir would interleave spool and
       lock files regardless of their hook URLs.
 
-    Returns the held fds (both kept for the process's lifetime). CLI-only:
-    embedders own their process model. Each lock name carries a "." so it
-    can never collide with a <session_id>.lock spool file (the id charset
-    forbids ".")."""
+    Acquired SEQUENTIALLY with cleanup: if the second lock refuses, the
+    first is closed before the SystemExit propagates. Returned fds are kept
+    for the process's lifetime. CLI-only: embedders own their process model.
+    Each lock name carries a "." so it can never collide with a
+    <session_id>.lock spool file (the id charset forbids ".")."""
     hook = bridge_hook_url(config)
     digest = hashlib.sha256(hook.encode()).hexdigest()[:16]
-    hook_lock = DEFAULT_LOCK_DIR / f"hook.{os.getuid()}.{digest}.lock"
+    hook_lock = DEFAULT_LOCK_DIR / f"hook.{digest}.lock"
     wake_lock = config.wake_dir / "bridge.singleton.lock"
-    return [
-        _flock_or_exit(
+    specs = [
+        (
             hook_lock,
             f"Another agent-event-bus-bridge is already registered for hook URL "
             f"{hook} ({hook_lock} is locked). Refusing to start: a second instance "
@@ -1805,7 +1817,7 @@ def _acquire_singleton_locks(config: BridgeConfig) -> list[int]:
             "--port AND --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL (a different "
             "--wake-dir alone does NOT change the hook URL, so it would not help).",
         ),
-        _flock_or_exit(
+        (
             wake_lock,
             f"Another agent-event-bus-bridge is already running on wake dir "
             f"{config.wake_dir} ({wake_lock} is locked). Refusing to start: two "
@@ -1814,6 +1826,19 @@ def _acquire_singleton_locks(config: BridgeConfig) -> list[int]:
             "AGENT_EVENT_BUS_WAKE_DIR.",
         ),
     ]
+    fds: list[int] = []
+    for lock_path, message in specs:
+        try:
+            fds.append(_flock_or_exit(lock_path, message))
+        except SystemExit:
+            # Close what we already hold, so a partial acquisition (e.g. the
+            # wake lock refuses after the hook lock succeeded) does not leak
+            # an fd - in-process that would hold the lock forever and 421 a
+            # later legitimate start on that hook URL.
+            for fd in fds:
+                os.close(fd)
+            raise
+    return fds
 
 
 def main():

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -178,13 +178,14 @@ class BridgeConfigError(ValueError):
 
 
 class _UnserializablePayloadError(Exception):
-    """json.dumps hit the recursion limit encoding a pathologically nested
-    payload. Raised out of _spool BEFORE any file is created or lock taken,
-    so process() can map it to a named 400 with a STRUCTURAL guarantee that
-    nothing durable happened - rather than catching a bare RecursionError
-    around all of deliver(), which also runs the tmux steps AFTER the spool
-    line is committed (a 400 there would make the bus retry an event whose
-    line already landed, duplicating it)."""
+    """_spool's json.dumps could not produce a standard-JSON line - the
+    payload was nested past the recursion limit, or carried an inf/nan value
+    (json.dumps(allow_nan=False) rejects those). Raised BEFORE any file is
+    created or lock taken, so process() can map it to a named 400 with a
+    STRUCTURAL guarantee that nothing durable happened - rather than catching
+    a bare error around all of deliver(), which also runs the tmux steps
+    AFTER the spool line is committed (a 400 there would make the bus retry
+    an event whose line already landed, duplicating it)."""
 
 
 def _now() -> float:
@@ -284,6 +285,17 @@ class Injector:
 
     def __init__(self, config: BridgeConfig):
         self.config = config
+        # Resolve the wake dir ONCE: validate_config normalized it to an
+        # absolute path and nothing reassigns it, so its resolved target is
+        # fixed for this Injector's life. _spool's containment check runs on
+        # every delivery - including the many foreign-session DMs a
+        # machine-unscoped bus delivers here just to conclude "not ours" - so
+        # keeping this off the per-event path drops one readlink/lstat chain
+        # per event. (The FileNotFoundError self-heal recreates the dir BY
+        # NAME, matching this by-name identity; a wake dir whose path
+        # components are re-symlinked mid-run is compared against the cached
+        # target, which is strictly less exposure than the per-call resolve.)
+        self._wake_dir_resolved = config.wake_dir.resolve()
         self._lock = threading.Lock()
         self._last_wake: dict[str, float] = {}
         # Armed panes.json warning KEYS (not messages - a torn write varies
@@ -459,18 +471,31 @@ class Injector:
         # Defense in depth behind resolve_target_session's charset check: a
         # traversal or absolute component in a wire-supplied id must never
         # produce a write outside the wake dir
-        if spool_file.resolve().parent != self.config.wake_dir.resolve():
+        if spool_file.resolve().parent != self._wake_dir_resolved:
             raise ValueError(f"Spool path escapes wake dir: {session_id!r}")
-        # Serialize BEFORE the lock/open: json.dumps can raise RecursionError
-        # on a payload nested just under the parse limit (loads and dumps
-        # spend their recursion budgets independently, and this call sits a
-        # few frames deeper than the loads that admitted the body), and a
-        # failure must create no file and take no lock. Re-raised as a
-        # dedicated type so process() maps ONLY the pre-durable failure to a
-        # 400 - never a post-spool error from deliver's later tmux steps.
+        # Serialize BEFORE the lock/open: a failure must create no file and
+        # take no lock. Two non-standard-JSON producers are rejected here, so
+        # the "every spooled line is standard JSON" invariant holds by
+        # construction (not by the bus's good behavior):
+        #  - allow_nan=False: an overflowing numeric literal (payload: 1e400)
+        #    parses through json.loads' parse_float=float, which returns inf
+        #    WITHOUT raising - so process()'s parse_constant never sees it -
+        #    and default json.dumps would write it back as bare Infinity, a
+        #    line jq / JSON.parse / Go's encoding/json all reject (the drain
+        #    hook then skips it and the wake is silently lost). allow_nan=False
+        #    raises ValueError on inf/nan here instead. (parse_constant still
+        #    rejects the bare NaN/Infinity TOKENS earlier, for events that
+        #    never reach the spool too.)
+        #  - RecursionError: a payload nested just under the parse limit
+        #    (loads and dumps spend their recursion budgets independently, and
+        #    this call sits a few frames deeper than the loads that admitted
+        #    the body).
+        # Both re-raise as the dedicated type so process() maps ONLY this
+        # pre-durable failure to a 400 - never a post-spool error from
+        # deliver's later tmux steps.
         try:
-            line = json.dumps(event) + "\n"
-        except RecursionError as e:
+            line = json.dumps(event, allow_nan=False) + "\n"
+        except (RecursionError, ValueError) as e:
             raise _UnserializablePayloadError from e
         # flock a sibling lock file around the append: flock contends per
         # open file description, so it serializes writers in this process and
@@ -570,14 +595,26 @@ class Injector:
         """
         panes_file = self.config.wake_dir / "panes.json"
         try:
-            # encoding="utf-8" explicitly, NOT the locale codec read_text()
-            # defaults to: a supervisor hands the daemon no LC_ALL/LANG,
-            # glibc resolves the C locale, and the default codec becomes
-            # ASCII - a healthy panes.json with any byte >0x7f would then
-            # raise UnicodeDecodeError and wrongly route into the
-            # unparseable arm, leaving every session on the box permanently
-            # spool-unmapped. The writer contract (guide) says UTF-8.
-            panes = json.loads(panes_file.read_text(encoding="utf-8"))
+            # os.open with O_NOFOLLOW + O_NONBLOCK, not read_text():
+            #  - O_NOFOLLOW: panes.json shares the wake dir's history (may have
+            #    been group/world-writable before the daemon narrowed it to
+            #    0o700), so a symlink planted at the name must not be followed -
+            #    the same guard _open_append_0600 carries for the spool/lock
+            #    files. ELOOP is an OSError, landing on the unreadable arm.
+            #  - O_NONBLOCK: a planted FIFO would otherwise block a threadpool
+            #    worker forever inside a deliver() that already committed its
+            #    spool line - each tmux-backend delivery parks one and /hook
+            #    starves once they are all consumed. This path has no
+            #    TMUX_TIMEOUT/deadline of its own. On a FIFO the read returns
+            #    EOF (empty -> unparseable) or EAGAIN (OSError -> unreadable);
+            #    on a regular file O_NONBLOCK is a no-op.
+            #  - encoding="utf-8", NOT the locale codec: a supervisor hands the
+            #    daemon no LC_ALL/LANG, glibc resolves C -> ASCII, and a
+            #    healthy file with any byte >0x7f would wrongly hit the
+            #    unparseable arm. The writer contract (guide) says UTF-8.
+            fd = os.open(panes_file, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+            with os.fdopen(fd, encoding="utf-8") as f:
+                panes = json.loads(f.read())
         except FileNotFoundError:
             # A missing file IS this session's absent read: clear the
             # file-level keys AND this session's entry key, matching the
@@ -913,15 +950,15 @@ def create_bridge_app(
             return {"error": "bad signature"}, 401
 
         try:
-            # parse_constant rejects the non-standard NaN/Infinity/-Infinity
-            # literals json.loads accepts by DEFAULT: json.dumps would write
-            # them straight back into a spool line no other parser accepts
-            # (jq, JSON.parse, Go's encoding/json all reject them), so a
-            # contract-following drainer skips the line under its
-            # skip-unparseable rule and the wake is silently lost while the
-            # bus counted it delivered. The rejector's ValueError folds into
-            # the named-400 arm, making "everything appended is standard
-            # JSON" true by construction, not by the bus's good behavior.
+            # parse_constant rejects the bare NaN/Infinity/-Infinity TOKENS
+            # json.loads accepts by DEFAULT, early and for every event
+            # (including ones that never reach the spool). It is NOT the whole
+            # guard: an overflowing number (1e400) reaches parse_float=float,
+            # which returns inf without raising, so it slips past here - that
+            # producer is caught at the write side by _spool's
+            # allow_nan=False, which is where the standard-JSON invariant
+            # actually holds. The rejector's ValueError folds into the
+            # named-400 arm below.
             event = json.loads(body, parse_constant=_reject_json_constant)
         # ValueError, not just JSONDecodeError: json.loads(bytes) DECODES
         # before parsing, and invalid UTF-8 raises UnicodeDecodeError (a
@@ -1081,10 +1118,20 @@ def create_bridge_app(
 
 def _host_from_header(raw_host: str) -> str:
     """Strip the port from a Host header value, handling bracketed IPv6
-    ("[::1]:8082" -> "::1"). Lowercased for comparison."""
+    ("[::1]:8082" -> "::1"), and normalize an IP literal to its canonical
+    form. Normalizing HERE (both the incoming Host and the allowlist entries
+    go through the same canonicalization) collapses every wire spelling of
+    an IPv6 address - compressed, expanded, upper/lower - onto one key, so
+    the guard does not depend on which spelling the bus's httpx client
+    happens to render the Host as. A hostname passes through lowercased."""
     if raw_host.startswith("["):  # bracketed IPv6, with or without a port
-        return raw_host.split("]", 1)[0].lstrip("[").lower()
-    return raw_host.rsplit(":", 1)[0].lower()
+        host = raw_host.split("]", 1)[0].lstrip("[").lower()
+    else:
+        host = raw_host.rsplit(":", 1)[0].lower()
+    try:
+        return str(ipaddress.ip_address(host))
+    except ValueError:
+        return host  # a hostname (or garbage) - compare verbatim
 
 
 class _HostAllowlistMiddleware:
@@ -1833,7 +1880,12 @@ def _flock_or_exit(lock_path: Path, conflict_message: str) -> int:
     wake dir is Injector's). A failed open becomes a named SystemExit rather
     than the bare traceback every other failure here avoids (e.g. EACCES on
     a foreign lock file, ELOOP on a symlinked one)."""
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # mode=0o700, matching _ensure_private_lock_dir's create mode: normally a
+    # no-op (both callers reach here with the parent present), but if the
+    # hook-lock dir vanished between the verify and this call, a default-mode
+    # re-create (0o777 & ~umask) would make the NEXT start's verify refuse
+    # our own dir as group/world-accessible.
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:
         fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
     except OSError as e:

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -70,7 +70,7 @@ from agent_event_bus.cli import DEFAULT_URL, call_tool
 # server.py opens/migrates the bus database and attaches its log handler at
 # import time, none of which this pure HTTP client of the bus may trigger
 # (see test_bridge_import_does_not_pull_in_the_bus_server).
-from agent_event_bus.helpers import SIGNATURE_HEADER
+from agent_event_bus.helpers import SIGNATURE_HEADER, WEBHOOK_CONTENT_TYPE
 
 logger = logging.getLogger("agent-event-bus-bridge")
 
@@ -482,10 +482,14 @@ class Injector:
             self._disarm_file_keys()
             self._warned_panes_keys.discard(f"bad-pane-value:{session_id}")
             return None
-        except ValueError as e:
+        except (ValueError, RecursionError) as e:
             # Parse failures (JSONDecodeError, UnicodeDecodeError from a
             # torn write) - typically transient, self-healing on the
-            # writer's next write. Separate reason from the OSError arm: a
+            # writer's next write. RecursionError is the non-ValueError
+            # sibling, same as process()'s json.loads arm: deep nesting
+            # blows the interpreter limit before any JSONDecodeError
+            # exists, and an escape here 500s a delivery whose spool line
+            # is already committed. Separate reason from the OSError arm: a
             # torn write escalating into a permanently unreadable file must
             # WARN again, not be demoted as a repeat of the same condition.
             self._warn_panes_once(
@@ -661,6 +665,15 @@ def create_bridge_app(
     # exposed-listener secret requirement) must hold on this path too
     validate_config(config)
     injector = Injector(config)
+    # The /hook Host allowlist (see hook_endpoint): loopback literals plus
+    # the hook URL's hostname - exactly the names a legitimate caller can
+    # arrive under (the bus fills Host from the URL it was told to POST to;
+    # local tools use a loopback literal). urlsplit().hostname already
+    # lowercases and strips IPv6 brackets.
+    hook_host = urllib.parse.urlsplit(bridge_hook_url(config)).hostname
+    allowed_hook_hosts = {"127.0.0.1", "localhost", "::1"}
+    if hook_host:
+        allowed_hook_hosts.add(hook_host)
     registration_thread: threading.Thread | None = None
     # Version-skew line bound (a closure cell: the arm lives in process(),
     # not on the injector). The condition - a bus predating derived levels -
@@ -781,22 +794,42 @@ def create_bridge_app(
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
     async def hook_endpoint(request: Request) -> JSONResponse:
-        # The check that keeps the loopback-needs-no-secret posture true
-        # against BROWSERS: fetch(mode:"no-cors") from any web page the
-        # operator has open can POST to 127.0.0.1 as long as its
-        # Content-Type stays CORS-safelisted (a string body defaults to
-        # text/plain) - no preflight is sent, the opaque response doesn't
-        # matter, the write would already have happened: attacker-authored
-        # spool lines from a background tab. Requiring the bus's actual
-        # media type forces a preflight the bridge never answers, so the
-        # browser never sends the POST at all; the bus (httpx,
-        # "Content-Type: application/json") is unaffected. Parameters are
-        # tolerated ("application/json; charset=utf-8") - the guard is
+        # Host allowlist - the half of the browser guard the Content-Type
+        # check below cannot carry: DNS rebinding makes the attacker page
+        # SAME-origin (served from evil.example:<our port>, then the A
+        # record flips to 127.0.0.1), and a same-origin POST is outside
+        # CORS entirely - no preflight, arbitrary headers, the JSON media
+        # type sent verbatim. What rebinding cannot forge is the Host
+        # header: the browser fills it from the page's URL, so a rebound
+        # request necessarily carries the attacker's hostname - never a
+        # loopback literal, never the hook URL host the bus was told to
+        # POST to. Hand-rolled rather than TrustedHostMiddleware: its
+        # host.split(":")[0] mangles bracketed IPv6 ("[::1]:8082" -> "["),
+        # and --bind ::1 is a supported shape. 421 Misdirected Request.
+        raw_host = request.headers.get("host", "")
+        if raw_host.startswith("["):  # bracketed IPv6, with or without port
+            host = raw_host.split("]", 1)[0].lstrip("[").lower()
+        else:
+            host = raw_host.rsplit(":", 1)[0].lower()
+        if host not in allowed_hook_hosts:
+            return JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
+        # The other half, for CROSS-origin pages: fetch(mode:"no-cors")
+        # from any web page the operator has open can POST to 127.0.0.1 as
+        # long as its Content-Type stays CORS-safelisted (a string body
+        # defaults to text/plain) - no preflight is sent, the opaque
+        # response doesn't matter, the write would already have happened:
+        # attacker-authored spool lines from a background tab. Requiring
+        # the bus's actual media type (single-sourced in helpers.py)
+        # forces a preflight the bridge never answers, so the browser
+        # never sends the POST at all; the bus is unaffected. Parameters
+        # are tolerated ("application/json; charset=utf-8") - the guard is
         # about which media types a browser can send preflight-free, not
         # about strictness for its own sake.
         content_type = request.headers.get("content-type", "")
-        if content_type.split(";", 1)[0].strip().lower() != "application/json":
-            return JSONResponse({"error": "Content-Type must be application/json"}, status_code=415)
+        if content_type.split(";", 1)[0].strip().lower() != WEBHOOK_CONTENT_TYPE:
+            return JSONResponse(
+                {"error": f"Content-Type must be {WEBHOOK_CONTENT_TYPE}"}, status_code=415
+            )
         # Precheck the honest case cheaply; the streamed count below covers
         # a missing or lying content-length (e.g. chunked encoding)
         content_length = request.headers.get("content-length")

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -109,11 +109,6 @@ MAX_BODY_BYTES = 1_048_576  # 1 MiB
 SPOOL_LOCK_ATTEMPTS = 20
 SPOOL_LOCK_RETRY_SECONDS = 0.1
 
-# Must stay a fixed multi-word constant: the send-keys call passes it as
-# one argument WITHOUT -l, so tmux would interpret a value matching a key
-# name (Enter, C-c, Escape) as a keystroke instead of typing it. If this
-# ever becomes configurable or carries payload text, switch the call to
-# `send-keys -l` for the text plus a separate `send-keys Enter`.
 # Cap on the warn-once key sets (wake failures and panes conditions): a
 # session that ends while broken never sheds its key - only a later
 # delivery for that same session can - so on a weeks-long daemon the sets
@@ -121,6 +116,11 @@ SPOOL_LOCK_RETRY_SECONDS = 0.1
 # clearing costs one repeat warning per still-live condition.
 _WARN_KEYS_CAP = 256
 
+# Must stay a fixed multi-word constant: the send-keys call passes it as
+# one argument WITHOUT -l, so tmux would interpret a value matching a key
+# name (Enter, C-c, Escape) as a keystroke instead of typing it. If this
+# ever becomes configurable or carries payload text, switch the call to
+# `send-keys -l` for the text plus a separate `send-keys Enter`.
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
 
@@ -274,9 +274,10 @@ class Injector:
         "spool" (spool backend working as designed), "spool-cooldown",
         "spool-unmapped" (tmux backend, no usable pane mapping - normally
         because the session lives on another machine, since webhooks have
-        no machine scoping, but also when panes.json is missing, unreadable,
-        malformed, or its entry is not a pane id; the misconfiguration
-        shapes warn, so check the log), or "spool-tmux-failed" (tmux backend, the send-keys
+        no machine scoping, but also when panes.json is missing,
+        unreadable, malformed, or its entry is not a pane id; the
+        misconfiguration shapes warn, so check the log), or
+        "spool-tmux-failed" (tmux backend, the send-keys
         attempt itself failed - the arm that means tmux on this box is
         broken). The action value is in-band for a direct caller of /hook
         only - the bus discards the response body - so operator-facing
@@ -488,10 +489,17 @@ class Injector:
             self._warned_panes_keys.discard(entry_key)
             return None
         pane = panes[session_id]
-        if not (isinstance(pane, str) and pane):
-            # Present but wrong-typed (0 instead of "%0", "", null): a
+        if not (isinstance(pane, str) and pane and pane.isprintable()):
+            # Present but wrong-shaped (0 instead of "%0", "", null, or a
+            # control character - JSON encodes NUL as \u0000): a
             # misconfiguration whose repair is nothing like "the mapping is
             # absent", so it must not fold into the unmapped debug line.
+            # isprintable() is load-bearing, not cosmetic: an argv element
+            # with an embedded NUL makes subprocess.run raise ValueError
+            # BEFORE check or timeout - a class _tmux_wake's post-spool arms
+            # don't catch - so it must be rejected here, where the warning
+            # names the entry to repair, and never reach argv. Real pane ids
+            # ("%0", "%12") are printable ASCII throughout.
             # Keyed per session: the condition is per entry, unlike the
             # file-level failures above.
             self._warn_panes_once(

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -66,8 +66,11 @@ from agent_event_bus.cli import DEFAULT_URL, call_tool
 
 # The header name is a wire contract with the bus - import it rather than
 # re-spelling it, the same coupling discipline as the tests building their
-# signatures from the bus's _compute_signature
-from agent_event_bus.server import SIGNATURE_HEADER
+# signatures from the bus's _compute_signature. From helpers, NOT server:
+# server.py opens/migrates the bus database and attaches its log handler at
+# import time, none of which this pure HTTP client of the bus may trigger
+# (see test_bridge_import_does_not_pull_in_the_bus_server).
+from agent_event_bus.helpers import SIGNATURE_HEADER
 
 logger = logging.getLogger("agent-event-bus-bridge")
 
@@ -128,6 +131,14 @@ class BridgeConfig:
     hook_url: str | None = None
     # Interface to bind; None derives it from the hook URL (see bind_host)
     bind: str | None = None
+
+
+class BridgeConfigError(ValueError):
+    """An invalid BridgeConfig. A ValueError subclass so EMBEDDERS can catch
+    it with a normal `except Exception` around app assembly - SystemExit is
+    a BaseException and would tear through that. config_from_args translates
+    it into SystemExit for the CLI path, which keeps main() printing the
+    message and exiting without a traceback."""
 
 
 def _now() -> float:
@@ -282,7 +293,7 @@ class Injector:
             # this would emit one INFO per foreign-machine DM - the exact
             # volume the unmapped arm's debug demotion exists to avoid - and
             # a mapped wake already logs "Woke ..." at INFO.
-            logger.info(f"Spooled event {event.get('event_id')} for {session_id[:8]}...")
+            logger.info(f"Spooled event {event.get('event_id')!r} for {session_id[:8]}...")
             return "spool"
 
         # Pane lookup BEFORE the cooldown machinery: on a multi-machine bus
@@ -360,21 +371,26 @@ class Injector:
         # rename could slip between our open and our flush and the line would
         # land in a file the drainer already read (and will delete)
         lock_file = self.config.wake_dir / f"{session_id}.lock"
+        # ONE deadline shared across the self-heal retry below: a per-call
+        # attempt counter would let contended-then-vanished-dir double the
+        # worst case past the sum-under-WEBHOOK_TIMEOUT invariant that
+        # TestBusTimingContract pins on the constants
+        deadline = _now() + SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS
 
         def _append() -> None:
             with lock_file.open("a") as lock_fd:
-                for _ in range(SPOOL_LOCK_ATTEMPTS):
+                while True:
                     try:
                         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         break
                     except BlockingIOError:
+                        if _now() >= deadline:
+                            raise OSError(
+                                f"Could not lock spool for {session_id} within "
+                                f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
+                                "(stuck drainer?)"
+                            ) from None
                         time.sleep(SPOOL_LOCK_RETRY_SECONDS)
-                else:
-                    raise OSError(
-                        f"Could not lock spool for {session_id} within "
-                        f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
-                        "(stuck drainer?)"
-                    )
                 try:
                     with spool_file.open("a") as f:
                         f.write(json.dumps(event) + "\n")
@@ -511,10 +527,15 @@ class Injector:
             logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
             # A working wake re-arms THIS session's failure conditions only -
             # clearing globally would oscillate a broken session's warning
-            # under interleaved healthy deliveries (the round-38 shape)
-            self._warned_wake_fail_keys = {
-                k for k in self._warned_wake_fail_keys if not k.startswith(f"{session_id}:")
-            }
+            # under interleaved healthy deliveries (the round-38 shape).
+            # Under the lock: the comprehension iterates the set, and a
+            # concurrent delivery's add would otherwise raise RuntimeError
+            # out of the one method whose exceptions must never 500 the
+            # webhook. The tmux subprocess stays outside the lock.
+            with self._lock:
+                self._warned_wake_fail_keys = {
+                    k for k in self._warned_wake_fail_keys if not k.startswith(f"{session_id}:")
+                }
             return True
         except (subprocess.SubprocessError, OSError) as e:
             # SubprocessError covers CalledProcessError/TimeoutExpired;
@@ -527,11 +548,16 @@ class Injector:
             # second broken session is never silenced by the first's key.
             key = f"{session_id}:{type(e).__name__}"
             message = f"tmux wake failed for {session_id[:8]}... ({e}); spooled only"
-            if key in self._warned_wake_fail_keys:
-                logger.debug(message)
-            else:
-                self._warned_wake_fail_keys.add(key)
+            # Same lock as the success-arm comprehension: an unsynchronized
+            # add would race its iteration. Logging stays outside the hold.
+            with self._lock:
+                first_sighting = key not in self._warned_wake_fail_keys
+                if first_sighting:
+                    self._warned_wake_fail_keys.add(key)
+            if first_sighting:
                 logger.warning(message)
+            else:
+                logger.debug(message)
             return False
 
 
@@ -567,6 +593,12 @@ def create_bridge_app(
     validate_config(config)
     injector = Injector(config)
     registration_thread: threading.Thread | None = None
+    # Version-skew line bound (a closure cell: the arm lives in process(),
+    # not on the injector). The condition - a bus predating derived levels -
+    # is persistent and per-deployment, so it gets the same first-sighting
+    # treatment as every other stuck-condition line; re-armed by the first
+    # delivery that DOES carry a level, which is what an upgraded bus sends.
+    skew_state = {"warned": False}
 
     @asynccontextmanager
     async def lifespan(app):
@@ -643,23 +675,32 @@ def create_bridge_app(
         # The bus always sends the derived signal_level; only actionable
         # events (DMs, help_needed, blockers, CI failures) justify a wake
         level = event.get("signal_level")
+        if level is not None:
+            skew_state["warned"] = False  # the bus sends levels - re-arm the skew line
         if level != "actionable":
             if level is None:
                 # A bus predating derived levels (#129) sends none at all -
                 # every delivery would land here forever, so make the
-                # version skew visible instead of filtering silently
-                logger.info(
-                    f"Event {event.get('event_id')} carries no signal_level "
+                # version skew visible instead of filtering silently -
+                # bounded: INFO on the first sighting, debug repeats (the
+                # volume is the DM rate against a persistent condition)
+                message = (
+                    f"Event {event.get('event_id')!r} carries no signal_level "
                     "(bus predates derived levels?); filtering it"
                 )
+                if skew_state["warned"]:
+                    logger.debug(message)
+                else:
+                    skew_state["warned"] = True
+                    logger.info(message)
             else:
-                logger.debug(f"Ignoring event {event.get('event_id')}: level {level!r}")
+                logger.debug(f"Ignoring event {event.get('event_id')!r}: level {level!r}")
             return {"status": "ignored", "reason": "below actionable"}, 200
 
         target = resolve_target_session(event)
         if target is None:
             logger.debug(
-                f"Ignoring event {event.get('event_id')}: "
+                f"Ignoring event {event.get('event_id')!r}: "
                 f"channel {event.get('channel')!r} has no target session"
             )
             return {"status": "ignored", "reason": "no target session"}, 200
@@ -923,7 +964,7 @@ def _to_number(value, cast, flag: str, env: str):
     try:
         return cast(value)
     except (TypeError, ValueError):
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Invalid value {value!r} (check {flag} / {env}): expected a number"
         ) from None
 
@@ -986,16 +1027,28 @@ def validate_config(config: BridgeConfig) -> None:
     calls it again for embedders (uvicorn --factory, an ASGI mount) that
     build a BridgeConfig by hand and never pass through argparse - the
     security posture (an exposed listener requires the HMAC secret) must
-    travel with the config, not with the entry point. Error messages name
-    flags and env vars because the CLI is the common path; the invariants
-    themselves are runtime ones. The advisory topology WARNINGS stay in
+    travel with the config, not with the entry point. Raises BridgeConfigError (a
+    ValueError - embedder-catchable, unlike SystemExit); config_from_args
+    translates it for the CLI. Error messages name flags and env vars
+    because the CLI is the common path; the invariants are runtime ones. The advisory topology WARNINGS stay in
     config_from_args - they are startup diagnostics, not invariants.
     """
+    # Normalize BEFORE checking: the CLI hands strings through argparse
+    # defaults, and a hand-built config may carry raw env values - a wrong
+    # type must become the named config error these checks exist to give,
+    # not a bare TypeError out of a comparison or an AttributeError off a
+    # str that was annotated Path
+    config.port = _to_number(config.port, int, "--port", "AGENT_EVENT_BUS_BRIDGE_PORT")
+    config.cooldown_seconds = _to_number(
+        config.cooldown_seconds, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
+    )
+    config.wake_dir = Path(config.wake_dir)
+
     # argparse `choices` only guards command-line values, and an embedder
     # skips argparse entirely - an unknown backend would silently mean
     # "spool" (deliver only tests != "tmux")
     if config.backend not in ("spool", "tmux"):
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Invalid backend {config.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
             "expected 'spool' or 'tmux'"
         )
@@ -1003,14 +1056,14 @@ def validate_config(config: BridgeConfig) -> None:
     # uvicorn traceback naming neither, and a negative cooldown would
     # silently disable the cooldown (now - ts < -5 is never true)
     if not (1 <= config.port <= 65535):
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Invalid port {config.port} (check --port / AGENT_EVENT_BUS_BRIDGE_PORT): "
             "expected 1-65535"
         )
     # isfinite too: nan makes every prune comparison False (cooldown never
     # engages), inf makes it always True (one wake ever, then silence)
     if not math.isfinite(config.cooldown_seconds) or config.cooldown_seconds < 0:
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Invalid cooldown {config.cooldown_seconds} "
             "(check --cooldown / AGENT_EVENT_BUS_BRIDGE_COOLDOWN): "
             "must be finite and >= 0"
@@ -1018,7 +1071,7 @@ def validate_config(config: BridgeConfig) -> None:
     # A daemon's cwd is whatever its supervisor hands it - a relative wake
     # dir would silently relocate the durable path (and its chmod)
     if not config.wake_dir.is_absolute():
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Invalid wake dir {config.wake_dir} "
             "(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): must be an absolute path"
         )
@@ -1032,9 +1085,11 @@ def validate_config(config: BridgeConfig) -> None:
     try:
         parsed_bus = urllib.parse.urlsplit(config.bus_url)
     except ValueError as e:
-        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: {e}") from None
+        raise BridgeConfigError(f"Invalid bus URL {config.bus_url!r}: {e}") from None
     if parsed_bus.scheme not in ("http", "https") or not parsed_bus.hostname:
-        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http(s)://host[:port]/path")
+        raise BridgeConfigError(
+            f"Invalid bus URL {config.bus_url!r}: expected http(s)://host[:port]/path"
+        )
     # Same check for the hook URL - it is what BOTH topology guards below
     # read: a scheme-less value parses to hostname None, reads as loopback,
     # skips the guards, and registers a URL the bus can never POST to
@@ -1042,14 +1097,14 @@ def validate_config(config: BridgeConfig) -> None:
         try:
             parsed_hook = urllib.parse.urlsplit(config.hook_url)
         except ValueError as e:
-            raise SystemExit(
+            raise BridgeConfigError(
                 f"Invalid hook URL {config.hook_url!r} "
                 f"(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): {e}"
             ) from None
         # Require a hostname too: "http:///hook" parses to hostname None,
         # which reads as loopback and would skip every topology guard
         if parsed_hook.scheme not in ("http", "https") or not parsed_hook.hostname:
-            raise SystemExit(
+            raise BridgeConfigError(
                 f"Invalid hook URL {config.hook_url!r} "
                 "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): "
                 "expected http(s)://host[:port]/path"
@@ -1061,7 +1116,7 @@ def validate_config(config: BridgeConfig) -> None:
     # startup dedupe could remove a live webhook belonging to the bus host.
     # Refuse the combination instead of failing silently.
     if not _is_loopback(config.bus_url) and _is_loopback(hook):
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Bus at {config.bus_url} is remote but the advertised hook URL "
             f"{hook} is loopback - the bus would POST to itself. "
             "Set --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL to an address the bus "
@@ -1077,7 +1132,7 @@ def validate_config(config: BridgeConfig) -> None:
             ipaddress.ip_address(config.bind)
         except ValueError:
             if config.bind not in LOOPBACK_HOSTS:
-                raise SystemExit(
+                raise BridgeConfigError(
                     f"Invalid bind address {config.bind!r} "
                     "(check --bind / AGENT_EVENT_BUS_BRIDGE_BIND): expected an IP address"
                 ) from None
@@ -1092,7 +1147,7 @@ def validate_config(config: BridgeConfig) -> None:
     # and the bridge must not invert that.
     exposed = not _is_host_loopback(bind) or not _is_loopback(hook)
     if exposed and not config.secret:
-        raise SystemExit(
+        raise BridgeConfigError(
             f"Listener would bind {bind} with hook URL "
             f"{hook} - reachable off-box, so set "
             "AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
@@ -1105,21 +1160,24 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     """Build the runtime config from parsed args plus environment."""
     config = BridgeConfig(
         bus_url=args.bus_url,
-        port=_to_number(args.port, int, "--port", "AGENT_EVENT_BUS_BRIDGE_PORT"),
+        port=args.port,  # raw; validate_config coerces and range-checks
         backend=args.backend,
         # `or None`: an accidentally empty env var must not put registration
         # (which would skip the secret, so unsigned payloads) and verification
         # (which would demand signatures) on opposite sides - that 401s every
         # delivery silently
         secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
-        cooldown_seconds=_to_number(
-            args.cooldown, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
-        ),
+        cooldown_seconds=args.cooldown,  # raw; validate_config coerces
         wake_dir=args.wake_dir,
         hook_url=args.hook_url,
         bind=args.bind,
     )
-    validate_config(config)
+    # Translate the embedder-catchable error into the CLI's exit shape -
+    # main() prints the message and exits without a traceback
+    try:
+        validate_config(config)
+    except BridgeConfigError as e:
+        raise SystemExit(str(e)) from None
     # Preflight the binary (CLI path only - embedders manage their own
     # runtime env): a tmux backend on a box without tmux would degrade
     # every wake to spool-tmux-failed for the daemon's lifetime - one

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -119,6 +119,12 @@ class Injector:
         self.config = config
         self._lock = threading.Lock()
         self._last_wake: dict[str, float] = {}
+        # Once at construction, not per delivery: keeps the lock hold to the
+        # append itself, and a deliberate later permission change by the
+        # operator isn't silently reverted on the next event. The dir is
+        # private (0o700) - spool files carry full event payloads.
+        self.config.wake_dir.mkdir(parents=True, exist_ok=True)
+        self.config.wake_dir.chmod(0o700)
 
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken:
@@ -138,8 +144,15 @@ class Injector:
                 return "spool"
 
             now = time.monotonic()
+            # Housekeeping: entries past the cooldown can never gate a wake
+            # again, and sessions are ephemeral - don't retain them forever
+            self._last_wake = {
+                sid: ts
+                for sid, ts in self._last_wake.items()
+                if (now - ts) < self.config.cooldown_seconds
+            }
             last = self._last_wake.get(session_id)
-            if last is not None and (now - last) < self.config.cooldown_seconds:
+            if last is not None:
                 return "spool-cooldown"
             # Reserve the window before releasing the lock: two concurrent
             # deliveries for the same session must not both pass the check
@@ -163,11 +176,8 @@ class Injector:
     def _spool(self, session_id: str, event: dict) -> None:
         """Always-on durable path: one JSON line per event, per session.
 
-        Callers must hold self._lock. The wake dir is kept private (0o700):
-        spool files carry full event payloads.
+        Callers must hold self._lock.
         """
-        self.config.wake_dir.mkdir(parents=True, exist_ok=True)
-        self.config.wake_dir.chmod(0o700)
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
         # Defense in depth behind resolve_target_session's charset check: a
         # traversal or absolute component in a wire-supplied id must never
@@ -178,11 +188,24 @@ class Injector:
             f.write(json.dumps(event) + "\n")
 
     def _tmux_pane(self, session_id: str) -> str | None:
-        """Look up the session's tmux pane from <wake_dir>/panes.json."""
+        """Look up the session's tmux pane from <wake_dir>/panes.json.
+
+        The mapping is maintained by an external session-side component, so
+        every failure shape - unreadable file, non-UTF-8 bytes from a torn
+        write, valid JSON that isn't an object - must degrade to "unmapped":
+        an exception escaping here would 500 the webhook and make the bus
+        retry an already-spooled event.
+        """
         panes_file = self.config.wake_dir / "panes.json"
         try:
             panes = json.loads(panes_file.read_text())
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError:
+            return None
+        except (OSError, ValueError) as e:
+            logger.warning(f"Unreadable panes.json ({e}); treating as unmapped")
+            return None
+        if not isinstance(panes, dict):
+            logger.warning("panes.json is not an object; treating as unmapped")
             return None
         pane = panes.get(session_id)
         return pane if isinstance(pane, str) and pane else None
@@ -292,8 +315,9 @@ def bridge_hook_url(config: BridgeConfig) -> str:
     return f"http://127.0.0.1:{config.port}/hook"
 
 
-def register_with_bus(config: BridgeConfig) -> int | None:
-    """Register this bridge's webhook on the bus. Returns webhook_id.
+def register_with_bus(config: BridgeConfig) -> int:
+    """Register this bridge's webhook on the bus. Returns webhook_id;
+    raises SystemExit on any failure (bus unreachable, or no id returned).
 
     Idempotent: an unclean exit (SIGKILL, crash, reboot) skips main()'s
     finally, leaving a stale active webhook at this URL - and the bus neither
@@ -324,9 +348,12 @@ def register_with_bus(config: BridgeConfig) -> int | None:
         },
         url=config.bus_url,
     )
-    webhook_id = result.get("webhook_id")
-    if webhook_id is not None:
-        logger.info(f"Registered bridge webhook #{webhook_id} on {config.bus_url}")
+    webhook_id = result.get("webhook_id") if isinstance(result, dict) else None
+    if webhook_id is None:
+        # A bus that answers but returns no id must be a retryable failure,
+        # not silent success - register_with_retry treats SystemExit as retry
+        raise SystemExit(f"register_webhook returned no webhook_id: {result!r}")
+    logger.info(f"Registered bridge webhook #{webhook_id} on {config.bus_url}")
     return webhook_id
 
 
@@ -360,8 +387,10 @@ def register_with_retry(
         try:
             state["webhook_id"] = register_with_bus(config)
             return
-        except SystemExit:
-            logger.warning(f"Bus unreachable at {config.bus_url}; retrying in {delay:.0f}s")
+        except SystemExit as e:
+            logger.warning(
+                f"Registration on {config.bus_url} failed ({e}); retrying in {delay:.0f}s"
+            )
         if stop.wait(delay):
             return
         delay = min(delay * 2, max_delay)

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -299,7 +299,11 @@ class Injector:
         """Type the wake prompt into the session's pane. False on any miss."""
         pane = self._tmux_pane(session_id)
         if pane is None:
-            logger.info(f"No tmux pane mapping for {session_id[:8]}...; spooled only")
+            # Debug, not info: webhooks have no machine scoping, so every DM
+            # aimed at a session on another machine lands here - per-event
+            # INFO would be permanent noise. Matches the below-actionable
+            # filter arm and _tmux_pane's silent missing-file case.
+            logger.debug(f"No tmux pane mapping for {session_id[:8]}...; spooled only")
             return False
         try:
             subprocess.run(

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -46,8 +46,12 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import anyio
+# Explicit submodule import: `import anyio` alone doesn't bind to_thread -
+# it currently resolves only through starlette's own imports. Matches
+# server.py and middleware.py.
+import anyio.to_thread
 from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -414,8 +418,6 @@ def create_bridge_app(
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
     async def hook_endpoint(request: Request) -> JSONResponse:
-        from starlette.concurrency import run_in_threadpool
-
         # Precheck the honest case cheaply; the post-read check below covers
         # a missing or lying content-length (e.g. chunked encoding)
         content_length = request.headers.get("content-length")
@@ -555,11 +557,23 @@ def register_with_bus(config: BridgeConfig) -> int:
 def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
     """Best-effort webhook cleanup on shutdown."""
     try:
-        call_tool("unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url)
-        logger.info(f"Unregistered bridge webhook #{webhook_id}")
+        result = call_tool("unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url)
     except SystemExit:
         # call_tool exits on connection errors; shutdown must not care
         logger.warning(f"Could not unregister webhook #{webhook_id} (bus unreachable)")
+        return
+    # Same accept-shape as the startup sweep: the bus reports logical
+    # failure in-band (success-False dict), and already-gone is the goal
+    # state. Shutdown stays best-effort, so a surprise is a warning here
+    # rather than the sweep's retryable SystemExit - but the log must not
+    # assert a removal it never checked; the next startup sweep reclaims.
+    ok = isinstance(result, dict) and (
+        result.get("success") or result.get("error") == "Webhook not found"
+    )
+    if ok:
+        logger.info(f"Unregistered bridge webhook #{webhook_id}")
+    else:
+        logger.warning(f"unregister_webhook #{webhook_id} returned unexpected result: {result!r}")
 
 
 def register_with_retry(

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -117,6 +117,13 @@ REGISTRATION_JOIN_TIMEOUT = 35.0
 # be checked, so bound what an unauthenticated peer can make us buffer
 MAX_BODY_BYTES = 1_048_576  # 1 MiB
 
+# panes.json is a small {session_id: pane_id} map maintained by an external
+# component, read on the delivery path for every tmux-backend DM. Bound the
+# read so a runaway or malicious file can't pull unbounded bytes into memory
+# per DM (a real mapping is orders of magnitude smaller); a truncated read
+# is almost certainly invalid JSON and lands on the unparseable arm.
+MAX_PANES_BYTES = 262_144  # 256 KiB
+
 # Bound the wait for the per-session spool flock. The drain contract keeps
 # the drainer's hold down to a couple of renames, so seconds of contention
 # means a stuck drainer (SIGSTOP, network mount) - and an unbounded block
@@ -446,13 +453,14 @@ class Injector:
         Serialized by the per-session flock below - against other threads in
         this process and against the drain hook alike.
 
-        A serialization failure (RecursionError out of json.dumps on a
-        pathologically nested payload - the same recursion sibling the
-        json.loads arms catch, one screen up in process()) is re-raised as
-        _UnserializablePayloadError BEFORE any file is created or lock taken, and
-        process() maps THAT to the named 400 every other wire-input path
-        returns. Every OTHER raise here is retry-meaningful: nothing is
-        durably stored, so the bus retry is real (unlike a post-spool error).
+        A serialization failure (a RecursionError on a pathologically nested
+        payload, or the ValueError json.dumps(allow_nan=False) raises on an
+        inf/nan that json.loads' parse_float admitted - e.g. 1e400) is
+        re-raised as _UnserializablePayloadError BEFORE any file is created or
+        lock taken, and process() maps THAT to the named 400 every other
+        wire-input path returns. Every OTHER raise here is retry-meaningful:
+        nothing is durably stored, so the bus retry is real (unlike a
+        post-spool error).
         """
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
         # The id is charset-clean by here (resolve_target_session validated
@@ -605,16 +613,20 @@ class Injector:
             #    worker forever inside a deliver() that already committed its
             #    spool line - each tmux-backend delivery parks one and /hook
             #    starves once they are all consumed. This path has no
-            #    TMUX_TIMEOUT/deadline of its own. On a FIFO the read returns
-            #    EOF (empty -> unparseable) or EAGAIN (OSError -> unreadable);
-            #    on a regular file O_NONBLOCK is a no-op.
+            #    TMUX_TIMEOUT/deadline of its own. On a no-writer FIFO the read
+            #    returns EOF (empty -> unparseable); a writer-attached FIFO
+            #    with nothing buffered surfaces as a TypeError from the text
+            #    layer (raw read returns None), caught below; on a regular file
+            #    O_NONBLOCK is a no-op.
             #  - encoding="utf-8", NOT the locale codec: a supervisor hands the
             #    daemon no LC_ALL/LANG, glibc resolves C -> ASCII, and a
             #    healthy file with any byte >0x7f would wrongly hit the
             #    unparseable arm. The writer contract (guide) says UTF-8.
+            #  - read(MAX_PANES_BYTES): bound the per-DM buffer against a
+            #    runaway file; a truncated read is invalid JSON -> unparseable.
             fd = os.open(panes_file, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
             with os.fdopen(fd, encoding="utf-8") as f:
-                panes = json.loads(f.read())
+                panes = json.loads(f.read(MAX_PANES_BYTES))
         except FileNotFoundError:
             # A missing file IS this session's absent read: clear the
             # file-level keys AND this session's entry key, matching the
@@ -625,16 +637,16 @@ class Injector:
             self._disarm_file_keys()
             self._warned_panes_keys.discard(f"bad-pane-value:{session_id}")
             return None
-        except (ValueError, RecursionError) as e:
-            # Parse failures (JSONDecodeError, UnicodeDecodeError from a
-            # torn write) - typically transient, self-healing on the
-            # writer's next write. RecursionError is the non-ValueError
-            # sibling, same as process()'s json.loads arm: deep nesting
-            # blows the interpreter limit before any JSONDecodeError
-            # exists, and an escape here 500s a delivery whose spool line
-            # is already committed. Separate reason from the OSError arm: a
-            # torn write escalating into a permanently unreadable file must
-            # WARN again, not be demoted as a repeat of the same condition.
+        except (ValueError, RecursionError, TypeError) as e:
+            # Parse failures - the read produced something json.loads can't
+            # take. ValueError: JSONDecodeError, or UnicodeDecodeError from a
+            # torn write. RecursionError: deep nesting blows the interpreter
+            # limit before any JSONDecodeError. TypeError: a writer-attached
+            # FIFO with nothing buffered makes the text layer's read return
+            # None (raw EAGAIN surfaces as None, not an OSError). All
+            # typically transient/self-healing; separate reason from the
+            # OSError arm so a torn write escalating into a permanently
+            # unreadable file WARNs again rather than demoting.
             self._warn_panes_once(
                 "unparseable", f"Unparseable panes.json ({e}); treating as unmapped"
             )
@@ -645,6 +657,19 @@ class Injector:
             # the guard, so this class carries its own reason key
             self._warn_panes_once(
                 "unreadable", f"Unreadable panes.json ({e}); treating as unmapped"
+            )
+            return None
+        except Exception as e:
+            # Never-500 backstop by SHAPE, not enumeration: this method's
+            # contract is that no failure reading an externally-maintained,
+            # hostile-adjacent file escapes to 500 an already-spooled
+            # delivery (which the bus would retry, duplicating lines). The
+            # specific arms above stay for reason selection; this catches
+            # anything they miss so the invariant can't be broken again by a
+            # new exception shape (it has been widened three times). Logged
+            # in full on first sighting so a genuine bug is not masked.
+            self._warn_panes_once(
+                "unexpected", f"Unexpected error reading panes.json ({e!r}); treating as unmapped"
             )
             return None
         # A successful json.loads proves the READ and PARSE conditions
@@ -700,11 +725,12 @@ class Injector:
         self._warned_panes_keys.discard(entry_key)  # healthy entry re-arms it
         return pane
 
-    _PANES_FILE_KEYS = frozenset({"unparseable", "unreadable", "not-an-object"})
+    _PANES_FILE_KEYS = frozenset({"unparseable", "unreadable", "not-an-object", "unexpected"})
     # The subset a successful read+parse clears regardless of the shape it
     # yields; not-an-object is left out because it tracks the shape, cleared
-    # only when the shape is actually a dict.
-    _PANES_READ_KEYS = frozenset({"unparseable", "unreadable"})
+    # only when the shape is actually a dict. "unexpected" (the never-500
+    # catch-all) is a read/parse-stage condition, so a healthy read re-arms it.
+    _PANES_READ_KEYS = frozenset({"unparseable", "unreadable", "unexpected"})
 
     def _disarm_file_keys(self) -> None:
         """The normal missing-file state clears ALL file-level conditions -

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -28,6 +28,7 @@ AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
 """
 
 import argparse
+import fcntl
 import hashlib
 import hmac
 import ipaddress
@@ -92,7 +93,13 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
     if not signature_header or not signature_header.startswith("sha256="):
         return False
     expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(f"sha256={expected}", signature_header)
+    # Compare as bytes: str compare_digest raises TypeError on non-ASCII
+    # input, and Starlette decodes headers as latin-1 - a hostile header
+    # byte above 0x7f must be a 401, not a 500. bytes keeps constant-time.
+    return hmac.compare_digest(
+        f"sha256={expected}".encode(),
+        signature_header.encode("latin-1", errors="replace"),
+    )
 
 
 # Session ids are UUIDs (36 chars) or display ids ("brave-trex"); nothing
@@ -194,8 +201,18 @@ class Injector:
         # produce a write outside the wake dir
         if spool_file.resolve().parent != self.config.wake_dir.resolve():
             raise ValueError(f"Spool path escapes wake dir: {session_id!r}")
-        with spool_file.open("a") as f:
-            f.write(json.dumps(event) + "\n")
+        # flock a sibling lock file around the append: self._lock serializes
+        # OUR writers, but the drain hook is another process - without this,
+        # its rename could slip between our open and our flush and the line
+        # would land in a file the drainer already read (and will delete)
+        lock_file = self.config.wake_dir / f"{session_id}.lock"
+        with lock_file.open("a") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            try:
+                with spool_file.open("a") as f:
+                    f.write(json.dumps(event) + "\n")
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
     def _tmux_pane(self, session_id: str) -> str | None:
         """Look up the session's tmux pane from <wake_dir>/panes.json.
@@ -495,7 +512,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--wake-dir",
         type=Path,
-        default=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
+        # `or`: an empty env var would make Path("") == cwd - the bridge
+        # would chmod and spool into whatever directory launched it
+        default=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR") or str(DEFAULT_WAKE_DIR)),
         help="Directory for spool files and panes.json",
     )
     parser.add_argument(
@@ -549,6 +568,13 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         raise SystemExit(
             f"Invalid cooldown {config.cooldown_seconds} "
             "(check --cooldown / AGENT_EVENT_BUS_BRIDGE_COOLDOWN): must be >= 0"
+        )
+    # A daemon's cwd is whatever its supervisor hands it - a relative wake
+    # dir would silently relocate the durable path (and its chmod)
+    if not config.wake_dir.is_absolute():
+        raise SystemExit(
+            f"Invalid wake dir {config.wake_dir} "
+            "(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): must be an absolute path"
         )
     # A scheme-less bus URL ("bus.example:8080/mcp") parses with no hostname
     # and would read as loopback, skipping the topology guard below - catch

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -30,6 +30,7 @@ AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
 import argparse
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -281,6 +282,11 @@ def create_bridge_app(
             event = json.loads(body)
         except json.JSONDecodeError:
             return {"error": "invalid JSON"}, 400
+        if not isinstance(event, dict):
+            # Valid JSON that isn't an object (123, [], "x") must be a 400,
+            # not an AttributeError-turned-500 - this endpoint is network
+            # reachable, more so once it binds beyond loopback
+            return {"error": "expected a JSON object"}, 400
 
         # The bus always sends the derived signal_level; only actionable
         # events (DMs, help_needed, blockers, CI failures) justify a wake
@@ -327,12 +333,19 @@ def bridge_hook_url(config: BridgeConfig) -> str:
     return config.hook_url or f"http://127.0.0.1:{config.port}/hook"
 
 
-LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+LOOPBACK_HOSTS = {"localhost"}
 
 
 def _is_loopback(url: str) -> bool:
+    """Loopback is all of 127.0.0.0/8 plus ::1 (Debian/Ubuntu resolve the
+    machine's own hostname to 127.0.1.1), not just the literal 127.0.0.1."""
     host = urllib.parse.urlsplit(url).hostname
-    return host is None or host in LOOPBACK_HOSTS
+    if host is None:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host in LOOPBACK_HOSTS
 
 
 def register_with_bus(config: BridgeConfig) -> int:
@@ -491,6 +504,11 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         wake_dir=args.wake_dir,
         hook_url=args.hook_url,
     )
+    # A scheme-less bus URL ("bus.example:8080/mcp") parses with no hostname
+    # and would read as loopback, skipping the topology guard below - catch
+    # the misconfiguration here instead of in a later connection error
+    if urllib.parse.urlsplit(config.bus_url).scheme not in ("http", "https"):
+        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http:// or https://")
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
     # delivered - and every machine would claim the same URL string, so the
@@ -502,6 +520,26 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"{bridge_hook_url(config)} is loopback - the bus would POST to itself. "
             "Set --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL to an address the bus "
             "host can reach (and set AGENT_EVENT_BUS_BRIDGE_SECRET)."
+        )
+    # A non-loopback hook URL means binding beyond localhost, where the HMAC
+    # is the only authentication: an unsigned endpoint would let anyone who
+    # can reach the port append attacker-authored lines to a session spool.
+    # Hard requirement, matching the refusal above - the bus itself defaults
+    # to auth-required, and the bridge must not invert that.
+    if not _is_loopback(bridge_hook_url(config)) and not config.secret:
+        raise SystemExit(
+            "Hook URL is non-loopback, so the listener must bind beyond localhost - "
+            "set AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
+            "authentication on this hop)."
+        )
+    # The bus POSTs to the hook URL's port while the listener binds --port;
+    # a mismatch is legitimate behind a reverse proxy, but name it - it's
+    # otherwise the same silent-inertness failure the guards above close
+    hook_port = urllib.parse.urlsplit(bridge_hook_url(config)).port
+    if hook_port is not None and hook_port != config.port:
+        logger.warning(
+            f"Hook URL advertises port {hook_port} but the listener binds {config.port} - "
+            "correct only if something forwards between them"
         )
     return config
 
@@ -519,16 +557,11 @@ def main():
     app = create_bridge_app(config, registration_state=state, registration_stop=stop)
     # Loopback hook URL -> bind localhost only (the local bus is the sole
     # caller). A non-loopback hook URL means a remote bus must reach us, so
-    # bind wide - at which point the HMAC secret is the only authentication.
+    # bind wide - config_from_args guarantees an HMAC secret on this path.
     if _is_loopback(bridge_hook_url(config)):
         host = "127.0.0.1"
     else:
-        host = "0.0.0.0"  # noqa: S104 - deliberate, guarded by warning below
-        if not config.secret:
-            logger.warning(
-                "Hook URL is non-loopback and AGENT_EVENT_BUS_BRIDGE_SECRET is unset - "
-                "anyone who can reach this port can inject wake events"
-            )
+        host = "0.0.0.0"  # noqa: S104 - deliberate; secret enforced at config time
     try:
         uvicorn.run(app, host=host, port=config.port)
     finally:

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -44,6 +44,7 @@ import math
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import threading
@@ -85,11 +86,13 @@ DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wa
 # same URL - a Path.home()-based path only contends within one HOME, so the
 # same uid under two HOMEs (a systemd unit vs a login shell) would both
 # acquire and both sweep. XDG_RUNTIME_DIR (per-user tmpfs) when set, else the
-# system temp dir; the uid-named subdir makes it HOME-independent and keeps a
-# shared /tmp safe (we own it, 0o700). Cross-USER on one loopback bus (a
-# different uid reaching the same bus, which the loopback-trusting auth
-# allows) stays out of scope for v1 - a different uid gets a different dir -
-# and is called out in the guide.
+# system temp dir (tempfile.gettempdir() - $TMPDIR/$TEMP/$TMP, else /tmp;
+# macOS resolves this to a per-user /var/folders/.../T). The uid-named subdir
+# makes it HOME-independent; on a box that falls back to a SHARED temp dir the
+# dir is create-and-VERIFIED before use (_ensure_private_lock_dir), not
+# adopted. Cross-USER on one loopback bus (a different uid reaching the same
+# bus, which the loopback-trusting auth allows) stays out of scope for v1 - a
+# different uid gets a different dir - and is called out in the guide.
 DEFAULT_LOCK_DIR = (
     Path(os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir())
     / f"agent-event-bus-bridge-{os.getuid()}"
@@ -811,10 +814,15 @@ def create_bridge_app(
         allowed_hook_hosts.add(hook_host)
     bind = bind_host(config)
     try:
+        bind_ip = ipaddress.ip_address(bind)
         # Skip the wildcards (0.0.0.0 / ::): nobody probes an unspecified
-        # address, and "localhost" is already covered above.
-        if not ipaddress.ip_address(bind).is_unspecified:
-            allowed_hook_hosts.add(bind)
+        # address, and "localhost" is already covered above. Store the
+        # NORMALIZED form - str(ip_address) renders IPv6 lowercase and
+        # compressed, exactly what _host_from_header yields - so an uppercase
+        # or expanded --bind (FE80::1, 0:0:0:0:0:0:0:1) still matches the
+        # Host a probe sends. IPv4 is unaffected.
+        if not bind_ip.is_unspecified:
+            allowed_hook_hosts.add(str(bind_ip))
     except ValueError:
         pass  # "localhost" - already present; the resolver decides its family
     # Version-skew line bound (a closure cell: the arm lives in process(),
@@ -1763,16 +1771,65 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     return config
 
 
+def _ensure_private_lock_dir(path: Path) -> None:
+    """Create `path` as a private (0o700) directory this process owns, or
+    SystemExit with a named message - create-and-VERIFY, not adopt. The
+    hook-lock dir sits at a uid-derived, guessable name under
+    tempfile.gettempdir(); on a box without XDG_RUNTIME_DIR that resolves to
+    a SHARED temp dir (containers, cron, launchd, su/sudo, any login without
+    pam_systemd), where a local user can pre-plant it. mkdir(exist_ok)+chmod
+    would then either EPERM into a bare traceback (foreign-owned) or
+    silently narrow-and-write-through (a symlink). This is the
+    directory-level counterpart of the O_NOFOLLOW that already guards the
+    lock FILE. lstat (not stat) so a symlink fails closed. Only the hook-lock
+    dir is routed here; the wake dir is Injector.__init__'s job."""
+    try:
+        os.mkdir(path, 0o700)
+        return  # we just created it - unambiguously ours
+    except FileExistsError:
+        pass
+    except OSError as e:
+        # read-only/full temp dir, a missing XDG_RUNTIME_DIR parent, ... -
+        # a named message, not the bare traceback every other config-time
+        # failure in this module avoids
+        raise SystemExit(
+            f"Cannot create bridge lock dir {path} ({e}); set XDG_RUNTIME_DIR "
+            "to a writable per-user directory."
+        ) from None
+    info = os.lstat(path)  # lstat: a symlink must NOT be followed here
+    if not stat.S_ISDIR(info.st_mode):
+        raise SystemExit(
+            f"Bridge lock path {path} is not a directory (a symlink or file is "
+            "planted there); refusing to use it. Remove it, or set XDG_RUNTIME_DIR."
+        )
+    if info.st_uid != os.getuid():
+        raise SystemExit(
+            f"Bridge lock dir {path} is owned by uid {info.st_uid}, not this "
+            f"process ({os.getuid()}); refusing to use it. Remove it, or set "
+            "XDG_RUNTIME_DIR to a per-user directory."
+        )
+    if info.st_mode & 0o077:
+        raise SystemExit(
+            f"Bridge lock dir {path} is group/world-accessible "
+            f"(mode {oct(info.st_mode & 0o777)}); refusing to use it. "
+            "chmod 700 it, or set XDG_RUNTIME_DIR."
+        )
+
+
 def _flock_or_exit(lock_path: Path, conflict_message: str) -> int:
     """Take an exclusive, non-blocking advisory flock on lock_path, or
     SystemExit(conflict_message) if another holder has it. Returns the held
     fd - the caller keeps it for the process's lifetime (the lock releases
-    when the fd closes). O_NOFOLLOW so a symlink planted at the path is not
-    followed; the parent dir is created 0o700 first (both lock homes hold no
-    payload, but private is the right default)."""
+    when the fd closes). O_NOFOLLOW so a symlink planted at the FILE is not
+    followed (the hook-lock DIR is verified by _ensure_private_lock_dir; the
+    wake dir is Injector's). A failed open becomes a named SystemExit rather
+    than the bare traceback every other failure here avoids (e.g. EACCES on
+    a foreign lock file, ELOOP on a symlinked one)."""
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.parent.chmod(0o700)
-    fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    try:
+        fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    except OSError as e:
+        raise SystemExit(f"Cannot open bridge lock {lock_path} ({e})") from None
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
@@ -1805,6 +1862,7 @@ def _acquire_singleton_locks(config: BridgeConfig) -> list[int]:
     <session_id>.lock spool file (the id charset forbids ".")."""
     hook = bridge_hook_url(config)
     digest = hashlib.sha256(hook.encode()).hexdigest()[:16]
+    _ensure_private_lock_dir(DEFAULT_LOCK_DIR)  # create-and-verify, not adopt
     hook_lock = DEFAULT_LOCK_DIR / f"hook.{digest}.lock"
     wake_lock = config.wake_dir / "bridge.singleton.lock"
     specs = [

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -233,14 +233,16 @@ class Injector:
         # so it must NOT run under the global lock, or one stalled drain
         # would stall every session's delivery
         self._spool(session_id, event)
-        # The one default-level breadcrumb on the happy path: without it the
-        # spool backend's terminal shows the registration line and then
-        # permanent silence, indistinguishable from a bus that stopped
-        # dispatching. Volume is bounded by the actionable-DM rate - exactly
-        # the traffic this daemon exists to surface.
-        logger.info(f"Spooled event {event.get('event_id')} for {session_id[:8]}...")
 
         if self.config.backend != "tmux":
+            # The one default-level breadcrumb on the happy path: without it
+            # the spool backend's terminal shows the registration line and
+            # then permanent silence, indistinguishable from a bus that
+            # stopped dispatching. Spool backend ONLY: in the tmux backend
+            # this would emit one INFO per foreign-machine DM - the exact
+            # volume the unmapped arm's debug demotion exists to avoid - and
+            # a mapped wake already logs "Woke ..." at INFO.
+            logger.info(f"Spooled event {event.get('event_id')} for {session_id[:8]}...")
             return "spool"
 
         # Pane lookup BEFORE the cooldown machinery: on a multi-machine bus
@@ -288,6 +290,13 @@ class Injector:
 
     def _spool(self, session_id: str, event: dict) -> None:
         """Always-on durable path: one JSON line per event, per session.
+
+        Durable against bridge and session crashes, not host crashes: the
+        file is flushed and closed before the 200, but never fsync'ed, so a
+        kernel panic or power loss inside the writeback window can lose a
+        wake the bus already counted delivered. fsync-on-append is an
+        accepted follow-up - it would eat into the SPOOL_LOCK deadline
+        budget that must stay under the bus's WEBHOOK_TIMEOUT.
 
         Serialized by the per-session flock below - against other threads in
         this process and against the drain hook alike.
@@ -913,6 +922,18 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Hook URL advertises port {hook_port} but the listener binds {config.port} - "
             "correct only if something forwards between them"
         )
+    # The listener only ever speaks plain HTTP (uvicorn.run gets no TLS
+    # config), so an https hook URL needs a terminator in front - and a
+    # terminator fronts one port while forwarding to another, so https with
+    # the ports AGREEING is precisely the no-terminator shape: every
+    # dispatch dies in the TLS handshake with every other guard quiet. The
+    # mismatched-port terminator shape is already named by the check above.
+    if hook_split.scheme == "https" and hook_port == config.port:
+        logger.warning(
+            f"Hook URL {bridge_hook_url(config)} is https but this listener serves "
+            "plain HTTP on that same port - correct only if a TLS terminator "
+            "forwards between them"
+        )
     # POST /hook is the only route this listener serves; any other
     # advertised path 404s every dispatch. Legitimate behind a rewriting
     # proxy, so warn-don't-refuse like the port mismatch above.
@@ -969,7 +990,15 @@ def main():
     import uvicorn
 
     args = build_parser().parse_args()
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    # DEV_MODE=1 turns on the debug diagnostics - the per-event reasons a
+    # delivery did nothing - matching server.py and the switch CLAUDE.md
+    # documents for this package. Without a level path every logger.debug
+    # in this module is dead code in the shipped daemon.
+    level = logging.DEBUG if os.environ.get("DEV_MODE") else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
+    # basicConfig is a no-op when the root logger already has handlers
+    # (e.g. under a test harness), so pin the module logger too
+    logger.setLevel(level)
     config = config_from_args(args)
 
     state: dict = {}

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -64,6 +64,11 @@ from starlette.routing import Route
 
 from agent_event_bus.cli import DEFAULT_URL, call_tool
 
+# The header name is a wire contract with the bus - import it rather than
+# re-spelling it, the same coupling discipline as the tests building their
+# signatures from the bus's _compute_signature
+from agent_event_bus.server import SIGNATURE_HEADER
+
 logger = logging.getLogger("agent-event-bus-bridge")
 
 DEFAULT_BRIDGE_PORT = 8082
@@ -673,7 +678,9 @@ def create_bridge_app(
                 return JSONResponse({"error": "body too large"}, status_code=413)
             chunks.append(chunk)
         body = b"".join(chunks)
-        signature = request.headers.get("x-event-bus-signature")
+        # Starlette header lookup is case-insensitive, so the canonical-case
+        # constant works directly
+        signature = request.headers.get(SIGNATURE_HEADER)
         payload, status = await run_in_threadpool(process, body, signature)
         return JSONResponse(payload, status_code=status)
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -37,6 +37,7 @@ import re
 import subprocess
 import threading
 import time
+import urllib.parse
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -75,6 +76,8 @@ class BridgeConfig:
     secret: str | None = None
     cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS
     wake_dir: Path = field(default_factory=lambda: DEFAULT_WAKE_DIR)
+    # URL the bus POSTs to; None means loopback (bus on this machine)
+    hook_url: str | None = None
 
 
 def verify_signature(body: bytes, signature_header: str | None, secret: str) -> bool:
@@ -85,12 +88,14 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
     return hmac.compare_digest(f"sha256={expected}", signature_header)
 
 
-# Session ids are UUIDs or display ids ("brave-trex"); nothing else. The
-# channel string is publisher-controlled wire input and the id becomes a spool
-# filename, so path separators, "..", and any other unexpected byte must never
-# reach the filesystem - the bus warns on malformed channels but does not
-# reject them.
-SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
+# Session ids are UUIDs (36 chars) or display ids ("brave-trex"); nothing
+# else. The channel string is publisher-controlled wire input and the id
+# becomes a spool filename, so path separators, "..", and any other
+# unexpected byte must never reach the filesystem - the bus warns on
+# malformed channels but does not reject them. The length bound keeps a
+# too-long name from turning into an unretryable OSError out of the spool
+# open (and caps spool-file blast radius).
+SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 def resolve_target_session(event: dict) -> str | None:
@@ -106,8 +111,7 @@ def resolve_target_session(event: dict) -> str | None:
         return None
     target = channel.split(":", 1)[1]
     if not SESSION_ID_PATTERN.fullmatch(target):
-        if target:
-            logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
+        logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
         return None
     return target
 
@@ -165,12 +169,11 @@ class Injector:
             return "tmux"
         with self._lock:
             # Roll back the reservation so the failure doesn't burn the
-            # window - unless a later delivery already re-claimed it
+            # window - unless a later delivery already re-claimed it. There
+            # is no previous value to restore: any entry that survived the
+            # prune returned spool-cooldown above.
             if self._last_wake.get(session_id) == now:
-                if last is None:
-                    del self._last_wake[session_id]
-                else:
-                    self._last_wake[session_id] = last
+                del self._last_wake[session_id]
         return "spool"
 
     def _spool(self, session_id: str, event: dict) -> None:
@@ -300,7 +303,13 @@ def create_bridge_app(
         return JSONResponse(payload, status_code=status)
 
     async def health(request: Request) -> JSONResponse:
-        return JSONResponse({"status": "ok", "service": "agent-event-bus-bridge"})
+        payload = {"status": "ok", "service": "agent-event-bus-bridge"}
+        if registration_state is not None:
+            # Registration is deliberately non-fatal, so this is the one
+            # place an operator (or a supervisor readiness check) can tell
+            # "working" from "listening but never registered"
+            payload["registered"] = registration_state.get("webhook_id") is not None
+        return JSONResponse(payload)
 
     return Starlette(
         routes=[
@@ -312,7 +321,18 @@ def create_bridge_app(
 
 
 def bridge_hook_url(config: BridgeConfig) -> str:
-    return f"http://127.0.0.1:{config.port}/hook"
+    """The URL the bus POSTs to. Loopback by default (bus on this machine);
+    --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL overrides it with an
+    address the bus host can reach when the bus is remote."""
+    return config.hook_url or f"http://127.0.0.1:{config.port}/hook"
+
+
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _is_loopback(url: str) -> bool:
+    host = urllib.parse.urlsplit(url).hostname
+    return host is None or host in LOOPBACK_HOSTS
 
 
 def register_with_bus(config: BridgeConfig) -> int:
@@ -439,6 +459,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
         help="Directory for spool files and panes.json",
     )
+    parser.add_argument(
+        "--hook-url",
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_HOOK_URL") or None,
+        help="URL the bus POSTs events to (default: http://127.0.0.1:<port>/hook; "
+        "must be an address the bus host can reach when the bus is remote)",
+    )
     return parser
 
 
@@ -452,7 +478,7 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Invalid backend {args.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
             "expected 'spool' or 'tmux'"
         )
-    return BridgeConfig(
+    config = BridgeConfig(
         bus_url=args.bus_url,
         port=args.port,
         backend=args.backend,
@@ -463,7 +489,21 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
         cooldown_seconds=args.cooldown,
         wake_dir=args.wake_dir,
+        hook_url=args.hook_url,
     )
+    # A loopback hook URL registered on a remote bus makes the bus POST to
+    # itself: registration succeeds, /health is green, nothing is ever
+    # delivered - and every machine would claim the same URL string, so the
+    # startup dedupe could remove a live webhook belonging to the bus host.
+    # Refuse the combination instead of failing silently.
+    if not _is_loopback(config.bus_url) and _is_loopback(bridge_hook_url(config)):
+        raise SystemExit(
+            f"Bus at {config.bus_url} is remote but the advertised hook URL "
+            f"{bridge_hook_url(config)} is loopback - the bus would POST to itself. "
+            "Set --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL to an address the bus "
+            "host can reach (and set AGENT_EVENT_BUS_BRIDGE_SECRET)."
+        )
+    return config
 
 
 def main():
@@ -477,10 +517,20 @@ def main():
     state: dict = {}
     stop = threading.Event()
     app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+    # Loopback hook URL -> bind localhost only (the local bus is the sole
+    # caller). A non-loopback hook URL means a remote bus must reach us, so
+    # bind wide - at which point the HMAC secret is the only authentication.
+    if _is_loopback(bridge_hook_url(config)):
+        host = "127.0.0.1"
+    else:
+        host = "0.0.0.0"  # noqa: S104 - deliberate, guarded by warning below
+        if not config.secret:
+            logger.warning(
+                "Hook URL is non-loopback and AGENT_EVENT_BUS_BRIDGE_SECRET is unset - "
+                "anyone who can reach this port can inject wake events"
+            )
     try:
-        # Localhost only: the bus is the sole intended caller, and HMAC (when
-        # a secret is set) authenticates it
-        uvicorn.run(app, host="127.0.0.1", port=config.port)
+        uvicorn.run(app, host=host, port=config.port)
     finally:
         # Lifespan shutdown already stopped and joined the registration
         # thread; the stop here only covers exits that skipped the lifespan

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -34,6 +34,7 @@ import hmac
 import ipaddress
 import json
 import logging
+import math
 import os
 import re
 import subprocess
@@ -80,6 +81,11 @@ MAX_BODY_BYTES = 1_048_576  # 1 MiB
 SPOOL_LOCK_ATTEMPTS = 50
 SPOOL_LOCK_RETRY_SECONDS = 0.1
 
+# Must stay a fixed multi-word constant: the send-keys call passes it as
+# one argument WITHOUT -l, so tmux would interpret a value matching a key
+# name (Enter, C-c, Escape) as a keystroke instead of typing it. If this
+# ever becomes configurable or carries payload text, switch the call to
+# `send-keys -l` for the text plus a separate `send-keys Enter`.
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
 
@@ -332,7 +338,11 @@ def create_bridge_app(
 
         try:
             event = json.loads(body)
-        except json.JSONDecodeError:
+        # ValueError, not just JSONDecodeError: json.loads(bytes) DECODES
+        # before parsing, and invalid UTF-8 raises UnicodeDecodeError (a
+        # ValueError but not a JSONDecodeError) - it must be a 400, not a
+        # 500 with bus retries behind it
+        except ValueError:
             return {"error": "invalid JSON"}, 400
         if not isinstance(event, dict):
             # Valid JSON that isn't an object (123, [], "x") must be a 400,
@@ -620,10 +630,13 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Invalid port {config.port} (check --port / AGENT_EVENT_BUS_BRIDGE_PORT): "
             "expected 1-65535"
         )
-    if config.cooldown_seconds < 0:
+    # isfinite too: nan makes every prune comparison False (cooldown never
+    # engages), inf makes it always True (one wake ever, then silence)
+    if not math.isfinite(config.cooldown_seconds) or config.cooldown_seconds < 0:
         raise SystemExit(
             f"Invalid cooldown {config.cooldown_seconds} "
-            "(check --cooldown / AGENT_EVENT_BUS_BRIDGE_COOLDOWN): must be >= 0"
+            "(check --cooldown / AGENT_EVENT_BUS_BRIDGE_COOLDOWN): "
+            "must be finite and >= 0"
         )
     # A daemon's cwd is whatever its supervisor hands it - a relative wake
     # dir would silently relocate the durable path (and its chmod)

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -366,7 +366,20 @@ class Injector:
         except FileNotFoundError:
             self._last_panes_warn_reason = None  # normal unmapped state re-arms
             return None
-        except (OSError, ValueError) as e:
+        except ValueError as e:
+            # Parse failures (JSONDecodeError, UnicodeDecodeError from a
+            # torn write) - typically transient, self-healing on the
+            # writer's next write. Separate reason from the OSError arm: a
+            # torn write escalating into a permanently unreadable file must
+            # WARN again, not be demoted as a repeat of the same condition.
+            self._warn_panes_once(
+                "unparseable", f"Unparseable panes.json ({e}); treating as unmapped"
+            )
+            return None
+        except OSError as e:
+            # I/O failures (PermissionError, IsADirectoryError) - typically
+            # persistent, and there may never be a healthy read to re-arm
+            # the guard, so this class carries its own reason key
             self._warn_panes_once(
                 "unreadable", f"Unreadable panes.json ({e}); treating as unmapped"
             )

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -114,6 +114,13 @@ SPOOL_LOCK_RETRY_SECONDS = 0.1
 # name (Enter, C-c, Escape) as a keystroke instead of typing it. If this
 # ever becomes configurable or carries payload text, switch the call to
 # `send-keys -l` for the text plus a separate `send-keys Enter`.
+# Cap on the warn-once key sets (wake failures and panes conditions): a
+# session that ends while broken never sheds its key - only a later
+# delivery for that same session can - so on a weeks-long daemon the sets
+# are pure retention for dead sessions. Housekeeping, not correctness:
+# clearing costs one repeat warning per still-live condition.
+_WARN_KEYS_CAP = 256
+
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
 
@@ -253,8 +260,11 @@ class Injector:
             self.config.wake_dir.chmod(0o700)
         except OSError as e:
             # The one startup filesystem precondition: a named config error
-            # like every other operator-facing input, not a bare traceback
-            raise SystemExit(
+            # like every other operator-facing input, not a bare traceback.
+            # BridgeConfigError, not SystemExit: Injector is constructed by
+            # create_bridge_app, so this raise crosses the embedding surface
+            # too - main() translates it for the CLI, same as validate_config
+            raise BridgeConfigError(
                 f"Cannot prepare wake dir {self.config.wake_dir} "
                 f"(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): {e}"
             ) from None
@@ -374,8 +384,13 @@ class Injector:
         # ONE deadline shared across the self-heal retry below: a per-call
         # attempt counter would let contended-then-vanished-dir double the
         # worst case past the sum-under-WEBHOOK_TIMEOUT invariant that
-        # TestBusTimingContract pins on the constants
-        deadline = _now() + SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS
+        # TestBusTimingContract pins on the constants. time.monotonic
+        # directly, NOT the _now() seam: the seam exists for the cooldown's
+        # semantics and tests freeze it - a frozen clock here would turn a
+        # held flock into an unbounded spin instead of the deadline raise.
+        # (ATTEMPTS x RETRY defines the budget; the loop is wall-clock
+        # gated, so ATTEMPTS is a budget multiplier, not a literal count.)
+        deadline = time.monotonic() + SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS
 
         def _append() -> None:
             with lock_file.open("a") as lock_fd:
@@ -384,7 +399,7 @@ class Injector:
                         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         break
                     except BlockingIOError:
-                        if _now() >= deadline:
+                        if time.monotonic() >= deadline:
                             raise OSError(
                                 f"Could not lock spool for {session_id} within "
                                 f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
@@ -512,6 +527,9 @@ class Injector:
         if key in self._warned_panes_keys:
             logger.debug(message)
         else:
+            if len(self._warned_panes_keys) >= _WARN_KEYS_CAP:
+                # Same dead-session retention bound as the wake-failure set
+                self._warned_panes_keys.clear()
             self._warned_panes_keys.add(key)
             logger.warning(message)
 
@@ -553,6 +571,13 @@ class Injector:
             with self._lock:
                 first_sighting = key not in self._warned_wake_fail_keys
                 if first_sighting:
+                    if len(self._warned_wake_fail_keys) >= _WARN_KEYS_CAP:
+                        # Housekeeping, not correctness: a session whose pane
+                        # never recovers never sheds its key (only success
+                        # discards), and sessions are ephemeral - so clear at
+                        # a cap; one repeat warning per condition after that
+                        # many distinct ones is the lesser noise
+                        self._warned_wake_fail_keys.clear()
                     self._warned_wake_fail_keys.add(key)
             if first_sighting:
                 logger.warning(message)
@@ -1324,7 +1349,13 @@ def main():
 
     state: dict = {}
     stop = threading.Event()
-    app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+    # Same translation as config_from_args: app construction raises the
+    # embedder-catchable BridgeConfigError (Injector's wake-dir check runs
+    # in there), and the CLI turns it into a clean message-and-exit
+    try:
+        app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+    except BridgeConfigError as e:
+        raise SystemExit(str(e)) from None
     try:
         uvicorn.run(app, host=bind_host(config), port=config.port)
     finally:

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -25,7 +25,9 @@ so nothing is lost. In the default spool backend the cooldown never engages -
 a spool line only becomes a wake when the drain hook acts on it, so bounding
 that belongs to the drain hook.
 
-Run:  agent-event-bus-bridge [--backend tmux] [--port 8082] ...
+Run:  uv run agent-event-bus-bridge [--backend tmux] [--port 8082] ...
+(from the repo checkout - the console script lives in the project venv;
+nothing puts it on PATH yet, that lands with the supervision story)
 The bridge registers its own webhook on the bus at startup (HMAC-signed when
 AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
 """
@@ -190,6 +192,8 @@ class Injector:
         self.config = config
         self._lock = threading.Lock()
         self._last_wake: dict[str, float] = {}
+        # Last panes.json warning emitted, for the warn-once guard below
+        self._last_panes_warning: str | None = None
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event. The dir is
@@ -226,6 +230,12 @@ class Injector:
         # so it must NOT run under the global lock, or one stalled drain
         # would stall every session's delivery
         self._spool(session_id, event)
+        # The one default-level breadcrumb on the happy path: without it the
+        # spool backend's terminal shows the registration line and then
+        # permanent silence, indistinguishable from a bus that stopped
+        # dispatching. Volume is bounded by the actionable-DM rate - exactly
+        # the traffic this daemon exists to surface.
+        logger.info(f"Spooled event {event.get('event_id')} for {session_id[:8]}...")
 
         if self.config.backend != "tmux":
             return "spool"
@@ -323,15 +333,31 @@ class Injector:
         try:
             panes = json.loads(panes_file.read_text())
         except FileNotFoundError:
+            self._last_panes_warning = None  # normal unmapped state re-arms
             return None
         except (OSError, ValueError) as e:
-            logger.warning(f"Unreadable panes.json ({e}); treating as unmapped")
+            self._warn_panes_once(f"Unreadable panes.json ({e}); treating as unmapped")
             return None
         if not isinstance(panes, dict):
-            logger.warning("panes.json is not an object; treating as unmapped")
+            self._warn_panes_once("panes.json is not an object; treating as unmapped")
             return None
+        self._last_panes_warning = None  # healthy read re-arms the warning
         pane = panes.get(session_id)
         return pane if isinstance(pane, str) and pane else None
+
+    def _warn_panes_once(self, message: str) -> None:
+        """A persistently broken panes.json must not emit one WARNING per
+        delivered DM - the same unbounded-volume shape as the unsafe-channel
+        warning, driven by DM rate against a stuck local condition instead
+        of a hostile publisher. Warn on the first sighting of each distinct
+        condition, debug repeats; a healthy read (or the file going away)
+        re-arms it, so a NEW breakage always warns. Unlocked - a rare race
+        just duplicates a warning."""
+        if message == self._last_panes_warning:
+            logger.debug(message)
+        else:
+            self._last_panes_warning = message
+            logger.warning(message)
 
     def _tmux_wake(self, session_id: str, pane: str) -> bool:
         """Type the wake prompt into the given pane. False on failure."""

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -29,6 +29,7 @@ AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
 
 import argparse
 import fcntl
+import functools
 import hashlib
 import hmac
 import ipaddress
@@ -45,6 +46,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import anyio
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -67,9 +69,10 @@ DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wa
 TMUX_TIMEOUT = 2.0
 
 # Bound on joining the registration thread at shutdown. register_with_bus
-# makes up to three sequential call_tool requests (list, unregister stale,
-# register), each under the CLI's 10s timeout - so cover the worst-case
-# chain. A still-slower bus can leak a row; the startup dedupe reclaims it.
+# makes 2 + N sequential call_tool requests (list, one unregister per
+# stale row, register), each under the CLI's 10s timeout - 35s covers the
+# common N <= 1 case. A longer sweep (several unclean exits) or a slower
+# bus can still leak a row; the startup dedupe reclaims it.
 REGISTRATION_JOIN_TIMEOUT = 35.0
 
 # Real bus payloads are a few KB; the body must be read before the HMAC can
@@ -168,8 +171,16 @@ class Injector:
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event. The dir is
         # private (0o700) - spool files carry full event payloads.
-        self.config.wake_dir.mkdir(parents=True, exist_ok=True)
-        self.config.wake_dir.chmod(0o700)
+        try:
+            self.config.wake_dir.mkdir(parents=True, exist_ok=True)
+            self.config.wake_dir.chmod(0o700)
+        except OSError as e:
+            # The one startup filesystem precondition: a named config error
+            # like every other operator-facing input, not a bare traceback
+            raise SystemExit(
+                f"Cannot prepare wake dir {self.config.wake_dir} "
+                f"(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): {e}"
+            ) from None
 
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken:
@@ -207,8 +218,8 @@ class Injector:
             # and double-inject
             self._last_wake[session_id] = now
 
-        # tmux runs outside the lock (bounded at 5s, but other sessions'
-        # deliveries shouldn't wait on it)
+        # tmux runs outside the lock (bounded at TMUX_TIMEOUT, but other
+        # sessions' deliveries shouldn't wait on it)
         if self._tmux_wake(session_id):
             return "tmux"
         with self._lock:
@@ -340,7 +351,12 @@ def create_bridge_app(
         finally:
             if registration_thread is not None:
                 registration_stop.set()
-                registration_thread.join(timeout=REGISTRATION_JOIN_TIMEOUT)
+                # Off the event loop: a join that waits on an in-flight
+                # call_tool POST would otherwise freeze signal handling for
+                # up to the timeout (#112 invariant, shutdown edition)
+                await anyio.to_thread.run_sync(
+                    functools.partial(registration_thread.join, REGISTRATION_JOIN_TIMEOUT)
+                )
 
     def process(body: bytes, signature: str | None) -> tuple[dict, int]:
         """Sync webhook handling (runs in a worker thread - the file appends
@@ -748,6 +764,15 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         logger.warning(
             f"Hook URL advertises port {hook_port} but the listener binds {config.port} - "
             "correct only if something forwards between them"
+        )
+    # POST /hook is the only route this listener serves; any other
+    # advertised path 404s every dispatch. Legitimate behind a rewriting
+    # proxy, so warn-don't-refuse like the port mismatch above.
+    hook_path = urllib.parse.urlsplit(bridge_hook_url(config)).path
+    if hook_path != "/hook":
+        logger.warning(
+            f"Hook URL path {hook_path!r} isn't /hook (the only route this "
+            "listener serves) - correct only if something rewrites between them"
         )
     # Fourth quadrant: a non-loopback bind under a loopback hook URL means
     # the bridge advertises 127.0.0.1 while nothing listens there - every

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -119,10 +119,13 @@ MAX_BODY_BYTES = 1_048_576  # 1 MiB
 
 # panes.json is a small {session_id: pane_id} map maintained by an external
 # component, read on the delivery path for every tmux-backend DM. Bound the
-# read so a runaway or malicious file can't pull unbounded bytes into memory
+# read so a runaway or malicious file can't pull unbounded data into memory
 # per DM (a real mapping is orders of magnitude smaller); a truncated read
-# is almost certainly invalid JSON and lands on the unparseable arm.
-MAX_PANES_BYTES = 262_144  # 256 KiB
+# is almost certainly invalid JSON and lands on the unparseable arm. This is
+# a CHARACTER cap - the read is text-mode UTF-8, so the bytes pulled off disk
+# are up to ~4x this for multibyte content (~1 MiB here), still bounded and
+# still far above any real mapping.
+MAX_PANES_CHARS = 262_144  # 256 Ki characters
 
 # Bound the wait for the per-session spool flock. The drain contract keeps
 # the drainer's hold down to a couple of renames, so seconds of contention
@@ -622,11 +625,11 @@ class Injector:
             #    daemon no LC_ALL/LANG, glibc resolves C -> ASCII, and a
             #    healthy file with any byte >0x7f would wrongly hit the
             #    unparseable arm. The writer contract (guide) says UTF-8.
-            #  - read(MAX_PANES_BYTES): bound the per-DM buffer against a
+            #  - read(MAX_PANES_CHARS): bound the per-DM buffer against a
             #    runaway file; a truncated read is invalid JSON -> unparseable.
             fd = os.open(panes_file, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
             with os.fdopen(fd, encoding="utf-8") as f:
-                panes = json.loads(f.read(MAX_PANES_BYTES))
+                panes = json.loads(f.read(MAX_PANES_CHARS))
         except FileNotFoundError:
             # A missing file IS this session's absent read: clear the
             # file-level keys AND this session's entry key, matching the

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -923,16 +923,21 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             "correct only if something forwards between them"
         )
     # The listener only ever speaks plain HTTP (uvicorn.run gets no TLS
-    # config), so an https hook URL needs a terminator in front - and a
+    # config), so an https hook URL needs a terminator in front. A SAME-BOX
     # terminator fronts one port while forwarding to another, so https with
-    # the ports AGREEING is precisely the no-terminator shape: every
-    # dispatch dies in the TLS handshake with every other guard quiet. The
-    # mismatched-port terminator shape is already named by the check above.
+    # the ports agreeing usually means no terminator exists - every dispatch
+    # dies in the TLS handshake with every other guard quiet. An OFF-HOST
+    # terminator (an LB at the same port number, forwarding here) is the
+    # legitimate shape the warning text names; it can't be told apart
+    # locally - the bind is a wildcard in the common case, and hook
+    # hostnames don't compare against bind addresses - so warn-don't-refuse
+    # like the port and path mismatches. The mismatched-port terminator
+    # shape is already named by the check above.
     if hook_split.scheme == "https" and hook_port == config.port:
         logger.warning(
             f"Hook URL {bridge_hook_url(config)} is https but this listener serves "
             "plain HTTP on that same port - correct only if a TLS terminator "
-            "forwards between them"
+            "(e.g. an off-host proxy) forwards between them"
         )
     # POST /hook is the only route this listener serves; any other
     # advertised path 404s every dispatch. Legitimate behind a rewriting

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -138,13 +138,16 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
     )
 
 
-# Session ids are UUIDs (36 chars) or display ids ("brave-trex"); nothing
-# else. The channel string is publisher-controlled wire input and the id
-# becomes a spool filename, so path separators, "..", and any other
-# unexpected byte must never reach the filesystem - the bus warns on
-# malformed channels but does not reject them. The length bound keeps a
-# too-long name from turning into an unretryable OSError out of the spool
-# open (and caps spool-file blast radius).
+# PATH SAFETY, not addressability: the channel string is
+# publisher-controlled wire input and the id becomes a spool filename, so
+# path separators, "..", and any other unexpected byte must never reach
+# the filesystem - the bus warns on malformed channels but does not reject
+# them. The length bound keeps a too-long name from turning into an
+# unretryable OSError out of the spool open (and caps spool-file blast
+# radius). The charset happens to cover display ids ("brave-trex") as well
+# as the UUIDs sessions are actually addressed by - but the bus resolves
+# DMs by session_id only (display_id is display-only bus-wide), so a
+# session:<display-id> DM spools to a file no drain hook will ever read.
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 # The unsafe-id rejection below is publisher-drivable (the bus warns on

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -103,24 +103,41 @@ class Injector:
 
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken:
-        "tmux", "spool", or "spool-cooldown"."""
-        self._spool(session_id, event)
+        "tmux", "spool", or "spool-cooldown".
 
+        The cooldown bounds successful injections only: spool writes are
+        durable bookkeeping, not wakes, and a failed tmux attempt must not
+        burn the window - the next event should retry (e.g. after a
+        SessionStart hook repairs the pane mapping).
+        """
         with self._lock:
-            now = time.monotonic()
-            last = self._last_wake.get(session_id)
-            if last is not None and (now - last) < self.config.cooldown_seconds:
-                # Spooled above; the previous wake-up covers it
-                return "spool-cooldown"
-            self._last_wake[session_id] = now
+            # Locked append: concurrent webhook deliveries would otherwise
+            # interleave buffered writes and tear a JSON line
+            self._spool(session_id, event)
 
-        if self.config.backend == "tmux" and self._tmux_wake(session_id):
+            if self.config.backend != "tmux":
+                return "spool"
+
+            last = self._last_wake.get(session_id)
+            if last is not None and (time.monotonic() - last) < self.config.cooldown_seconds:
+                return "spool-cooldown"
+
+        # tmux runs outside the lock (bounded at 5s, but other sessions'
+        # deliveries shouldn't wait on it)
+        if self._tmux_wake(session_id):
+            with self._lock:
+                self._last_wake[session_id] = time.monotonic()
             return "tmux"
         return "spool"
 
     def _spool(self, session_id: str, event: dict) -> None:
-        """Always-on durable path: one JSON line per event, per session."""
+        """Always-on durable path: one JSON line per event, per session.
+
+        Callers must hold self._lock. The wake dir is kept private (0o700):
+        spool files carry full event payloads.
+        """
         self.config.wake_dir.mkdir(parents=True, exist_ok=True)
+        self.config.wake_dir.chmod(0o700)
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
         with spool_file.open("a") as f:
             f.write(json.dumps(event) + "\n")
@@ -163,7 +180,7 @@ def create_bridge_app(config: BridgeConfig, injector: Injector | None = None) ->
         """Sync webhook handling (runs in a worker thread - the file appends
         and tmux subprocess must stay off the event loop, same invariant as
         the bus server's #112 fix)."""
-        if config.secret is not None and not verify_signature(body, signature, config.secret):
+        if config.secret and not verify_signature(body, signature, config.secret):
             return {"error": "bad signature"}, 401
 
         try:
@@ -202,12 +219,33 @@ def create_bridge_app(config: BridgeConfig, injector: Injector | None = None) ->
     )
 
 
+def bridge_hook_url(config: BridgeConfig) -> str:
+    return f"http://127.0.0.1:{config.port}/hook"
+
+
 def register_with_bus(config: BridgeConfig) -> int | None:
-    """Register this bridge's webhook on the bus. Returns webhook_id."""
+    """Register this bridge's webhook on the bus. Returns webhook_id.
+
+    Idempotent: an unclean exit (SIGKILL, crash, reboot) skips main()'s
+    finally, leaving a stale active webhook at this URL - and the bus neither
+    dedupes by URL nor deactivates failing hooks, so each stale row would
+    duplicate every wake. Remove matching URLs before registering.
+    """
+    hook_url = bridge_hook_url(config)
+
+    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
+    if isinstance(existing, list):
+        for wh in existing:
+            if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
+                call_tool(
+                    "unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url
+                )
+                logger.info(f"Removed stale bridge webhook #{wh['webhook_id']}")
+
     result = call_tool(
         "register_webhook",
         {
-            "url": f"http://127.0.0.1:{config.port}/hook",
+            "url": hook_url,
             # No server-side filter: payloads carry the derived signal_level,
             # and the bridge filters to actionable locally. (Webhook filters
             # only cover channel/event_types; "actionable" spans both DMs and
@@ -260,6 +298,12 @@ def main():
         default=float(os.environ.get("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", DEFAULT_COOLDOWN_SECONDS)),
         help="Minimum seconds between wakes per session (loop prevention)",
     )
+    parser.add_argument(
+        "--wake-dir",
+        type=Path,
+        default=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
+        help="Directory for spool files and panes.json",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -268,9 +312,13 @@ def main():
         bus_url=args.bus_url,
         port=args.port,
         backend=args.backend,
-        secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET"),
+        # `or None`: an accidentally empty env var must not put registration
+        # (which would skip the secret, so unsigned payloads) and verification
+        # (which would demand signatures) on opposite sides - that 401s every
+        # delivery silently
+        secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
         cooldown_seconds=args.cooldown,
-        wake_dir=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
+        wake_dir=args.wake_dir,
     )
 
     webhook_id = register_with_bus(config)

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -59,8 +59,12 @@ DEFAULT_COOLDOWN_SECONDS = 30.0
 DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wake"
 
 # tmux send-keys is bounded like the notifier subprocesses in helpers.py -
-# a hung tmux must not wedge the bridge
-TMUX_TIMEOUT = 5.0
+# a hung tmux must not wedge the bridge. Sized under the bus's
+# WEBHOOK_TIMEOUT (5s per attempt, server.py): the bus's clock starts
+# before ours, so a bound at or above its timeout means the bus never
+# sees the response this bound exists to produce - just a timeout plus
+# retries (and a duplicate spool line per retry).
+TMUX_TIMEOUT = 2.0
 
 # Bound on joining the registration thread at shutdown. register_with_bus
 # makes up to three sequential call_tool requests (list, unregister stale,
@@ -77,8 +81,11 @@ MAX_BODY_BYTES = 1_048_576  # 1 MiB
 # means a stuck drainer (SIGSTOP, network mount) - and an unbounded block
 # here parks a threadpool worker per pending event until /hook starves.
 # Raising after the deadline is correct: nothing is durably stored yet, so
-# the bus retry is meaningful (unlike post-spool errors).
-SPOOL_LOCK_ATTEMPTS = 50
+# the bus retry is meaningful (unlike post-spool errors). Like TMUX_TIMEOUT,
+# the deadline (attempts x retry) must stay under the bus's WEBHOOK_TIMEOUT
+# (5s per attempt) - and their SUM must too, or a slow-lock-then-slow-tmux
+# request times out bus-side even though each bound individually held.
+SPOOL_LOCK_ATTEMPTS = 20
 SPOOL_LOCK_RETRY_SECONDS = 0.1
 
 # Must stay a fixed multi-word constant: the send-keys call passes it as
@@ -324,10 +331,16 @@ def create_bridge_app(
                 daemon=True,
             )
             registration_thread.start()
-        yield
-        if registration_thread is not None:
-            registration_stop.set()
-            registration_thread.join(timeout=REGISTRATION_JOIN_TIMEOUT)
+        # try/finally: a cancelled or erroring lifespan (forced shutdown,
+        # timeout_graceful_shutdown) is thrown in AT the yield - without the
+        # guard the stop-and-join is skipped and the row leaks exactly the
+        # way the join was added to prevent
+        try:
+            yield
+        finally:
+            if registration_thread is not None:
+                registration_stop.set()
+                registration_thread.join(timeout=REGISTRATION_JOIN_TIMEOUT)
 
     def process(body: bytes, signature: str | None) -> tuple[dict, int]:
         """Sync webhook handling (runs in a worker thread - the file appends
@@ -340,14 +353,16 @@ def create_bridge_app(
             event = json.loads(body)
         # ValueError, not just JSONDecodeError: json.loads(bytes) DECODES
         # before parsing, and invalid UTF-8 raises UnicodeDecodeError (a
-        # ValueError but not a JSONDecodeError) - it must be a 400, not a
-        # 500 with bus retries behind it
+        # ValueError but not a JSONDecodeError). The bus retries any >=400
+        # identically, so a 400 buys a clean named error in both logs
+        # instead of a traceback per attempt - not fewer retries.
         except ValueError:
             return {"error": "invalid JSON"}, 400
         if not isinstance(event, dict):
-            # Valid JSON that isn't an object (123, [], "x") must be a 400,
-            # not an AttributeError-turned-500 - this endpoint is network
-            # reachable, more so once it binds beyond loopback
+            # Valid JSON that isn't an object (123, [], "x"): a named 400,
+            # not an AttributeError traceback (retried by the bus either
+            # way) - this endpoint is network reachable, more so once it
+            # binds beyond loopback
             return {"error": "expected a JSON object"}, 400
 
         # The bus always sends the derived signal_level; only actionable

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -155,7 +155,9 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
 # radius). The charset happens to cover display ids ("brave-trex") as well
 # as the UUIDs sessions are actually addressed by - but the bus resolves
 # DMs by session_id only (display_id is display-only bus-wide), so a
-# session:<display-id> DM spools to a file no drain hook will ever read.
+# session:<display-id> DM (actionable by default - an explicit lower
+# signal_level is filtered before spooling) lands in a file no drain hook
+# will ever read.
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 # The unsafe-id rejection below is publisher-drivable (the bus warns on
@@ -449,6 +451,16 @@ def create_bridge_app(
     removes it; any embedding (uvicorn --factory, an ASGI mount) gets clean
     shutdown without needing a main()-style finally of its own.
     """
+    # A half-wired pair would bind and serve /health but never register,
+    # with nothing logged and registered:false forever - the silent failure
+    # mode the lifespan wiring exists to prevent, reachable through the
+    # embedding surface this docstring advertises. main() always passes
+    # both, so a partial call is unambiguously a programming error.
+    if (registration_state is None) != (registration_stop is None):
+        raise ValueError(
+            "registration_state and registration_stop come as a pair - "
+            "pass both to enable bus registration, or neither"
+        )
     injector = Injector(config)
     registration_thread: threading.Thread | None = None
 
@@ -1084,7 +1096,7 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         hook_family == 4
         and bind_ip is not None
         and bind_ip.version == 6
-        and not bind_ip.is_unspecified
+        and not _is_host_wildcard(bind_host(config))
     ):
         logger.warning(
             f"Hook URL host is an IPv4 address but the listener binds "

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -61,9 +61,11 @@ DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wa
 # a hung tmux must not wedge the bridge
 TMUX_TIMEOUT = 5.0
 
-# Bound on joining the registration thread at shutdown: long enough for an
-# in-flight register call to commit, short enough not to hang exit
-REGISTRATION_JOIN_TIMEOUT = 10.0
+# Bound on joining the registration thread at shutdown. register_with_bus
+# makes up to three sequential call_tool requests (list, unregister stale,
+# register), each under the CLI's 10s timeout - so cover the worst-case
+# chain. A still-slower bus can leak a row; the startup dedupe reclaims it.
+REGISTRATION_JOIN_TIMEOUT = 35.0
 
 # Real bus payloads are a few KB; the body must be read before the HMAC can
 # be checked, so bound what an unauthenticated peer can make us buffer
@@ -120,8 +122,11 @@ def resolve_target_session(event: dict) -> str | None:
     events (help_needed on a repo channel, ...) have no single target and
     are left for normal polling.
     """
-    channel = event.get("channel") or ""
-    if not channel.startswith("session:"):
+    # channel is a field inside a wire-supplied object - a non-string value
+    # (123, true, a list) must resolve to no target, not raise .startswith
+    # into a 500 with bus retries behind it
+    channel = event.get("channel")
+    if not isinstance(channel, str) or not channel.startswith("session:"):
         return None
     target = channel.split(":", 1)[1]
     if not SESSION_ID_PATTERN.fullmatch(target):
@@ -153,14 +158,17 @@ class Injector:
         burn the window - the next event should retry (e.g. after a
         SessionStart hook repairs the pane mapping).
         """
+        # The per-session flock inside _spool serializes appends on its own
+        # (flock contends per open file description, in-process included),
+        # and it can block on an external drainer holding the drain lock -
+        # so it must NOT run under the global lock, or one stalled drain
+        # would stall every session's delivery
+        self._spool(session_id, event)
+
+        if self.config.backend != "tmux":
+            return "spool"
+
         with self._lock:
-            # Locked append: concurrent webhook deliveries would otherwise
-            # interleave buffered writes and tear a JSON line
-            self._spool(session_id, event)
-
-            if self.config.backend != "tmux":
-                return "spool"
-
             now = time.monotonic()
             # Housekeeping: entries past the cooldown can never gate a wake
             # again, and sessions are ephemeral - don't retain them forever
@@ -193,7 +201,8 @@ class Injector:
     def _spool(self, session_id: str, event: dict) -> None:
         """Always-on durable path: one JSON line per event, per session.
 
-        Callers must hold self._lock.
+        Serialized by the per-session flock below - against other threads in
+        this process and against the drain hook alike.
         """
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
         # Defense in depth behind resolve_target_session's charset check: a
@@ -584,13 +593,16 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # Same check for the hook URL - it is what BOTH topology guards below
     # read: a scheme-less value parses to hostname None, reads as loopback,
     # skips the guards, and registers a URL the bus can never POST to
-    if config.hook_url is not None and (
-        urllib.parse.urlsplit(config.hook_url).scheme not in ("http", "https")
-    ):
-        raise SystemExit(
-            f"Invalid hook URL {config.hook_url!r} "
-            "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): expected http:// or https://"
-        )
+    if config.hook_url is not None:
+        parsed_hook = urllib.parse.urlsplit(config.hook_url)
+        # Require a hostname too: "http:///hook" parses to hostname None,
+        # which reads as loopback and would skip every topology guard
+        if parsed_hook.scheme not in ("http", "https") or not parsed_hook.hostname:
+            raise SystemExit(
+                f"Invalid hook URL {config.hook_url!r} "
+                "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): "
+                "expected http(s)://host[:port]/path"
+            )
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
     # delivered - and every machine would claim the same URL string, so the

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -210,10 +210,14 @@ class Injector:
         self.config = config
         self._lock = threading.Lock()
         self._last_wake: dict[str, float] = {}
-        # Last panes.json failure REASON warned about (not the message - a
-        # torn write varies its parse position per read), for the warn-once
-        # guard below
-        self._last_panes_warn_reason: str | None = None
+        # Armed panes.json warning KEYS (not messages - a torn write varies
+        # its parse position per read). A set, not a single slot: the
+        # file-level conditions and each session's bad-entry condition are
+        # independent, and a single slot would let a healthy read for one
+        # session re-arm another's warning - interleaved deliveries (the
+        # NORMAL multi-machine steady state, where most DMs are unmapped)
+        # would oscillate that into one WARNING per DM.
+        self._warned_panes_keys: set[str] = set()
         # Same idea for tmux wake failures, its own slot (the conditions
         # are independent): a missing/broken tmux binary fails every wake
         # with the same exception type forever, and per-DM WARNING for a
@@ -237,9 +241,10 @@ class Injector:
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken: "tmux",
         "spool" (spool backend working as designed), "spool-cooldown",
-        "spool-unmapped" (tmux backend, no pane mapping - the NORMAL outcome
-        for a session on another machine, since webhooks have no machine
-        scoping), or "spool-tmux-failed" (tmux backend, the send-keys
+        "spool-unmapped" (tmux backend, no USABLE pane mapping: absent -
+        the NORMAL outcome for a session on another machine, since webhooks
+        have no machine scoping - or present but not a pane id, which
+        warns), or "spool-tmux-failed" (tmux backend, the send-keys
         attempt itself failed - the arm that means tmux on this box is
         broken). The action value is in-band for a direct caller of /hook
         only - the bus discards the response body - so operator-facing
@@ -389,7 +394,7 @@ class Injector:
         try:
             panes = json.loads(panes_file.read_text())
         except FileNotFoundError:
-            self._last_panes_warn_reason = None  # normal unmapped state re-arms
+            self._disarm_file_keys()  # normal unmapped state re-arms
             return None
         except ValueError as e:
             # Parse failures (JSONDecodeError, UnicodeDecodeError from a
@@ -414,48 +419,60 @@ class Injector:
                 "not-an-object", "panes.json is not an object; treating as unmapped"
             )
             return None
+        self._disarm_file_keys()  # the FILE parsed - file-level conditions cleared
         # Membership, not .get(): a JSON null value and an absent key both
         # come back None from .get(), and null is the LIKELIEST bad value in
         # practice (panes[sid] = os.environ.get("TMUX_PANE") emits exactly
         # that outside tmux) - it must land in the bad-value arm below, not
         # read as healthy-absent and re-arm the guard
+        entry_key = f"bad-pane-value:{session_id}"
         if session_id not in panes:
-            self._last_panes_warn_reason = None  # genuinely absent - re-arms
+            # Genuinely absent re-arms THIS session's entry condition only -
+            # discarding more would let the (normal) unmapped arm re-arm a
+            # different session's warning and oscillate the bound
+            self._warned_panes_keys.discard(entry_key)
             return None
         pane = panes[session_id]
         if not (isinstance(pane, str) and pane):
             # Present but wrong-typed (0 instead of "%0", "", null): a
             # misconfiguration whose repair is nothing like "the mapping is
             # absent", so it must not fold into the unmapped debug line.
-            # Same bound as the file failures - and the re-arm deliberately
-            # does NOT run before this check, or every delivery would
-            # re-arm-then-warn.
+            # Keyed per session: the condition is per entry, unlike the
+            # file-level failures above.
             self._warn_panes_once(
-                "bad-pane-value",
+                entry_key,
                 f"panes.json entry for {session_id[:8]}... is not a pane id "
                 f"({pane!r}); treating as unmapped",
             )
             return None
-        self._last_panes_warn_reason = None  # healthy read re-arms the warning
+        self._warned_panes_keys.discard(entry_key)  # healthy entry re-arms it
         return pane
 
-    def _warn_panes_once(self, reason: str, message: str) -> None:
+    _PANES_FILE_KEYS = frozenset({"unparseable", "unreadable", "not-an-object"})
+
+    def _disarm_file_keys(self) -> None:
+        """A healthy file read (or the normal missing-file state) clears the
+        file-level conditions - and ONLY those; per-entry keys are cleared
+        by their own session's healthy or absent reads."""
+        self._warned_panes_keys -= self._PANES_FILE_KEYS
+
+    def _warn_panes_once(self, key: str, message: str) -> None:
         """A persistently broken panes.json must not emit one WARNING per
         delivered DM - the same unbounded-volume shape as the unsafe-channel
         warning, driven by DM rate against a stuck local condition instead
-        of a hostile publisher. Keyed on the REASON, not the message: the
-        message embeds str(e), and a torn non-atomic write yields a
-        different parse position on every read - message-keyed dedupe would
-        warn once per delivery, the value-keyed defect in local-file form.
-        The full exception text still reaches the log on the first sighting
-        (and every repeat at debug under DEV_MODE). Warn on the first
-        sighting of each distinct reason, debug repeats; a healthy read (or
-        the file going away) re-arms it, so a NEW breakage always warns.
+        of a hostile publisher. Keyed, not message-matched: the message
+        embeds str(e), and a torn non-atomic write yields a different parse
+        position on every read. Armed keys live in a SET so independent
+        conditions bound independently - file-level keys are cleared by a
+        healthy file read, per-entry keys by that session's own healthy or
+        absent read; a single slot would oscillate under interleaved
+        deliveries. The full exception text still reaches the log on the
+        first sighting (and every repeat at debug under DEV_MODE).
         Unlocked - a rare race just duplicates a warning."""
-        if reason == self._last_panes_warn_reason:
+        if key in self._warned_panes_keys:
             logger.debug(message)
         else:
-            self._last_panes_warn_reason = reason
+            self._warned_panes_keys.add(key)
             logger.warning(message)
 
     def _tmux_wake(self, session_id: str, pane: str) -> bool:

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -167,7 +167,11 @@ SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 # instead: at most one WARNING per interval regardless of content, repeats
 # at debug (DEV_MODE surfaces every offending string). A persistent
 # condition re-warns each interval instead of going dark forever. Unlocked -
-# a rare race just duplicates a warning.
+# a rare race just duplicates a warning. Deliberately PROCESS-WIDE module
+# state, unlike the per-Injector panes guard: resolve_target_session is a
+# module function that runs before any Injector exists, and the log the
+# bound protects is per-process anyway. (Two apps mounted in one process
+# therefore share the window - acceptable for v1.)
 _UNSAFE_WARN_INTERVAL_SECONDS = 60.0
 _unsafe_warn_state = {"last": -math.inf}
 
@@ -391,10 +395,15 @@ class Injector:
                 "not-an-object", "panes.json is not an object; treating as unmapped"
             )
             return None
-        pane = panes.get(session_id)
-        if pane is None:
-            self._last_panes_warn_reason = None  # healthy read re-arms the warning
+        # Membership, not .get(): a JSON null value and an absent key both
+        # come back None from .get(), and null is the LIKELIEST bad value in
+        # practice (panes[sid] = os.environ.get("TMUX_PANE") emits exactly
+        # that outside tmux) - it must land in the bad-value arm below, not
+        # read as healthy-absent and re-arm the guard
+        if session_id not in panes:
+            self._last_panes_warn_reason = None  # genuinely absent - re-arms
             return None
+        pane = panes[session_id]
         if not (isinstance(pane, str) and pane):
             # Present but wrong-typed (0 instead of "%0", "", null): a
             # misconfiguration whose repair is nothing like "the mapping is
@@ -962,15 +971,19 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
                 "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): "
                 "expected http(s)://host[:port]/path"
             )
+    # One derivation for the whole topology block below: every guard
+    # reasons about the same (hook URL, effective bind) pair, and nothing
+    # in between mutates config. `bind` is hoisted after --bind validation.
+    hook = bridge_hook_url(config)
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
     # delivered - and every machine would claim the same URL string, so the
     # startup dedupe could remove a live webhook belonging to the bus host.
     # Refuse the combination instead of failing silently.
-    if not _is_loopback(config.bus_url) and _is_loopback(bridge_hook_url(config)):
+    if not _is_loopback(config.bus_url) and _is_loopback(hook):
         raise SystemExit(
             f"Bus at {config.bus_url} is remote but the advertised hook URL "
-            f"{bridge_hook_url(config)} is loopback - the bus would POST to itself. "
+            f"{hook} is loopback - the bus would POST to itself. "
             "Set --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL to an address the bus "
             "host can reach (and set AGENT_EVENT_BUS_BRIDGE_SECRET). If the bus is "
             "on THIS machine, address it as 127.0.0.1 or localhost - a hostname "
@@ -988,6 +1001,7 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
                     f"Invalid bind address {config.bind!r} "
                     "(check --bind / AGENT_EVENT_BUS_BRIDGE_BIND): expected an IP address"
                 ) from None
+    bind = bind_host(config)
     # The HMAC is the only authentication once the endpoint is reachable
     # off-box, and exposure is decided by the EFFECTIVE bind (bind_host
     # consults --bind first) as well as the hook URL: a non-loopback bind
@@ -996,11 +1010,11 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # URL means the hop exists even behind a local TLS terminator. Hard
     # requirement either way - the bus itself defaults to auth-required,
     # and the bridge must not invert that.
-    exposed = not _is_host_loopback(bind_host(config)) or not _is_loopback(bridge_hook_url(config))
+    exposed = not _is_host_loopback(bind) or not _is_loopback(hook)
     if exposed and not config.secret:
         raise SystemExit(
-            f"Listener would bind {bind_host(config)} with hook URL "
-            f"{bridge_hook_url(config)} - reachable off-box, so set "
+            f"Listener would bind {bind} with hook URL "
+            f"{hook} - reachable off-box, so set "
             "AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
             "authentication on this hop). Check --bind / AGENT_EVENT_BUS_BRIDGE_BIND "
             "and --hook-url."
@@ -1009,22 +1023,22 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # bind under a reachable hook URL means the bus's POSTs are refused at
     # the TCP level. Legitimate behind a same-box TLS terminator, so warn
     # rather than refuse - same policy as the port mismatch below.
-    if _is_host_loopback(bind_host(config)) and not _is_loopback(bridge_hook_url(config)):
+    if _is_host_loopback(bind) and not _is_loopback(hook):
         logger.warning(
-            f"Hook URL {bridge_hook_url(config)} is reachable but the listener binds "
-            f"{bind_host(config)} (loopback) - correct only if something forwards between them"
+            f"Hook URL {hook} is reachable but the listener binds "
+            f"{bind} (loopback) - correct only if something forwards between them"
         )
     # The bus POSTs to the hook URL's port while the listener binds --port;
     # a mismatch is legitimate behind a reverse proxy, but name it - it's
     # otherwise the same silent-inertness failure the guards above close.
     # SplitResult.port raises for a malformed port - keep that a named
     # config error like every other input.
-    hook_split = urllib.parse.urlsplit(bridge_hook_url(config))
+    hook_split = urllib.parse.urlsplit(hook)
     try:
         hook_port = hook_split.port
     except ValueError:
         raise SystemExit(
-            f"Invalid hook URL {bridge_hook_url(config)!r} "
+            f"Invalid hook URL {hook!r} "
             "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): bad port"
         ) from None
     if hook_port is None:
@@ -1051,14 +1065,14 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # shape is already named by the check above.
     if hook_split.scheme == "https" and hook_port == config.port:
         logger.warning(
-            f"Hook URL {bridge_hook_url(config)} is https but this listener serves "
+            f"Hook URL {hook} is https but this listener serves "
             "plain HTTP on that same port - correct only if a TLS terminator "
             "(e.g. an off-host proxy) forwards between them"
         )
     # POST /hook is the only route this listener serves; any other
     # advertised path 404s every dispatch. Legitimate behind a rewriting
     # proxy, so warn-don't-refuse like the port mismatch above.
-    hook_path = urllib.parse.urlsplit(bridge_hook_url(config)).path
+    hook_path = hook_split.path
     if hook_path != "/hook":
         logger.warning(
             f"Hook URL path {hook_path!r} isn't /hook (the only route this "
@@ -1069,14 +1083,10 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # every dispatch is refused at TCP. Wildcard binds are exempt: 0.0.0.0
     # and :: listen on loopback too, so that combination works exactly as
     # advertised. Same warn-don't-refuse policy as above.
-    if (
-        not _is_host_loopback(bind_host(config))
-        and not _is_host_wildcard(bind_host(config))
-        and _is_loopback(bridge_hook_url(config))
-    ):
+    if not _is_host_loopback(bind) and not _is_host_wildcard(bind) and _is_loopback(hook):
         logger.warning(
-            f"Listener binds {bind_host(config)} but the hook URL "
-            f"{bridge_hook_url(config)} advertises loopback - the bus can't reach it; "
+            f"Listener binds {bind} but the hook URL "
+            f"{hook} advertises loopback - the bus can't reach it; "
             "set --hook-url to an address on the bound interface"
         )
     # Address-family mismatch: 0.0.0.0 binds IPv4 only, so an IPv6 hook
@@ -1087,19 +1097,17 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # binds ("localhost") are exempt the other way - the resolver decides
     # their family.
     try:
-        hook_family = ipaddress.ip_address(
-            urllib.parse.urlsplit(bridge_hook_url(config)).hostname
-        ).version
+        hook_family = ipaddress.ip_address(hook_split.hostname).version
     except ValueError:
         hook_family = None  # hostname - the resolver decides its family
     try:
-        bind_ip = ipaddress.ip_address(bind_host(config))
+        bind_ip = ipaddress.ip_address(bind)
     except ValueError:
         bind_ip = None  # "localhost" - the resolver decides its family
     if hook_family == 6 and bind_ip is not None and bind_ip.version == 4:
         logger.warning(
             f"Hook URL host is an IPv6 address but the listener binds "
-            f"{bind_host(config)} (IPv4 only) - the bus can't reach it; "
+            f"{bind} (IPv4 only) - the bus can't reach it; "
             "set --bind to '::' (dual-stack) or an IPv6 address"
         )
     # The mirror direction: a v4 hook literal with a PINNED v6 bind (::1, a
@@ -1112,11 +1120,11 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         hook_family == 4
         and bind_ip is not None
         and bind_ip.version == 6
-        and not _is_host_wildcard(bind_host(config))
+        and not _is_host_wildcard(bind)
     ):
         logger.warning(
             f"Hook URL host is an IPv4 address but the listener binds "
-            f"{bind_host(config)} (IPv6 only) - the bus can't reach it; "
+            f"{bind} (IPv6 only) - the bus can't reach it; "
             "bind an IPv4 or dual-stack ('::') address, or advertise an "
             "IPv6 hook URL"
         )

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -43,6 +43,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import subprocess
 import threading
 import time
@@ -213,6 +214,11 @@ class Injector:
         # torn write varies its parse position per read), for the warn-once
         # guard below
         self._last_panes_warn_reason: str | None = None
+        # Same idea for tmux wake failures, its own slot (the conditions
+        # are independent): a missing/broken tmux binary fails every wake
+        # with the same exception type forever, and per-DM WARNING for a
+        # stuck local condition is the volume shape bounded everywhere else
+        self._last_wake_fail_reason: str | None = None
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event. The dir is
@@ -338,7 +344,20 @@ class Injector:
         # rename could slip between our open and our flush and the line would
         # land in a file the drainer already read (and will delete)
         lock_file = self.config.wake_dir / f"{session_id}.lock"
-        with lock_file.open("a") as lock_fd:
+        try:
+            lock_handle = lock_file.open("a")
+        except FileNotFoundError:
+            # The wake dir can vanish at runtime - hand-clearing spools is
+            # the documented interim workflow while pruning is a follow-up -
+            # and without recovery every later delivery 500s until restart
+            # (bus retries exhausted, wakes lost, /health still green).
+            # Recreate once and retry, keeping mkdir/chmod off the happy
+            # path; the resolve() check above already ran, so this cannot
+            # widen the path-safety surface.
+            self.config.wake_dir.mkdir(parents=True, exist_ok=True)
+            self.config.wake_dir.chmod(0o700)
+            lock_handle = lock_file.open("a")
+        with lock_handle as lock_fd:
             for _ in range(SPOOL_LOCK_ATTEMPTS):
                 try:
                     fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -449,13 +468,23 @@ class Injector:
                 timeout=TMUX_TIMEOUT,
             )
             logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
+            self._last_wake_fail_reason = None  # a working tmux re-arms
             return True
         except (subprocess.SubprocessError, OSError) as e:
             # SubprocessError covers CalledProcessError/TimeoutExpired;
             # OSError covers a missing or non-executable tmux binary. An
             # exception escaping here would 500 the webhook and make the bus
-            # retry an event that is already durably spooled (duplicate lines)
-            logger.warning(f"tmux wake failed for {session_id[:8]}... ({e}); spooled only")
+            # retry an event that is already durably spooled (duplicate
+            # lines). Bounded like the panes guard - keyed on the exception
+            # TYPE, so a persistent condition (tmux gone) warns once and
+            # then debugs, while a different failure type warns fresh.
+            reason = type(e).__name__
+            message = f"tmux wake failed for {session_id[:8]}... ({e}); spooled only"
+            if reason == self._last_wake_fail_reason:
+                logger.debug(message)
+            else:
+                self._last_wake_fail_reason = reason
+                logger.warning(message)
             return False
 
 
@@ -899,6 +928,15 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         raise SystemExit(
             f"Invalid backend {args.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
             "expected 'spool' or 'tmux'"
+        )
+    # Preflight the binary: a tmux backend on a box without tmux would
+    # degrade every wake to spool-tmux-failed for the daemon's lifetime -
+    # one startup message beats discovering it per-DM. A tmux that breaks
+    # LATER is still handled (and bounded) by the wake-failure guard.
+    if args.backend == "tmux" and shutil.which("tmux") is None:
+        raise SystemExit(
+            "Backend is tmux but no tmux binary is on PATH "
+            "(check --backend / AGENT_EVENT_BUS_BRIDGE_BACKEND)"
         )
     config = BridgeConfig(
         bus_url=args.bus_url,

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -391,9 +391,25 @@ class Injector:
                 "not-an-object", "panes.json is not an object; treating as unmapped"
             )
             return None
-        self._last_panes_warn_reason = None  # healthy read re-arms the warning
         pane = panes.get(session_id)
-        return pane if isinstance(pane, str) and pane else None
+        if pane is None:
+            self._last_panes_warn_reason = None  # healthy read re-arms the warning
+            return None
+        if not (isinstance(pane, str) and pane):
+            # Present but wrong-typed (0 instead of "%0", "", null): a
+            # misconfiguration whose repair is nothing like "the mapping is
+            # absent", so it must not fold into the unmapped debug line.
+            # Same bound as the file failures - and the re-arm deliberately
+            # does NOT run before this check, or every delivery would
+            # re-arm-then-warn.
+            self._warn_panes_once(
+                "bad-pane-value",
+                f"panes.json entry for {session_id[:8]}... is not a pane id "
+                f"({pane!r}); treating as unmapped",
+            )
+            return None
+        self._last_panes_warn_reason = None  # healthy read re-arms the warning
+        return pane
 
     def _warn_panes_once(self, reason: str, message: str) -> None:
         """A persistently broken panes.json must not emit one WARNING per

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -78,6 +78,9 @@ logger = logging.getLogger("agent-event-bus-bridge")
 DEFAULT_BRIDGE_PORT = 8082
 DEFAULT_COOLDOWN_SECONDS = 30.0
 DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wake"
+# Fixed home for the hook-URL singleton lock, independent of --wake-dir (two
+# bridges with different wake dirs but the same hook URL must still contend).
+DEFAULT_LOCK_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "bridge-locks"
 
 # tmux send-keys is bounded like the notifier subprocesses in helpers.py -
 # a hung tmux must not wedge the bridge. Sized under the bus's
@@ -781,15 +784,26 @@ def create_bridge_app(
     # exposed-listener secret requirement) must hold on this path too
     validate_config(config)
     injector = Injector(config)
-    # The /hook Host allowlist (see hook_endpoint): loopback literals plus
-    # the hook URL's hostname - exactly the names a legitimate caller can
-    # arrive under (the bus fills Host from the URL it was told to POST to;
-    # local tools use a loopback literal). urlsplit().hostname already
-    # lowercases and strips IPv6 brackets.
+    # The Host allowlist (see _HostAllowlistMiddleware): loopback literals,
+    # the hook URL's hostname, and the effective bind address - exactly the
+    # names a legitimate caller can arrive under (the bus fills Host from the
+    # URL it was told to POST to; local tools use a loopback literal; a
+    # monitoring probe may address the bound interface by IP). urlsplit()
+    # .hostname already lowercases and strips IPv6 brackets. The bind
+    # address is safe to allow: a DNS-rebinding page's Host carries the
+    # attacker hostname by construction, never the bound literal.
     hook_host = urllib.parse.urlsplit(bridge_hook_url(config)).hostname
     allowed_hook_hosts = {"127.0.0.1", "localhost", "::1"}
     if hook_host:
         allowed_hook_hosts.add(hook_host)
+    bind = bind_host(config)
+    try:
+        # Skip the wildcards (0.0.0.0 / ::): nobody probes an unspecified
+        # address, and "localhost" is already covered above.
+        if not ipaddress.ip_address(bind).is_unspecified:
+            allowed_hook_hosts.add(bind)
+    except ValueError:
+        pass  # "localhost" - already present; the resolver decides its family
     # Version-skew line bound (a closure cell: the arm lives in process(),
     # not on the injector). The condition - a bus predating derived levels -
     # is persistent and per-deployment, so it gets the same first-sighting
@@ -1527,7 +1541,8 @@ def validate_config(config: BridgeConfig) -> None:
             if config.bind not in LOOPBACK_HOSTS:
                 raise BridgeConfigError(
                     f"Invalid bind address {config.bind!r} "
-                    "(check --bind / AGENT_EVENT_BUS_BRIDGE_BIND): expected an IP address"
+                    "(check --bind / AGENT_EVENT_BUS_BRIDGE_BIND): expected an IP "
+                    "address or localhost"
                 ) from None
     bind = bind_host(config)
     # The HMAC is the only authentication once the endpoint is reachable
@@ -1735,38 +1750,70 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     return config
 
 
-def _acquire_singleton_lock(config: BridgeConfig):
-    """flock a per-wake-dir singleton so a SECOND bridge on the same wake
-    dir refuses to start before it ever touches the bus. Rationale: the
-    startup sweep removes any active webhook at this bridge's hook URL and
-    cannot tell a stale row (unclean exit) from a LIVE PEER's - so a plain
-    double-start would unregister the running bridge's webhook, register its
-    own, then fail to bind (EADDRINUSE) and unregister that on exit, leaving
-    the original bridge listening, still reporting registered:true, and deaf
-    with nothing in its own log. Failing here turns that into the
-    "already running" message a double-start should give, upstream of the
-    destructive sweep. Two bridges must not share a wake dir anyway - they'd
-    share spool and lock files. Returns the held fd; the caller keeps it for
-    the process's lifetime (the lock releases when it closes, on exit).
-
-    CLI-only: embedders own their process model. The name carries a "." so
-    it can never collide with a <session_id>.lock spool file (the id charset
-    forbids "."). O_NOFOLLOW matches the spool/lock opens (a planted symlink
-    in the wake dir is not followed)."""
-    lock_path = config.wake_dir / "bridge.singleton.lock"
+def _flock_or_exit(lock_path: Path, conflict_message: str) -> int:
+    """Take an exclusive, non-blocking advisory flock on lock_path, or
+    SystemExit(conflict_message) if another holder has it. Returns the held
+    fd - the caller keeps it for the process's lifetime (the lock releases
+    when the fd closes). O_NOFOLLOW so a symlink planted at the path is not
+    followed; the parent dir is created 0o700 first (both lock homes hold no
+    payload, but private is the right default)."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.parent.chmod(0o700)
     fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         os.close(fd)
-        raise SystemExit(
-            f"Another agent-event-bus-bridge is already running on wake dir "
-            f"{config.wake_dir} ({lock_path} is locked). Refusing to start: a "
-            "second instance would steal the running bridge's webhook "
-            "registration and leave it deaf. Stop the other instance, or run "
-            "this one with a different --wake-dir / AGENT_EVENT_BUS_WAKE_DIR."
-        ) from None
+        raise SystemExit(conflict_message) from None
     return fd
+
+
+def _acquire_singleton_locks(config: BridgeConfig) -> list[int]:
+    """Refuse a SECOND bridge that would collide on either resource a
+    running instance owns, before it ever touches the bus. Two INDEPENDENT
+    hazards, so two locks:
+
+    - HOOK URL: the startup sweep removes any active webhook at this hook
+      URL and cannot tell a stale row (unclean exit) from a LIVE PEER's, so
+      a second instance registering the same URL unregisters the first's
+      row, then fails to bind (EADDRINUSE) and unregisters its own on exit -
+      leaving the running bridge listening, reporting registered:true, and
+      deaf. This is keyed on the hook URL (not the wake dir) because that is
+      what the sweep contends on: two instances with different --wake-dir
+      and the same port still collide. The lock lives in a FIXED dir
+      independent of --wake-dir, keyed by a hash of the URL and the uid (so
+      a different user's same-URL lock - which they couldn't open under
+      0o600 anyway - never blocks this one).
+    - WAKE DIR: two bridges sharing a wake dir would interleave spool and
+      lock files regardless of their hook URLs.
+
+    Returns the held fds (both kept for the process's lifetime). CLI-only:
+    embedders own their process model. Each lock name carries a "." so it
+    can never collide with a <session_id>.lock spool file (the id charset
+    forbids ".")."""
+    hook = bridge_hook_url(config)
+    digest = hashlib.sha256(hook.encode()).hexdigest()[:16]
+    hook_lock = DEFAULT_LOCK_DIR / f"hook.{os.getuid()}.{digest}.lock"
+    wake_lock = config.wake_dir / "bridge.singleton.lock"
+    return [
+        _flock_or_exit(
+            hook_lock,
+            f"Another agent-event-bus-bridge is already registered for hook URL "
+            f"{hook} ({hook_lock} is locked). Refusing to start: a second instance "
+            "would unregister the running bridge's webhook and leave it deaf. Stop "
+            "the other instance, or give this one a distinct hook URL - a different "
+            "--port AND --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL (a different "
+            "--wake-dir alone does NOT change the hook URL, so it would not help).",
+        ),
+        _flock_or_exit(
+            wake_lock,
+            f"Another agent-event-bus-bridge is already running on wake dir "
+            f"{config.wake_dir} ({wake_lock} is locked). Refusing to start: two "
+            "bridges would interleave the same spool and lock files. Stop the other "
+            "instance, or run this one with a different --wake-dir / "
+            "AGENT_EVENT_BUS_WAKE_DIR.",
+        ),
+    ]
 
 
 def main():
@@ -1797,10 +1844,10 @@ def main():
     # After create_bridge_app (the Injector created + chmodded the wake dir)
     # and BEFORE uvicorn.run triggers the lifespan's registration sweep: a
     # second instance must refuse here, upstream of the bus mutation. Held
-    # for the whole run; released when the fd closes in the finally (process
+    # for the whole run; released when the fds close in the finally (process
     # exit in production - the finally also lets a re-entered main() in the
     # same process, e.g. tests, re-acquire).
-    singleton_fd = _acquire_singleton_lock(config)
+    singleton_fds = _acquire_singleton_locks(config)
     try:
         uvicorn.run(app, host=bind_host(config), port=config.port)
     finally:
@@ -1810,7 +1857,8 @@ def main():
         stop.set()
         if state.get("webhook_id") is not None:
             unregister_from_bus(config, state["webhook_id"])
-        os.close(singleton_fd)  # release the singleton lock
+        for fd in singleton_fds:
+            os.close(fd)  # release the singleton locks
 
 
 if __name__ == "__main__":

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -124,6 +124,14 @@ class BridgeConfig:
     bind: str | None = None
 
 
+def _now() -> float:
+    """Monotonic-clock seam: tests freeze THIS, not time.monotonic itself -
+    patching the stdlib module attribute would freeze the clock for every
+    caller in the process (portal threads included), not just the code
+    under test."""
+    return time.monotonic()
+
+
 def verify_signature(body: bytes, signature_header: str | None, secret: str) -> bool:
     """Check the bus's X-Event-Bus-Signature HMAC against the raw body."""
     if not signature_header or not signature_header.startswith("sha256="):
@@ -178,7 +186,7 @@ def resolve_target_session(event: dict) -> str | None:
         return None
     target = channel.split(":", 1)[1]
     if not SESSION_ID_PATTERN.fullmatch(target):
-        now = time.monotonic()
+        now = _now()
         if now - _unsafe_warn_state["last"] >= _UNSAFE_WARN_INTERVAL_SECONDS:
             _unsafe_warn_state["last"] = now
             logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
@@ -261,7 +269,7 @@ class Injector:
             return "spool-unmapped"
 
         with self._lock:
-            now = time.monotonic()
+            now = _now()
             # Housekeeping: entries past the cooldown can never gate a wake
             # again, and sessions are ephemeral - don't retain them forever
             self._last_wake = {
@@ -619,7 +627,10 @@ def bind_host(config: BridgeConfig) -> str:
 
 def register_with_bus(config: BridgeConfig) -> int:
     """Register this bridge's webhook on the bus. Returns webhook_id;
-    raises SystemExit on any failure (bus unreachable, or no id returned).
+    raises on any failure - SystemExit for this module's own named checks
+    and for call_tool's connection-error arm, the original transport
+    exception (debug=True) for everything else. register_with_retry treats
+    both shapes as retry-with-backoff.
 
     Idempotent: an unclean exit (SIGKILL, crash, reboot) skips main()'s
     finally, leaving a stale active webhook at this URL - and the bus neither
@@ -628,7 +639,14 @@ def register_with_bus(config: BridgeConfig) -> int:
     """
     hook_url = bridge_hook_url(config)
 
-    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
+    # debug=True: call_tool would otherwise funnel every failure into a bare
+    # SystemExit(1) with the real cause printed to stderr - a stream a
+    # supervisor may discard - leaving the retry loop logging
+    # "SystemExit(1)" for a 401, timeout, and bad body alike. With the flag,
+    # those re-raise and their repr reaches the daemon's own log; the one
+    # failure still funneled into a bare exit is a connection error, which
+    # the retry loop renders as exactly that.
+    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url, debug=True)
     if not isinstance(existing, list):
         # Proceeding without the dedupe would stack the duplicate deliveries
         # this sweep exists to prevent - retryable failure, like the no-id
@@ -641,7 +659,10 @@ def register_with_bus(config: BridgeConfig) -> int:
             continue
         if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
             removal = call_tool(
-                "unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url
+                "unregister_webhook",
+                {"webhook_id": wh["webhook_id"]},
+                url=config.bus_url,
+                debug=True,
             )
             # unregister_webhook reports logical failure in-band (a
             # success-False dict) rather than raising, and call_tool only
@@ -670,6 +691,7 @@ def register_with_bus(config: BridgeConfig) -> int:
             **({"secret": config.secret} if config.secret else {}),
         },
         url=config.bus_url,
+        debug=True,
     )
     webhook_id = result.get("webhook_id") if isinstance(result, dict) else None
     if webhook_id is None:
@@ -683,10 +705,20 @@ def register_with_bus(config: BridgeConfig) -> int:
 def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
     """Best-effort webhook cleanup on shutdown."""
     try:
-        result = call_tool("unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url)
+        result = call_tool(
+            "unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url, debug=True
+        )
     except SystemExit:
-        # call_tool exits on connection errors; shutdown must not care
+        # With debug=True the only failure call_tool still funnels into
+        # SystemExit is its connection-error arm - so this log line now
+        # reports a diagnosis it actually observed
         logger.warning(f"Could not unregister webhook #{webhook_id} (bus unreachable)")
+        return
+    except Exception as e:
+        # Everything else re-raises with its cause (401, timeout, bad
+        # body); shutdown stays best-effort, but the one log line an
+        # operator has when a row leaks should carry the real reason
+        logger.warning(f"Could not unregister webhook #{webhook_id} ({e!r})")
         return
     # Same accept-shape as the startup sweep: the bus reports logical
     # failure in-band (success-False dict), and already-gone is the goal
@@ -722,12 +754,23 @@ def register_with_retry(
         try:
             state["webhook_id"] = register_with_bus(config)
             return
-        # SystemExit is call_tool's failure shape; Exception covers anything
-        # unexpected inside register_with_bus - either way the thread must
-        # back off and retry, never die silently
+        # SystemExit is call_tool's failure shape; Exception covers the
+        # transport errors debug=True re-raises and anything unexpected
+        # inside register_with_bus - either way the thread must back off
+        # and retry, never die silently
         except (SystemExit, Exception) as e:
+            # With debug=True at the call sites, a BARE SystemExit(1) means
+            # exactly one thing - call_tool's connection-error arm - so name
+            # it instead of logging "SystemExit(1)" for every cause alike
+            # (the real reason went to stderr, a stream a supervisor may
+            # discard). The bridge's own SystemExits carry their message.
+            reason = (
+                "bus unreachable (connection error)"
+                if isinstance(e, SystemExit) and e.code == 1
+                else repr(e)
+            )
             logger.warning(
-                f"Registration on {config.bus_url} failed ({e!r}); retrying in {delay:.0f}s"
+                f"Registration on {config.bus_url} failed ({reason}); retrying in {delay:.0f}s"
             )
         if stop.wait(delay):
             return

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -225,8 +225,11 @@ class Injector:
         self._last_wake_fail_reason: str | None = None
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
-        # operator isn't silently reverted on the next event. The dir is
-        # private (0o700) - spool files carry full event payloads.
+        # operator isn't silently reverted on the next event - though it IS
+        # re-asserted on the next restart (and by the self-heal path), on a
+        # directory the bridge did not necessarily create: spool files carry
+        # full event payloads, so the private mode is worth asserting every
+        # start rather than trusting whatever was there.
         try:
             self.config.wake_dir.mkdir(parents=True, exist_ok=True)
             self.config.wake_dir.chmod(0o700)

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -530,6 +530,18 @@ def _is_host_loopback(host: str) -> bool:
         return host in LOOPBACK_HOSTS
 
 
+def _is_host_wildcard(host: str) -> bool:
+    """0.0.0.0 / :: are unspecified, not loopback, to ipaddress - but a
+    wildcard bind listens on every interface INCLUDING loopback, so a
+    loopback hook URL is perfectly reachable under one. Exempt them from
+    the advertises-loopback mismatch (they still count as exposed for the
+    secret requirement - that part is genuinely true)."""
+    try:
+        return ipaddress.ip_address(host).is_unspecified
+    except ValueError:
+        return False
+
+
 def _is_loopback(url: str) -> bool:
     host = urllib.parse.urlsplit(url).hostname
     return True if host is None else _is_host_loopback(host)
@@ -680,7 +692,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="agent-event-bus re-awakening bridge (RFC #122)")
     parser.add_argument(
         "--bus-url",
-        default=os.environ.get("AGENT_EVENT_BUS_URL", DEFAULT_URL),
+        # `or`, matching every sibling: an accidentally empty export must
+        # fall back to the default, not become a refused empty URL
+        default=os.environ.get("AGENT_EVENT_BUS_URL") or DEFAULT_URL,
         help="Bus MCP endpoint to register the webhook on",
     )
     parser.add_argument(
@@ -692,7 +706,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--backend",
         choices=["spool", "tmux"],
-        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_BACKEND", "spool"),
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_BACKEND") or "spool",
         help="Wake mechanism: spool file only, or tmux send-keys + spool",
     )
     parser.add_argument(
@@ -879,10 +893,16 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Hook URL path {hook_path!r} isn't /hook (the only route this "
             "listener serves) - correct only if something rewrites between them"
         )
-    # Fourth quadrant: a non-loopback bind under a loopback hook URL means
-    # the bridge advertises 127.0.0.1 while nothing listens there - every
-    # dispatch is refused at TCP. Same warn-don't-refuse policy as above.
-    if not _is_host_loopback(bind_host(config)) and _is_loopback(bridge_hook_url(config)):
+    # Fourth quadrant: a PINNED non-loopback bind under a loopback hook URL
+    # means the bridge advertises 127.0.0.1 while nothing listens there -
+    # every dispatch is refused at TCP. Wildcard binds are exempt: 0.0.0.0
+    # and :: listen on loopback too, so that combination works exactly as
+    # advertised. Same warn-don't-refuse policy as above.
+    if (
+        not _is_host_loopback(bind_host(config))
+        and not _is_host_wildcard(bind_host(config))
+        and _is_loopback(bridge_hook_url(config))
+    ):
         logger.warning(
             f"Listener binds {bind_host(config)} but the hook URL "
             f"{bridge_hook_url(config)} advertises loopback - the bus can't reach it; "

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -185,12 +185,19 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
 # the filesystem - the bus warns on malformed channels but does not reject
 # them. The length bound keeps a too-long name from turning into an
 # unretryable OSError out of the spool open (and caps spool-file blast
-# radius). The charset happens to cover display ids ("brave-trex") as well
-# as the UUIDs sessions are actually addressed by - but the bus resolves
-# DMs by session_id only (display_id is display-only bus-wide), so a
-# session:<display-id> DM (actionable by default - an explicit lower
-# signal_level is filtered before spooling) lands in a file no drain hook
-# will ever read.
+# radius). The charset covers display ids ("brave-trex") and the UUIDs the
+# bus GENERATES - but not necessarily the id a session is addressed by: a
+# session registered with a client_id becomes that string verbatim
+# (server.py register_session sets session_id = client_id or uuid4(), and
+# nothing validates it), so a cwd- or repo:branch-derived client_id with a
+# ".", "/", space, or >64 chars gets a session_id this pattern REJECTS. A
+# DM to such a session then resolves to no target and spools nowhere, with
+# only the rate-limited "unsafe session id" WARNING below - which reads as
+# a hostile publisher, not a legitimate own registration. Loosening the
+# pattern is not the fix (the id still becomes a filename); validating
+# client_id bus-side at registration is, and belongs in its own change.
+# Same dead end round 26 documented for display_id, reached from the
+# client_id side.
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 # The unsafe-id rejection below is publisher-drivable (the bus warns on
@@ -389,6 +396,14 @@ class Injector:
 
         Serialized by the per-session flock below - against other threads in
         this process and against the drain hook alike.
+
+        A serialization failure (RecursionError out of json.dumps on a
+        pathologically nested payload - the same recursion sibling the
+        json.loads arms catch, one screen up in process()) is raised BEFORE
+        any file is created or lock taken, and process() maps it to the
+        named 400 every other wire-input path returns. Every OTHER raise
+        here is retry-meaningful: nothing is durably stored, so the bus
+        retry is real (unlike a post-spool error).
         """
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
         # Defense in depth behind resolve_target_session's charset check: a
@@ -396,6 +411,12 @@ class Injector:
         # produce a write outside the wake dir
         if spool_file.resolve().parent != self.config.wake_dir.resolve():
             raise ValueError(f"Spool path escapes wake dir: {session_id!r}")
+        # Serialize BEFORE the lock/open: json.dumps can raise RecursionError
+        # on a payload nested just under the parse limit (loads and dumps
+        # spend their recursion budgets independently, and this call sits a
+        # few frames deeper than the loads that admitted the body), and a
+        # failure must create no file and take no lock. process() catches it.
+        line = json.dumps(event) + "\n"
         # flock a sibling lock file around the append: flock contends per
         # open file description, so it serializes writers in this process and
         # the drain hook (another process) alike - without it, the drainer's
@@ -421,6 +442,18 @@ class Injector:
             # shared path, and the documented manual workflows invite a
             # later chmod on it. Create-time only; the append path pays
             # nothing once the file exists.
+            # O_NOFOLLOW covers BOTH the spool and lock opens: --wake-dir may
+            # have been group/world-writable before the daemon first ran,
+            # and Injector.__init__'s chmod narrows the dir but does not
+            # remove a pre-planted <sid>.lock / <sid>.jsonl SYMLINK already
+            # inside it - a plain open would follow it and create/open the
+            # target as the operator. The spool path's resolve() check
+            # catches its own link but is TOCTOU-racy by construction;
+            # O_NOFOLLOW is kernel-enforced at open time and guards the lock
+            # sibling (which has no resolve() check) too. Neither file is
+            # ever legitimately a symlink, so the happy path pays nothing;
+            # a symlinked final component fails ELOOP - an OSError, already
+            # the retryable arm.
             # encoding="utf-8" explicitly: fdopen(..., "a") otherwise picks
             # the locale codec (ASCII under a C-locale daemon), and the
             # spool line is a UTF-8-JSON cross-process contract the drain
@@ -429,7 +462,7 @@ class Injector:
             # ensure_ascii=False from raising UnicodeEncodeError mid-append
             # under the held flock, 500ing an already-committed delivery.
             return os.fdopen(
-                os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600),
+                os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o600),
                 "a",
                 encoding="utf-8",
             )
@@ -450,7 +483,7 @@ class Injector:
                         time.sleep(SPOOL_LOCK_RETRY_SECONDS)
                 try:
                     with _open_append_0600(spool_file) as f:
-                        f.write(json.dumps(event) + "\n")
+                        f.write(line)
                 finally:
                     fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
@@ -808,22 +841,36 @@ def create_bridge_app(
             )
             return {"status": "ignored", "reason": "no target session"}, 200
 
-        action = injector.deliver(target, event)
+        try:
+            action = injector.deliver(target, event)
+        except RecursionError:
+            # json.dumps in _spool has the same non-ValueError recursion
+            # sibling the json.loads arm above catches - and it runs a few
+            # frames deeper, so a payload nested just under the parse limit
+            # is admitted here and then fails to encode. Deterministic
+            # (all three bus retries would raise identically), so answer
+            # with the named 400 every wire-input path gives, not three
+            # tracebacks. _spool serializes before it locks, so nothing is
+            # stored and no lock is held when this fires.
+            return {"error": "invalid JSON"}, 400
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
-    async def hook_endpoint(request: Request) -> JSONResponse:
-        # Host allowlist - the half of the browser guard the Content-Type
-        # check below cannot carry: DNS rebinding makes the attacker page
-        # SAME-origin (served from evil.example:<our port>, then the A
-        # record flips to 127.0.0.1), and a same-origin POST is outside
-        # CORS entirely - no preflight, arbitrary headers, the JSON media
-        # type sent verbatim. What rebinding cannot forge is the Host
-        # header: the browser fills it from the page's URL, so a rebound
-        # request necessarily carries the attacker's hostname - never a
-        # loopback literal, never the hook URL host the bus was told to
-        # POST to. Hand-rolled rather than TrustedHostMiddleware: its
-        # host.split(":")[0] mangles bracketed IPv6 ("[::1]:8082" -> "["),
-        # and --bind ::1 is a supported shape. 421 Misdirected Request.
+    def _host_rejection(request: Request) -> JSONResponse | None:
+        # DNS-rebinding guard, shared by /hook and /health: a page served
+        # from evil.example:<our port> whose A record then flips to
+        # 127.0.0.1 is SAME-origin with the bridge, so CORS never applies -
+        # no preflight, arbitrary headers, the request reaches the handler.
+        # What rebinding cannot forge is the Host header: the browser fills
+        # it from the page's URL, so a rebound request necessarily carries
+        # the attacker's hostname, never a loopback literal or the hook URL
+        # host the bus was told to POST to. Both routes need it - /hook so
+        # the write is refused, /health so a rebound tab cannot even
+        # CONFIRM a bridge is running here (the signal that the probe is
+        # worth the round trip). A supervisor probing 127.0.0.1/health
+        # sends a loopback Host and still passes. Hand-rolled rather than
+        # TrustedHostMiddleware: its host.split(":")[0] mangles bracketed
+        # IPv6 ("[::1]:8082" -> "["), and --bind ::1 is a supported shape.
+        # 421 Misdirected Request.
         raw_host = request.headers.get("host", "")
         if raw_host.startswith("["):  # bracketed IPv6, with or without port
             host = raw_host.split("]", 1)[0].lstrip("[").lower()
@@ -831,7 +878,14 @@ def create_bridge_app(
             host = raw_host.rsplit(":", 1)[0].lower()
         if host not in allowed_hook_hosts:
             return JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
-        # The other half, for CROSS-origin pages: fetch(mode:"no-cors")
+        return None
+
+    async def hook_endpoint(request: Request) -> JSONResponse:
+        rejected = _host_rejection(request)
+        if rejected is not None:
+            return rejected
+        # The other half of the browser guard, for CROSS-origin pages:
+        # fetch(mode:"no-cors")
         # from any web page the operator has open can POST to 127.0.0.1 as
         # long as its Content-Type stays CORS-safelisted (a string body
         # defaults to text/plain) - no preflight is sent, the opaque
@@ -878,6 +932,13 @@ def create_bridge_app(
         return JSONResponse(payload, status_code=status)
 
     async def health(request: Request) -> JSONResponse:
+        # Same DNS-rebinding Host guard as /hook: a rebound tab must not
+        # even confirm a bridge runs here. A supervisor's loopback probe
+        # passes; the readiness-probe story is intact for the callers that
+        # matter.
+        rejected = _host_rejection(request)
+        if rejected is not None:
+            return rejected
         payload = {"status": "ok", "service": "agent-event-bus-bridge"}
         if registration_state is not None:
             # Registration is deliberately non-fatal, so this is the one
@@ -941,12 +1002,30 @@ def _is_loopback(url: str) -> bool:
 def bind_host(config: BridgeConfig) -> str:
     """Which interface the listener binds: --bind wins, else loopback for a
     loopback hook URL (the local bus is the sole caller), else all
-    interfaces. config_from_args requires the HMAC secret whenever the
-    effective bind OR the hook URL is non-loopback."""
+    interfaces. validate_config requires the HMAC secret whenever the
+    effective bind OR the hook URL is non-loopback - on every path, not
+    just the CLI (the refusal moved there in round 41 so it travels with a
+    hand-built config onto the embedding paths)."""
     if config.bind:
         return config.bind
-    if _is_loopback(bridge_hook_url(config)):
+    hook_host = urllib.parse.urlsplit(bridge_hook_url(config)).hostname
+    if hook_host is None:
+        # A hostless hook URL reads as loopback; validate_config refuses it
+        # upstream, so this is only reachable via a direct bind_host call
         return "127.0.0.1"
+    if _is_host_loopback(hook_host):
+        # Bind the SPECIFIC loopback address the hook URL names, not a
+        # hardcoded 127.0.0.1: loopback is all of 127.0.0.0/8 plus ::1, so
+        # a hook on 127.0.1.1 (Debian's own-hostname address), a 127.0.0.2
+        # alias, or [::1] all read as loopback here - and the old hardcode
+        # bound an interface the bus could never reach (ECONNREFUSED on
+        # every dispatch) while both sides still counted as loopback, so
+        # every exposure and topology guard stayed silent. urlsplit lowered
+        # the host and stripped IPv6 brackets, so ip_address parses it.
+        try:
+            return str(ipaddress.ip_address(hook_host))  # 127.0.1.1, ::1, ...
+        except ValueError:
+            return "127.0.0.1"  # "localhost" - no single literal to bind
     return "0.0.0.0"  # noqa: S104 - deliberate; secret enforced at config time
 
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -138,6 +138,15 @@ class BridgeConfig:
     hook_url: str | None = None
     # Interface to bind; None derives it from the hook URL (see bind_host)
     bind: str | None = None
+    # Embedder-only opt-in for the exposure invariant: under
+    # `uvicorn --factory --host ...` or an ASGI mount the HOSTING server
+    # owns the real bind - this config never sees it, so bind_host reads
+    # the (None) bind as loopback and the exposed-listener secret
+    # requirement in validate_config cannot fire. Set True when the
+    # hosting server is not loopback-only to get the same hard refusal
+    # the CLI gives a wide --bind. The CLI path never needs it: there the
+    # bridge owns the bind, so the derived check is already real.
+    assume_exposed: bool = False
 
 
 class BridgeConfigError(ValueError):
@@ -393,8 +402,18 @@ class Injector:
         # gated, so ATTEMPTS is a budget multiplier, not a literal count.)
         deadline = time.monotonic() + SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS
 
+        def _open_append_0600(path: Path):
+            # Explicit create mode, not the process umask (a plain append
+            # open would land 0o644 under the usual one): spool lines carry
+            # full publisher-authored payloads, and the directory's 0o700 is
+            # the only other guard - --wake-dir can point at a pre-existing
+            # shared path, and the documented manual workflows invite a
+            # later chmod on it. Create-time only; the append path pays
+            # nothing once the file exists.
+            return os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600), "a")
+
         def _append() -> None:
-            with lock_file.open("a") as lock_fd:
+            with _open_append_0600(lock_file) as lock_fd:
                 while True:
                     try:
                         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -408,7 +427,7 @@ class Injector:
                             ) from None
                         time.sleep(SPOOL_LOCK_RETRY_SECONDS)
                 try:
-                    with spool_file.open("a") as f:
+                    with _open_append_0600(spool_file) as f:
                         f.write(json.dumps(event) + "\n")
                 finally:
                     fcntl.flock(lock_fd, fcntl.LOCK_UN)
@@ -610,6 +629,12 @@ def create_bridge_app(
     and unregisters the committed id. The app created the row, so the app
     removes it; any embedding (uvicorn --factory, an ASGI mount) gets clean
     shutdown without needing a main()-style finally of its own.
+
+    On those embeddings the HOSTING server owns the listener's bind, which
+    validate_config cannot see - its exposure check reads the config's
+    (None) bind as loopback. When the host is not loopback-only, set
+    assume_exposed=True on the config (opts into the CLI's hard refusal)
+    or just set the secret.
     """
     # A half-wired pair would bind and serve /health but never register,
     # with nothing logged and registered:false forever - the silent failure
@@ -1015,7 +1040,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--port",
         # Raw string default, cast in config_from_args - see _to_number
         default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_PORT") or str(DEFAULT_BRIDGE_PORT),
-        help=f"Localhost port to listen on (default: {DEFAULT_BRIDGE_PORT})",
+        help=f"Port to listen on (default: {DEFAULT_BRIDGE_PORT}; see --bind for the interface)",
     )
     parser.add_argument(
         "--backend",
@@ -1060,7 +1085,13 @@ def validate_config(config: BridgeConfig) -> None:
     calls it again for embedders (uvicorn --factory, an ASGI mount) that
     build a BridgeConfig by hand and never pass through argparse - the
     security posture (an exposed listener requires the HMAC secret) must
-    travel with the config, not with the entry point. Raises
+    travel with the config, not with the entry point. One caveat travels
+    the other way: exposure is derived from bind_host(config) and the hook
+    URL, and on embedding paths the HOSTING server owns the real bind
+    (uvicorn's --host, the enclosing app's) - invisible here, so the
+    bind-derived half of the check only binds on the CLI path. Embedders
+    whose hosting server is not loopback-only must set assume_exposed=True
+    (same refusal) or just set the secret. Raises
     BridgeConfigError (a ValueError - embedder-catchable, unlike
     SystemExit); config_from_args translates it for the CLI. NORMALIZES
     port / cooldown_seconds / wake_dir on the config IN PLACE before
@@ -1182,9 +1213,20 @@ def validate_config(config: BridgeConfig) -> None:
     # attacker-authored lines to a session spool, and a non-loopback hook
     # URL means the hop exists even behind a local TLS terminator. Hard
     # requirement either way - the bus itself defaults to auth-required,
-    # and the bridge must not invert that.
-    exposed = not _is_host_loopback(bind) or not _is_loopback(hook)
+    # and the bridge must not invert that. assume_exposed ORs in because
+    # the bind-derived half only binds on the CLI path: an embedder's
+    # hosting server owns the real bind, invisibly to this check.
+    exposed = not _is_host_loopback(bind) or not _is_loopback(hook) or config.assume_exposed
     if exposed and not config.secret:
+        if config.assume_exposed and _is_host_loopback(bind) and _is_loopback(hook):
+            # Name the actual lever: the generic message below would claim
+            # a loopback bind is "reachable off-box"
+            raise BridgeConfigError(
+                "assume_exposed is set but no secret is configured - the hosting "
+                "server's listener is reachable off-box and the HMAC signature is "
+                "the only authentication on this hop. Set "
+                "AGENT_EVENT_BUS_BRIDGE_SECRET (or secret= on the config)."
+            )
         raise BridgeConfigError(
             f"Listener would bind {bind} with hook URL "
             f"{hook} - reachable off-box, so set "

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -1,0 +1,287 @@
+"""Webhook-to-injection bridge: re-awaken idle Claude Code sessions (RFC #122).
+
+EXPERIMENTAL prototype. The bus has a push subsystem (webhooks) that nothing
+consumes, while delivery to sessions is pull-only - a DM to an idle session
+sits unread until its human happens to prompt. This daemon closes the loop:
+
+    publish_event(channel="session:X", ...)
+        -> bus webhook POST -> bridge (localhost)
+        -> filter to actionable signal
+        -> inject a wake-up for session X
+
+Injection backends:
+  spool  (default) append the event as a JSON line to
+         <wake_dir>/<session_id>.jsonl - portable; a Stop/UserPromptSubmit
+         hook can drain the spool at its next opportunity
+  tmux   `tmux send-keys` a wake prompt into the session's pane, then fall
+         back to spool when no pane mapping exists. Pane mappings are read
+         from <wake_dir>/panes.json ({session_id: pane_id}), which something
+         session-side (e.g. a SessionStart hook publishing $TMUX_PANE) must
+         maintain.
+
+Loop prevention: a per-session cooldown (default 30s) bounds injections; an
+event that arrives during cooldown is spooled instead, so nothing is lost.
+
+Run:  agent-event-bus-bridge [--backend tmux] [--port 8082] ...
+The bridge registers its own webhook on the bus at startup (HMAC-signed when
+AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
+"""
+
+import argparse
+import hashlib
+import hmac
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from agent_event_bus.cli import DEFAULT_URL, call_tool
+
+logger = logging.getLogger("agent-event-bus-bridge")
+
+DEFAULT_BRIDGE_PORT = 8082
+DEFAULT_COOLDOWN_SECONDS = 30.0
+DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wake"
+
+# tmux send-keys is bounded like the notifier subprocesses in helpers.py -
+# a hung tmux must not wedge the bridge
+TMUX_TIMEOUT = 5.0
+
+WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
+
+
+@dataclass
+class BridgeConfig:
+    """Runtime configuration for the bridge daemon."""
+
+    bus_url: str = DEFAULT_URL
+    port: int = DEFAULT_BRIDGE_PORT
+    backend: str = "spool"  # "spool" | "tmux"
+    secret: str | None = None
+    cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS
+    wake_dir: Path = field(default_factory=lambda: DEFAULT_WAKE_DIR)
+
+
+def verify_signature(body: bytes, signature_header: str | None, secret: str) -> bool:
+    """Check the bus's X-Event-Bus-Signature HMAC against the raw body."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(f"sha256={expected}", signature_header)
+
+
+def resolve_target_session(event: dict) -> str | None:
+    """Which session should this event wake?
+
+    v1 wakes only for direct messages (session:<id> channels) - the
+    unambiguous "aimed at exactly this session" case. Broadcast actionable
+    events (help_needed on a repo channel, ...) have no single target and
+    are left for normal polling.
+    """
+    channel = event.get("channel") or ""
+    if channel.startswith("session:") and len(channel) > len("session:"):
+        return channel.split(":", 1)[1]
+    return None
+
+
+class Injector:
+    """Delivers wake-ups, bounded by a per-session cooldown."""
+
+    def __init__(self, config: BridgeConfig):
+        self.config = config
+        self._lock = threading.Lock()
+        self._last_wake: dict[str, float] = {}
+
+    def deliver(self, session_id: str, event: dict) -> str:
+        """Wake session_id for event. Returns the action taken:
+        "tmux", "spool", or "spool-cooldown"."""
+        self._spool(session_id, event)
+
+        with self._lock:
+            now = time.monotonic()
+            last = self._last_wake.get(session_id)
+            if last is not None and (now - last) < self.config.cooldown_seconds:
+                # Spooled above; the previous wake-up covers it
+                return "spool-cooldown"
+            self._last_wake[session_id] = now
+
+        if self.config.backend == "tmux" and self._tmux_wake(session_id):
+            return "tmux"
+        return "spool"
+
+    def _spool(self, session_id: str, event: dict) -> None:
+        """Always-on durable path: one JSON line per event, per session."""
+        self.config.wake_dir.mkdir(parents=True, exist_ok=True)
+        spool_file = self.config.wake_dir / f"{session_id}.jsonl"
+        with spool_file.open("a") as f:
+            f.write(json.dumps(event) + "\n")
+
+    def _tmux_pane(self, session_id: str) -> str | None:
+        """Look up the session's tmux pane from <wake_dir>/panes.json."""
+        panes_file = self.config.wake_dir / "panes.json"
+        try:
+            panes = json.loads(panes_file.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        pane = panes.get(session_id)
+        return pane if isinstance(pane, str) and pane else None
+
+    def _tmux_wake(self, session_id: str) -> bool:
+        """Type the wake prompt into the session's pane. False on any miss."""
+        pane = self._tmux_pane(session_id)
+        if pane is None:
+            logger.info(f"No tmux pane mapping for {session_id[:8]}...; spooled only")
+            return False
+        try:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", pane, WAKE_PROMPT, "Enter"],
+                check=True,
+                capture_output=True,
+                timeout=TMUX_TIMEOUT,
+            )
+            logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning(f"tmux wake failed for {session_id[:8]}... ({e}); spooled only")
+            return False
+
+
+def create_bridge_app(config: BridgeConfig, injector: Injector | None = None) -> Starlette:
+    """Build the ASGI app: POST /hook (webhook receiver) + GET /health."""
+    injector = injector or Injector(config)
+
+    def process(body: bytes, signature: str | None) -> tuple[dict, int]:
+        """Sync webhook handling (runs in a worker thread - the file appends
+        and tmux subprocess must stay off the event loop, same invariant as
+        the bus server's #112 fix)."""
+        if config.secret is not None and not verify_signature(body, signature, config.secret):
+            return {"error": "bad signature"}, 401
+
+        try:
+            event = json.loads(body)
+        except json.JSONDecodeError:
+            return {"error": "invalid JSON"}, 400
+
+        # The bus always sends the derived signal_level; only actionable
+        # events (DMs, help_needed, blockers, CI failures) justify a wake
+        if event.get("signal_level") != "actionable":
+            return {"status": "ignored", "reason": "below actionable"}, 200
+
+        target = resolve_target_session(event)
+        if target is None:
+            return {"status": "ignored", "reason": "no target session"}, 200
+
+        action = injector.deliver(target, event)
+        return {"status": "delivered", "action": action, "session_id": target}, 200
+
+    async def hook_endpoint(request: Request) -> JSONResponse:
+        from starlette.concurrency import run_in_threadpool
+
+        body = await request.body()
+        signature = request.headers.get("x-event-bus-signature")
+        payload, status = await run_in_threadpool(process, body, signature)
+        return JSONResponse(payload, status_code=status)
+
+    async def health(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok", "service": "agent-event-bus-bridge"})
+
+    return Starlette(
+        routes=[
+            Route("/hook", hook_endpoint, methods=["POST"]),
+            Route("/health", health, methods=["GET"]),
+        ]
+    )
+
+
+def register_with_bus(config: BridgeConfig) -> int | None:
+    """Register this bridge's webhook on the bus. Returns webhook_id."""
+    result = call_tool(
+        "register_webhook",
+        {
+            "url": f"http://127.0.0.1:{config.port}/hook",
+            # No server-side filter: payloads carry the derived signal_level,
+            # and the bridge filters to actionable locally. (Webhook filters
+            # only cover channel/event_types; "actionable" spans both DMs and
+            # specific broadcast types.)
+            **({"secret": config.secret} if config.secret else {}),
+        },
+        url=config.bus_url,
+    )
+    webhook_id = result.get("webhook_id")
+    if webhook_id is not None:
+        logger.info(f"Registered bridge webhook #{webhook_id} on {config.bus_url}")
+    return webhook_id
+
+
+def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
+    """Best-effort webhook cleanup on shutdown."""
+    try:
+        call_tool("unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url)
+        logger.info(f"Unregistered bridge webhook #{webhook_id}")
+    except SystemExit:
+        # call_tool exits on connection errors; shutdown must not care
+        logger.warning(f"Could not unregister webhook #{webhook_id} (bus unreachable)")
+
+
+def main():
+    """Run the bridge daemon."""
+    import uvicorn
+
+    parser = argparse.ArgumentParser(description="agent-event-bus re-awakening bridge (RFC #122)")
+    parser.add_argument(
+        "--bus-url",
+        default=os.environ.get("AGENT_EVENT_BUS_URL", DEFAULT_URL),
+        help="Bus MCP endpoint to register the webhook on",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("AGENT_EVENT_BUS_BRIDGE_PORT", DEFAULT_BRIDGE_PORT)),
+        help=f"Localhost port to listen on (default: {DEFAULT_BRIDGE_PORT})",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["spool", "tmux"],
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_BACKEND", "spool"),
+        help="Wake mechanism: spool file only, or tmux send-keys + spool",
+    )
+    parser.add_argument(
+        "--cooldown",
+        type=float,
+        default=float(os.environ.get("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", DEFAULT_COOLDOWN_SECONDS)),
+        help="Minimum seconds between wakes per session (loop prevention)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    config = BridgeConfig(
+        bus_url=args.bus_url,
+        port=args.port,
+        backend=args.backend,
+        secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET"),
+        cooldown_seconds=args.cooldown,
+        wake_dir=Path(os.environ.get("AGENT_EVENT_BUS_WAKE_DIR", str(DEFAULT_WAKE_DIR))),
+    )
+
+    webhook_id = register_with_bus(config)
+    try:
+        # Localhost only: the bus is the sole intended caller, and HMAC (when
+        # a secret is set) authenticates it
+        uvicorn.run(create_bridge_app(config), host="127.0.0.1", port=config.port)
+    finally:
+        if webhook_id is not None:
+            unregister_from_bus(config, webhook_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -71,6 +71,15 @@ REGISTRATION_JOIN_TIMEOUT = 35.0
 # be checked, so bound what an unauthenticated peer can make us buffer
 MAX_BODY_BYTES = 1_048_576  # 1 MiB
 
+# Bound the wait for the per-session spool flock. The drain contract keeps
+# the drainer's hold down to a couple of renames, so seconds of contention
+# means a stuck drainer (SIGSTOP, network mount) - and an unbounded block
+# here parks a threadpool worker per pending event until /hook starves.
+# Raising after the deadline is correct: nothing is durably stored yet, so
+# the bus retry is meaningful (unlike post-spool errors).
+SPOOL_LOCK_ATTEMPTS = 50
+SPOOL_LOCK_RETRY_SECONDS = 0.1
+
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
 
@@ -210,13 +219,25 @@ class Injector:
         # produce a write outside the wake dir
         if spool_file.resolve().parent != self.config.wake_dir.resolve():
             raise ValueError(f"Spool path escapes wake dir: {session_id!r}")
-        # flock a sibling lock file around the append: self._lock serializes
-        # OUR writers, but the drain hook is another process - without this,
-        # its rename could slip between our open and our flush and the line
-        # would land in a file the drainer already read (and will delete)
+        # flock a sibling lock file around the append: flock contends per
+        # open file description, so it serializes writers in this process and
+        # the drain hook (another process) alike - without it, the drainer's
+        # rename could slip between our open and our flush and the line would
+        # land in a file the drainer already read (and will delete)
         lock_file = self.config.wake_dir / f"{session_id}.lock"
         with lock_file.open("a") as lock_fd:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            for _ in range(SPOOL_LOCK_ATTEMPTS):
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    time.sleep(SPOOL_LOCK_RETRY_SECONDS)
+            else:
+                raise OSError(
+                    f"Could not lock spool for {session_id} within "
+                    f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
+                    "(stuck drainer?)"
+                )
             try:
                 with spool_file.open("a") as f:
                     f.write(json.dumps(event) + "\n")
@@ -414,6 +435,10 @@ def register_with_bus(config: BridgeConfig) -> int:
     existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
     if isinstance(existing, list):
         for wh in existing:
+            # Guard the element shape too: an AttributeError here would
+            # escape register_with_retry and kill the registration thread
+            if not isinstance(wh, dict):
+                continue
             if wh.get("url") == hook_url and wh.get("webhook_id") is not None:
                 call_tool(
                     "unregister_webhook", {"webhook_id": wh["webhook_id"]}, url=config.bus_url
@@ -472,9 +497,12 @@ def register_with_retry(
         try:
             state["webhook_id"] = register_with_bus(config)
             return
-        except SystemExit as e:
+        # SystemExit is call_tool's failure shape; Exception covers anything
+        # unexpected inside register_with_bus - either way the thread must
+        # back off and retry, never die silently
+        except (SystemExit, Exception) as e:
             logger.warning(
-                f"Registration on {config.bus_url} failed ({e}); retrying in {delay:.0f}s"
+                f"Registration on {config.bus_url} failed ({e!r}); retrying in {delay:.0f}s"
             )
         if stop.wait(delay):
             return
@@ -585,11 +613,13 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Invalid wake dir {config.wake_dir} "
             "(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): must be an absolute path"
         )
-    # A scheme-less bus URL ("bus.example:8080/mcp") parses with no hostname
-    # and would read as loopback, skipping the topology guard below - catch
-    # the misconfiguration here instead of in a later connection error
-    if urllib.parse.urlsplit(config.bus_url).scheme not in ("http", "https"):
-        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http:// or https://")
+    # A scheme-less bus URL ("bus.example:8080/mcp") or hostless one
+    # ("http:///mcp") parses with no hostname and would read as loopback,
+    # skipping the topology guard below - catch the misconfiguration here
+    # instead of in a later connection error
+    parsed_bus = urllib.parse.urlsplit(config.bus_url)
+    if parsed_bus.scheme not in ("http", "https") or not parsed_bus.hostname:
+        raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http(s)://host[:port]/path")
     # Same check for the hook URL - it is what BOTH topology guards below
     # read: a scheme-less value parses to hostname None, reads as loopback,
     # skips the guards, and registers a URL the bus can never POST to

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -58,6 +58,7 @@ from pathlib import Path
 import anyio.to_thread
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
+from starlette.middleware import Middleware
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -173,6 +174,13 @@ def _now() -> float:
     caller in the process (portal threads included), not just the code
     under test."""
     return time.monotonic()
+
+
+def _reject_json_constant(literal: str):
+    """json.loads parse_constant hook: reject NaN/Infinity/-Infinity so
+    nothing non-standard reaches a spool line. Raises ValueError, which the
+    hook's named-400 arm catches."""
+    raise ValueError(f"non-standard JSON constant {literal!r}")
 
 
 def verify_signature(body: bytes, signature_header: str | None, secret: str) -> bool:
@@ -782,7 +790,6 @@ def create_bridge_app(
     allowed_hook_hosts = {"127.0.0.1", "localhost", "::1"}
     if hook_host:
         allowed_hook_hosts.add(hook_host)
-    registration_thread: threading.Thread | None = None
     # Version-skew line bound (a closure cell: the arm lives in process(),
     # not on the injector). The condition - a bus predating derived levels -
     # is persistent and per-deployment, so it gets the same first-sighting
@@ -792,19 +799,29 @@ def create_bridge_app(
 
     @asynccontextmanager
     async def lifespan(app):
-        nonlocal registration_thread
+        # registration_thread and cycle_stop are LOCALS, deliberately not
+        # nonlocal/shared: @asynccontextmanager makes a fresh generator per
+        # startup/shutdown cycle, so each cycle gets its own stop event and
+        # thread handle. The old design cleared ONE shared event on
+        # re-entry, which could resurrect a prior cycle's thread that
+        # outlived REGISTRATION_JOIN_TIMEOUT - it would see the shared event
+        # un-set and resume its retry loop, and both threads would then
+        # register and race state["webhook_id"], leaking the loser row until
+        # a later startup sweep reclaimed it. A per-cycle event can never be
+        # un-set by a later startup.
+        registration_thread: threading.Thread | None = None
+        cycle_stop: threading.Event | None = None
         if registration_state is not None and registration_stop is not None:
-            # A re-entered lifespan must register again: the previous
-            # cycle's shutdown set() this event, and register_with_retry
-            # checks it before its first attempt - without the clear, a
-            # second cycle on the same app binds, serves /health, and never
-            # registers (the silent shape the pair check above closes for
-            # half-wired calls). main() constructs the event unset, so this
-            # is a no-op on the first cycle.
-            registration_stop.clear()
+            # The per-cycle cycle_stop is what the thread actually waits on;
+            # the caller's registration_stop is only the observable "stopped"
+            # flag (mirrored in the finally). Old code cleared the shared
+            # event on startup, so a pre-set one was already ignored - a
+            # fresh cycle here matches that while never sharing an event a
+            # stale thread could be woken through.
+            cycle_stop = threading.Event()
             registration_thread = threading.Thread(
                 target=register_with_retry,
-                args=(config, registration_state, registration_stop),
+                args=(config, registration_state, cycle_stop),
                 daemon=True,
             )
             registration_thread.start()
@@ -815,8 +832,14 @@ def create_bridge_app(
         try:
             yield
         finally:
-            if registration_thread is not None:
-                registration_stop.set()
+            if registration_thread is not None and cycle_stop is not None:
+                cycle_stop.set()
+                # Mirror onto the caller's event: the thread waits on the
+                # per-cycle cycle_stop, but registration_stop stays the
+                # observable "stopped" flag main()'s belt-and-braces finally
+                # and external code read.
+                if registration_stop is not None:
+                    registration_stop.set()
                 # Off the event loop: a join that waits on an in-flight
                 # call_tool POST would otherwise freeze signal handling for
                 # up to the timeout (#112 invariant, shutdown edition).
@@ -847,7 +870,16 @@ def create_bridge_app(
             return {"error": "bad signature"}, 401
 
         try:
-            event = json.loads(body)
+            # parse_constant rejects the non-standard NaN/Infinity/-Infinity
+            # literals json.loads accepts by DEFAULT: json.dumps would write
+            # them straight back into a spool line no other parser accepts
+            # (jq, JSON.parse, Go's encoding/json all reject them), so a
+            # contract-following drainer skips the line under its
+            # skip-unparseable rule and the wake is silently lost while the
+            # bus counted it delivered. The rejector's ValueError folds into
+            # the named-400 arm, making "everything appended is standard
+            # JSON" true by construction, not by the bus's good behavior.
+            event = json.loads(body, parse_constant=_reject_json_constant)
         # ValueError, not just JSONDecodeError: json.loads(bytes) DECODES
         # before parsing, and invalid UTF-8 raises UnicodeDecodeError (a
         # ValueError but not a JSONDecodeError). RecursionError is the
@@ -915,37 +947,10 @@ def create_bridge_app(
             return {"error": "invalid JSON"}, 400
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
-    def _host_rejection(request: Request) -> JSONResponse | None:
-        # DNS-rebinding guard, shared by /hook and /health: a page served
-        # from evil.example:<our port> whose A record then flips to
-        # 127.0.0.1 is SAME-origin with the bridge, so CORS never applies -
-        # no preflight, arbitrary headers, the request reaches the handler.
-        # What rebinding cannot forge is the Host header: the browser fills
-        # it from the page's URL, so a rebound request necessarily carries
-        # the attacker's hostname, never a loopback literal or the hook URL
-        # host the bus was told to POST to. Both routes need it - /hook so
-        # the write is refused, /health so a rebound tab cannot even
-        # CONFIRM a bridge is running here (the signal that the probe is
-        # worth the round trip). A supervisor probing 127.0.0.1/health
-        # sends a loopback Host and still passes. Hand-rolled rather than
-        # TrustedHostMiddleware: its host.split(":")[0] mangles bracketed
-        # IPv6 ("[::1]:8082" -> "["), and --bind ::1 is a supported shape.
-        # 421 Misdirected Request.
-        raw_host = request.headers.get("host", "")
-        if raw_host.startswith("["):  # bracketed IPv6, with or without port
-            host = raw_host.split("]", 1)[0].lstrip("[").lower()
-        else:
-            host = raw_host.rsplit(":", 1)[0].lower()
-        if host not in allowed_hook_hosts:
-            return JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
-        return None
-
     async def hook_endpoint(request: Request) -> JSONResponse:
-        rejected = _host_rejection(request)
-        if rejected is not None:
-            return rejected
-        # The other half of the browser guard, for CROSS-origin pages:
-        # fetch(mode:"no-cors")
+        # The Host allowlist (DNS-rebinding guard) runs in middleware ahead
+        # of routing - see _HostAllowlistMiddleware. This is the OTHER half
+        # of the browser guard, for CROSS-origin pages: fetch(mode:"no-cors")
         # from any web page the operator has open can POST to 127.0.0.1 as
         # long as its Content-Type stays CORS-safelisted (a string body
         # defaults to text/plain) - no preflight is sent, the opaque
@@ -1000,13 +1005,10 @@ def create_bridge_app(
         return JSONResponse(payload, status_code=status)
 
     async def health(request: Request) -> JSONResponse:
-        # Same DNS-rebinding Host guard as /hook: a rebound tab must not
-        # even confirm a bridge runs here. A supervisor's loopback probe
-        # passes; the readiness-probe story is intact for the callers that
-        # matter.
-        rejected = _host_rejection(request)
-        if rejected is not None:
-            return rejected
+        # The Host guard runs in middleware ahead of routing (see
+        # _HostAllowlistMiddleware), so a rebound tab cannot confirm a
+        # bridge runs here even via a 405/404. A supervisor's loopback
+        # probe passes.
         payload = {"status": "ok", "service": "agent-event-bus-bridge"}
         if registration_state is not None:
             # Registration is deliberately non-fatal, so this is the one
@@ -1020,6 +1022,9 @@ def create_bridge_app(
             Route("/hook", hook_endpoint, methods=["POST"]),
             Route("/health", health, methods=["GET"]),
         ],
+        # Ahead of the router: the Host guard must answer before a method or
+        # path mismatch (405/404) can confirm a bridge is here.
+        middleware=[Middleware(_HostAllowlistMiddleware, allowed=allowed_hook_hosts)],
         lifespan=lifespan,
     )
     # POST /hook/ must be a loud 404 (bus retries and logs it), not a 307:
@@ -1029,6 +1034,47 @@ def create_bridge_app(
     # bridge processes nothing.
     app.router.redirect_slashes = False
     return app
+
+
+def _host_from_header(raw_host: str) -> str:
+    """Strip the port from a Host header value, handling bracketed IPv6
+    ("[::1]:8082" -> "::1"). Lowercased for comparison."""
+    if raw_host.startswith("["):  # bracketed IPv6, with or without a port
+        return raw_host.split("]", 1)[0].lstrip("[").lower()
+    return raw_host.rsplit(":", 1)[0].lower()
+
+
+class _HostAllowlistMiddleware:
+    """DNS-rebinding guard applied AHEAD of routing, so it covers method and
+    path mismatches too. A page served from evil.example:<our port> whose A
+    record then flips to 127.0.0.1 is SAME-origin with the bridge, so CORS
+    never applies and the request reaches us - but the browser fills Host
+    from the page's URL, so a rebound request never carries a loopback
+    literal or the hook URL host the bus was told to POST to. Enforcing this
+    inside the endpoints (the round-57 shape) left GET /hook -> 405 and
+    /anything -> 404 answerable BEFORE the endpoint ran, and 405-vs-404 still
+    confirms a bridge is here - the exact existence signal extending the
+    guard to /health was meant to deny. As middleware it runs before the
+    router. Hand-rolled rather than TrustedHostMiddleware, whose
+    host.split(':')[0] mangles bracketed IPv6 (--bind ::1 is supported).
+    421 Misdirected Request."""
+
+    def __init__(self, app, allowed: set[str]):
+        self.app = app
+        self.allowed = allowed
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            raw_host = ""
+            for key, value in scope.get("headers") or ():
+                if key == b"host":
+                    raw_host = value.decode("latin-1")
+                    break
+            if _host_from_header(raw_host) not in self.allowed:
+                response = JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
 
 
 def bridge_hook_url(config: BridgeConfig) -> str:
@@ -1365,6 +1411,13 @@ def validate_config(config: BridgeConfig) -> None:
         (config.bus_url, "--bus-url / AGENT_EVENT_BUS_URL"),
         (config.hook_url, "--hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL"),
         (config.bind, "--bind / AGENT_EVENT_BUS_BRIDGE_BIND"),
+        # secret is truthy when bytes, so it satisfies the exposed-listener
+        # requirement and then fails at RUNTIME instead: register_with_bus'
+        # json= serialization raises TypeError (retried forever, /health
+        # registered:false), and verify_signature's secret.encode() would
+        # AttributeError into a 500. HMAC keys are conventionally bytes, so
+        # b"..." is a plausible embedder slip.
+        (config.secret, "AGENT_EVENT_BUS_BRIDGE_SECRET / secret="),
     ):
         if value is not None and not isinstance(value, str):
             raise BridgeConfigError(f"Invalid value {value!r} (check {label}): expected a string")
@@ -1682,6 +1735,40 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     return config
 
 
+def _acquire_singleton_lock(config: BridgeConfig):
+    """flock a per-wake-dir singleton so a SECOND bridge on the same wake
+    dir refuses to start before it ever touches the bus. Rationale: the
+    startup sweep removes any active webhook at this bridge's hook URL and
+    cannot tell a stale row (unclean exit) from a LIVE PEER's - so a plain
+    double-start would unregister the running bridge's webhook, register its
+    own, then fail to bind (EADDRINUSE) and unregister that on exit, leaving
+    the original bridge listening, still reporting registered:true, and deaf
+    with nothing in its own log. Failing here turns that into the
+    "already running" message a double-start should give, upstream of the
+    destructive sweep. Two bridges must not share a wake dir anyway - they'd
+    share spool and lock files. Returns the held fd; the caller keeps it for
+    the process's lifetime (the lock releases when it closes, on exit).
+
+    CLI-only: embedders own their process model. The name carries a "." so
+    it can never collide with a <session_id>.lock spool file (the id charset
+    forbids "."). O_NOFOLLOW matches the spool/lock opens (a planted symlink
+    in the wake dir is not followed)."""
+    lock_path = config.wake_dir / "bridge.singleton.lock"
+    fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        raise SystemExit(
+            f"Another agent-event-bus-bridge is already running on wake dir "
+            f"{config.wake_dir} ({lock_path} is locked). Refusing to start: a "
+            "second instance would steal the running bridge's webhook "
+            "registration and leave it deaf. Stop the other instance, or run "
+            "this one with a different --wake-dir / AGENT_EVENT_BUS_WAKE_DIR."
+        ) from None
+    return fd
+
+
 def main():
     """Run the bridge daemon."""
     import uvicorn
@@ -1707,6 +1794,13 @@ def main():
         app = create_bridge_app(config, registration_state=state, registration_stop=stop)
     except BridgeConfigError as e:
         raise SystemExit(str(e)) from None
+    # After create_bridge_app (the Injector created + chmodded the wake dir)
+    # and BEFORE uvicorn.run triggers the lifespan's registration sweep: a
+    # second instance must refuse here, upstream of the bus mutation. Held
+    # for the whole run; released when the fd closes in the finally (process
+    # exit in production - the finally also lets a re-entered main() in the
+    # same process, e.g. tests, re-acquire).
+    singleton_fd = _acquire_singleton_lock(config)
     try:
         uvicorn.run(app, host=bind_host(config), port=config.port)
     finally:
@@ -1716,6 +1810,7 @@ def main():
         stop.set()
         if state.get("webhook_id") is not None:
             unregister_from_bus(config, state["webhook_id"])
+        os.close(singleton_fd)  # release the singleton lock
 
 
 if __name__ == "__main__":

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -58,7 +58,7 @@ from pathlib import Path
 import anyio.to_thread
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
@@ -155,6 +155,16 @@ class BridgeConfigError(ValueError):
     a BaseException and would tear through that. config_from_args translates
     it into SystemExit for the CLI path, which keeps main() printing the
     message and exiting without a traceback."""
+
+
+class _UnserializablePayloadError(Exception):
+    """json.dumps hit the recursion limit encoding a pathologically nested
+    payload. Raised out of _spool BEFORE any file is created or lock taken,
+    so process() can map it to a named 400 with a STRUCTURAL guarantee that
+    nothing durable happened - rather than catching a bare RecursionError
+    around all of deliver(), which also runs the tmux steps AFTER the spool
+    line is committed (a 400 there would make the bus retry an event whose
+    line already landed, duplicating it)."""
 
 
 def _now() -> float:
@@ -399,13 +409,26 @@ class Injector:
 
         A serialization failure (RecursionError out of json.dumps on a
         pathologically nested payload - the same recursion sibling the
-        json.loads arms catch, one screen up in process()) is raised BEFORE
-        any file is created or lock taken, and process() maps it to the
-        named 400 every other wire-input path returns. Every OTHER raise
-        here is retry-meaningful: nothing is durably stored, so the bus
-        retry is real (unlike a post-spool error).
+        json.loads arms catch, one screen up in process()) is re-raised as
+        _UnserializablePayloadError BEFORE any file is created or lock taken, and
+        process() maps THAT to the named 400 every other wire-input path
+        returns. Every OTHER raise here is retry-meaningful: nothing is
+        durably stored, so the bus retry is real (unlike a post-spool error).
         """
         spool_file = self.config.wake_dir / f"{session_id}.jsonl"
+        # The id is charset-clean by here (resolve_target_session validated
+        # it), so a containment failure means a SYMLINK was planted in the
+        # wake dir, not a hostile id: name that so an operator runs `ls -l`
+        # on the wake dir instead of hunting a publisher. O_NOFOLLOW on the
+        # open below is the kernel-enforced backstop that catches the same
+        # thing at open time (ELOOP); this is the readable message, and it
+        # never follows the link. A hard raise, not a degrade: a symlink in
+        # the wake dir is local tampering that will not self-heal.
+        if spool_file.is_symlink():
+            raise ValueError(
+                f"Spool file {spool_file} is a symlink (-> {os.readlink(spool_file)!r}); "
+                "refusing to follow it - remove it from the wake dir"
+            )
         # Defense in depth behind resolve_target_session's charset check: a
         # traversal or absolute component in a wire-supplied id must never
         # produce a write outside the wake dir
@@ -415,8 +438,13 @@ class Injector:
         # on a payload nested just under the parse limit (loads and dumps
         # spend their recursion budgets independently, and this call sits a
         # few frames deeper than the loads that admitted the body), and a
-        # failure must create no file and take no lock. process() catches it.
-        line = json.dumps(event) + "\n"
+        # failure must create no file and take no lock. Re-raised as a
+        # dedicated type so process() maps ONLY the pre-durable failure to a
+        # 400 - never a post-spool error from deliver's later tmux steps.
+        try:
+            line = json.dumps(event) + "\n"
+        except RecursionError as e:
+            raise _UnserializablePayloadError from e
         # flock a sibling lock file around the append: flock contends per
         # open file description, so it serializes writers in this process and
         # the drain hook (another process) alike - without it, the drainer's
@@ -555,12 +583,24 @@ class Injector:
                 "unreadable", f"Unreadable panes.json ({e}); treating as unmapped"
             )
             return None
+        # A successful json.loads proves the READ and PARSE conditions
+        # cleared, whatever the shape below is - so clear those two keys
+        # NOW, before the shape check. Otherwise a valid-but-non-dict file
+        # (a JSON list) returns via the not-an-object arm with unparseable /
+        # unreadable still armed from an earlier condition, and a
+        # genuinely-new later parse or read failure demotes to debug -
+        # exactly the outcome the re-arm design exists to prevent. Only the
+        # read/parse keys, NOT not-an-object: that is a SHAPE condition, so
+        # clearing it here would defeat its own warn-once (it would re-warn
+        # every read of a persistently non-dict file).
+        self._warned_panes_keys -= self._PANES_READ_KEYS
         if not isinstance(panes, dict):
             self._warn_panes_once(
                 "not-an-object", "panes.json is not an object; treating as unmapped"
             )
             return None
-        self._disarm_file_keys()  # the FILE parsed - file-level conditions cleared
+        # Shape is a dict too - the last file-level condition clears
+        self._warned_panes_keys.discard("not-an-object")
         # Membership, not .get(): a JSON null value and an absent key both
         # come back None from .get(), and null is the LIKELIEST bad value in
         # practice (panes[sid] = os.environ.get("TMUX_PANE") emits exactly
@@ -597,11 +637,17 @@ class Injector:
         return pane
 
     _PANES_FILE_KEYS = frozenset({"unparseable", "unreadable", "not-an-object"})
+    # The subset a successful read+parse clears regardless of the shape it
+    # yields; not-an-object is left out because it tracks the shape, cleared
+    # only when the shape is actually a dict.
+    _PANES_READ_KEYS = frozenset({"unparseable", "unreadable"})
 
     def _disarm_file_keys(self) -> None:
-        """A healthy file read (or the normal missing-file state) clears the
-        file-level conditions - and ONLY those; per-entry keys are cleared
-        by their own session's healthy or absent reads."""
+        """The normal missing-file state clears ALL file-level conditions -
+        a delete-and-recreate is a full clean-state cycle. (A healthy read
+        clears the read/parse keys inline, and not-an-object only when the
+        shape is a dict.) Per-entry keys are cleared by their own session's
+        healthy or absent reads."""
         self._warned_panes_keys -= self._PANES_FILE_KEYS
 
     def _warn_panes_once(self, key: str, message: str) -> None:
@@ -701,6 +747,17 @@ def create_bridge_app(
     (None) bind as loopback. When the host is not loopback-only, set
     assume_exposed=True on the config (opts into the CLI's hard refusal)
     or just set the secret.
+
+    The host also owns the port and any mount prefix, and both are derived
+    from config.port into bridge_hook_url(config) - which is BOTH the URL
+    the lifespan registers on the bus AND the Host allowlist /hook and
+    /health enforce. So set hook_url whenever the hosting server's address,
+    port, or mount path differs from the derived http://127.0.0.1:<port>/hook
+    default: otherwise the bus registers and POSTs to a URL the outer app
+    404s (or nothing listens on), the Host guard rejects the real caller,
+    and /health reports registered:true forever - none of the port/path/
+    quadrant warnings fire, because those live in config_from_args, off the
+    embedding path.
     """
     # A half-wired pair would bind and serve /health but never register,
     # with nothing logged and registered:false forever - the silent failure
@@ -843,15 +900,18 @@ def create_bridge_app(
 
         try:
             action = injector.deliver(target, event)
-        except RecursionError:
+        except _UnserializablePayloadError:
             # json.dumps in _spool has the same non-ValueError recursion
             # sibling the json.loads arm above catches - and it runs a few
             # frames deeper, so a payload nested just under the parse limit
-            # is admitted here and then fails to encode. Deterministic
-            # (all three bus retries would raise identically), so answer
-            # with the named 400 every wire-input path gives, not three
-            # tracebacks. _spool serializes before it locks, so nothing is
-            # stored and no lock is held when this fires.
+            # is admitted here and then fails to encode. Deterministic (all
+            # three bus retries would raise identically), so answer with the
+            # named 400 every wire-input path gives, not three tracebacks.
+            # Catching the DEDICATED type, not a bare RecursionError around
+            # deliver: _spool raises it before it opens/locks anything, so
+            # this 400 structurally cannot fire after a spool line has
+            # landed (which would make the bus retry and duplicate it) - a
+            # RecursionError from deliver's later tmux steps stays a 500.
             return {"error": "invalid JSON"}, 400
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
@@ -916,14 +976,22 @@ def create_bridge_app(
         # Stream with a running count, not request.body(): body() concatenates
         # every chunk unconditionally, so a chunked POST (no content-length to
         # precheck) could make the daemon buffer arbitrarily many bytes before
-        # a post-read check ever ran - the bound must hold WHILE reading
+        # a post-read check ever ran - the bound must hold WHILE reading.
+        # ClientDisconnect (the peer aborts mid-body - uvicorn delivers
+        # http.disconnect) is the one wire-driven path that would otherwise
+        # escape as an unnamed 500 traceback; every sibling failure returns a
+        # named 4xx so the log carries a diagnosis, not a stack. Nothing is
+        # written and no lock is taken, so a 400 is honest.
         chunks: list[bytes] = []
         received = 0
-        async for chunk in request.stream():
-            received += len(chunk)
-            if received > MAX_BODY_BYTES:
-                return JSONResponse({"error": "body too large"}, status_code=413)
-            chunks.append(chunk)
+        try:
+            async for chunk in request.stream():
+                received += len(chunk)
+                if received > MAX_BODY_BYTES:
+                    return JSONResponse({"error": "body too large"}, status_code=413)
+                chunks.append(chunk)
+        except ClientDisconnect:
+            return JSONResponse({"error": "client disconnected mid-body"}, status_code=400)
         body = b"".join(chunks)
         # Starlette header lookup is case-insensitive, so the canonical-case
         # constant works directly
@@ -1287,6 +1355,19 @@ def validate_config(config: BridgeConfig) -> None:
             f"Invalid wake dir {config.wake_dir!r} "
             "(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): expected a filesystem path"
         ) from None
+    # The three string inputs get no numeric coercion, so a hand-built
+    # config carrying a non-str slips through until it raises a bare
+    # AttributeError out of urlsplit (bus_url, hook_url) - or, for bind,
+    # validates as a bogus address (ipaddress.ip_address(123) is 0.0.0.123)
+    # and fails only later inside uvicorn.run. Name them here like every
+    # other config error. Embedder-only: argparse hands strings.
+    for value, label in (
+        (config.bus_url, "--bus-url / AGENT_EVENT_BUS_URL"),
+        (config.hook_url, "--hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL"),
+        (config.bind, "--bind / AGENT_EVENT_BUS_BRIDGE_BIND"),
+    ):
+        if value is not None and not isinstance(value, str):
+            raise BridgeConfigError(f"Invalid value {value!r} (check {label}): expected a string")
 
     # argparse `choices` only guards command-line values, and an embedder
     # skips argparse entirely - an unknown backend would silently mean
@@ -1531,6 +1612,34 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"{hook} advertises loopback - the bus can't reach it; "
             "set --hook-url to an address on the bound interface"
         )
+    # The missing member of the quadrant family: two DIFFERENT loopback
+    # literals of the SAME family. A PINNED --bind 127.0.0.1 under a
+    # 127.0.1.1 hook URL (a 127.0.0.2 alias, ...) is all-loopback so the
+    # checks above stay quiet, same-family so the family checks below stay
+    # quiet, and exposed is False so no secret is demanded - yet the bus
+    # POSTs to an address nothing listens on (ECONNREFUSED every dispatch).
+    # A DERIVED bind can't reach this (bind_host binds the hook's own
+    # literal); only a pinned --bind contradicting the hook can. localhost
+    # is exempt on either side (no single literal to compare); the
+    # cross-family case is left to the family checks below to avoid a
+    # double warning. Warn-don't-refuse like the rest of the family.
+    if _is_host_loopback(bind) and _is_loopback(hook):
+        try:
+            bind_lit = ipaddress.ip_address(bind)
+            hook_lit = ipaddress.ip_address(hook_split.hostname)
+        except ValueError:
+            bind_lit = hook_lit = None  # "localhost" on a side - no literal
+        if (
+            bind_lit is not None
+            and hook_lit is not None
+            and bind_lit.version == hook_lit.version
+            and bind_lit != hook_lit
+        ):
+            logger.warning(
+                f"Listener binds loopback {bind} but the hook URL advertises a "
+                f"different loopback address {hook_split.hostname} - the bus "
+                "can't reach it; align --bind and --hook-url"
+            )
     # Address-family mismatch: 0.0.0.0 binds IPv4 only, so an IPv6 hook
     # literal (a Tailscale IPv6 address, say) is refused at TCP while every
     # quadrant warning above stays quiet - both sides can be non-loopback

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -64,6 +64,10 @@ TMUX_TIMEOUT = 5.0
 # in-flight register call to commit, short enough not to hang exit
 REGISTRATION_JOIN_TIMEOUT = 10.0
 
+# Real bus payloads are a few KB; the body must be read before the HMAC can
+# be checked, so bound what an unauthenticated peer can make us buffer
+MAX_BODY_BYTES = 1_048_576  # 1 MiB
+
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
 
@@ -305,7 +309,14 @@ def create_bridge_app(
     async def hook_endpoint(request: Request) -> JSONResponse:
         from starlette.concurrency import run_in_threadpool
 
+        # Precheck the honest case cheaply; the post-read check below covers
+        # a missing or lying content-length (e.g. chunked encoding)
+        content_length = request.headers.get("content-length")
+        if content_length and content_length.isdigit() and int(content_length) > MAX_BODY_BYTES:
+            return JSONResponse({"error": "body too large"}, status_code=413)
         body = await request.body()
+        if len(body) > MAX_BODY_BYTES:
+            return JSONResponse({"error": "body too large"}, status_code=413)
         signature = request.headers.get("x-event-bus-signature")
         payload, status = await run_in_threadpool(process, body, signature)
         return JSONResponse(payload, status_code=status)
@@ -338,23 +349,25 @@ def bridge_hook_url(config: BridgeConfig) -> str:
 LOOPBACK_HOSTS = {"localhost"}
 
 
-def _is_loopback(url: str) -> bool:
+def _is_host_loopback(host: str) -> bool:
     """Loopback is all of 127.0.0.0/8 plus ::1 (Debian/Ubuntu resolve the
     machine's own hostname to 127.0.1.1), not just the literal 127.0.0.1."""
-    host = urllib.parse.urlsplit(url).hostname
-    if host is None:
-        return True
     try:
         return ipaddress.ip_address(host).is_loopback
     except ValueError:
         return host in LOOPBACK_HOSTS
 
 
+def _is_loopback(url: str) -> bool:
+    host = urllib.parse.urlsplit(url).hostname
+    return True if host is None else _is_host_loopback(host)
+
+
 def bind_host(config: BridgeConfig) -> str:
-    """Which interface the listener binds. A loopback hook URL means the
-    local bus is the sole caller -> localhost only. A reachable hook URL
-    means a remote bus must reach us -> all interfaces, unless --bind pins
-    one (config_from_args guarantees an HMAC secret on that path)."""
+    """Which interface the listener binds: --bind wins, else loopback for a
+    loopback hook URL (the local bus is the sole caller), else all
+    interfaces. config_from_args requires the HMAC secret whenever the
+    effective bind OR the hook URL is non-loopback."""
     if config.bind:
         return config.bind
     if _is_loopback(bridge_hook_url(config)):
@@ -567,16 +580,43 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             "on THIS machine, address it as 127.0.0.1 or localhost - a hostname "
             "that resolves to 127.0.1.1 reads as remote."
         )
-    # A non-loopback hook URL means binding beyond localhost, where the HMAC
-    # is the only authentication: an unsigned endpoint would let anyone who
-    # can reach the port append attacker-authored lines to a session spool.
-    # Hard requirement, matching the refusal above - the bus itself defaults
-    # to auth-required, and the bridge must not invert that.
-    if not _is_loopback(bridge_hook_url(config)) and not config.secret:
+    # --bind must be an address uvicorn can actually bind - a typo would
+    # otherwise surface as a bare socket.gaierror naming neither the flag
+    # nor the env var
+    if config.bind is not None:
+        try:
+            ipaddress.ip_address(config.bind)
+        except ValueError:
+            if config.bind not in LOOPBACK_HOSTS:
+                raise SystemExit(
+                    f"Invalid bind address {config.bind!r} "
+                    "(check --bind / AGENT_EVENT_BUS_BRIDGE_BIND): expected an IP address"
+                ) from None
+    # The HMAC is the only authentication once the endpoint is reachable
+    # off-box, and exposure is decided by the EFFECTIVE bind (bind_host
+    # consults --bind first) as well as the hook URL: a non-loopback bind
+    # with no secret would let anyone who reaches the port append
+    # attacker-authored lines to a session spool, and a non-loopback hook
+    # URL means the hop exists even behind a local TLS terminator. Hard
+    # requirement either way - the bus itself defaults to auth-required,
+    # and the bridge must not invert that.
+    exposed = not _is_host_loopback(bind_host(config)) or not _is_loopback(bridge_hook_url(config))
+    if exposed and not config.secret:
         raise SystemExit(
-            "Hook URL is non-loopback, so the listener must bind beyond localhost - "
-            "set AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
-            "authentication on this hop)."
+            f"Listener would bind {bind_host(config)} with hook URL "
+            f"{bridge_hook_url(config)} - reachable off-box, so set "
+            "AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
+            "authentication on this hop). Check --bind / AGENT_EVENT_BUS_BRIDGE_BIND "
+            "and --hook-url."
+        )
+    # The inverse mismatch is silent inertness, not exposure: a loopback
+    # bind under a reachable hook URL means the bus's POSTs are refused at
+    # the TCP level. Legitimate behind a same-box TLS terminator, so warn
+    # rather than refuse - same policy as the port mismatch below.
+    if _is_host_loopback(bind_host(config)) and not _is_loopback(bridge_hook_url(config)):
+        logger.warning(
+            f"Hook URL {bridge_hook_url(config)} is reachable but the listener binds "
+            f"{bind_host(config)} (loopback) - correct only if something forwards between them"
         )
     # The bus POSTs to the hook URL's port while the listener binds --port;
     # a mismatch is legitimate behind a reverse proxy, but name it - it's

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -142,6 +142,16 @@ def verify_signature(body: bytes, signature_header: str | None, secret: str) -> 
 # open (and caps spool-file blast radius).
 SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
+# The unsafe-id rejection below is publisher-drivable (the bus warns on
+# malformed channels but never rejects them), so a per-event WARNING would
+# let any publisher choose how much the bridge writes to its log. Warn on
+# the first sighting of each distinct channel string, debug the rest.
+# Cleared at a cap rather than LRU-evicted: past that many distinct garbage
+# channels, one repeat warning per channel is the lesser noise. Unlocked -
+# a rare race just duplicates a warning.
+_warned_unsafe_channels: set[str] = set()
+_WARNED_UNSAFE_CHANNELS_CAP = 64
+
 
 def resolve_target_session(event: dict) -> str | None:
     """Which session should this event wake?
@@ -159,7 +169,13 @@ def resolve_target_session(event: dict) -> str | None:
         return None
     target = channel.split(":", 1)[1]
     if not SESSION_ID_PATTERN.fullmatch(target):
-        logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
+        if channel in _warned_unsafe_channels:
+            logger.debug(f"Ignoring event with unsafe session id in channel {channel!r}")
+        else:
+            if len(_warned_unsafe_channels) >= _WARNED_UNSAFE_CHANNELS_CAP:
+                _warned_unsafe_channels.clear()
+            _warned_unsafe_channels.add(channel)
+            logger.warning(f"Ignoring event with unsafe session id in channel {channel!r}")
         return None
     return target
 
@@ -187,8 +203,13 @@ class Injector:
             ) from None
 
     def deliver(self, session_id: str, event: dict) -> str:
-        """Wake session_id for event. Returns the action taken:
-        "tmux", "spool", or "spool-cooldown".
+        """Wake session_id for event. Returns the action taken: "tmux",
+        "spool" (spool backend working as designed), "spool-cooldown", or
+        "spool-tmux-failed" (tmux backend, wake missed or failed). The
+        distinct failure value is the one in-band signal - it rides the 200
+        response's `action` field - that separates "tmux is broken on this
+        box" from the spool backend's normal path, since the unmapped-pane
+        arm logs only at debug.
 
         The cooldown bounds successful injections only: spool writes are
         durable bookkeeping, not wakes, and a failed tmux attempt must not
@@ -233,7 +254,7 @@ class Injector:
             # prune returned spool-cooldown above.
             if self._last_wake.get(session_id) == now:
                 del self._last_wake[session_id]
-        return "spool"
+        return "spool-tmux-failed"
 
     def _spool(self, session_id: str, event: dict) -> None:
         """Always-on durable path: one JSON line per event, per session.
@@ -331,11 +352,14 @@ def create_bridge_app(
     """Build the ASGI app: POST /hook (webhook receiver) + GET /health.
 
     When registration_state/registration_stop are given, the app's lifespan
-    owns bus registration: startup launches register_with_retry in a
-    background thread (so the listener binds first and a down bus can't kill
-    the daemon), and shutdown stops it and joins - stop can't interrupt a
+    owns bus registration end to end: startup launches register_with_retry
+    in a background thread (so the listener binds first and a down bus can't
+    kill the daemon), and shutdown stops it, joins - stop can't interrupt a
     register call already inside its HTTP POST, so without the join a clean
-    exit could read webhook_id before the thread writes it and leak the row.
+    exit could read webhook_id before the thread writes it and leak the row -
+    and unregisters the committed id. The app created the row, so the app
+    removes it; any embedding (uvicorn --factory, an ASGI mount) gets clean
+    shutdown without needing a main()-style finally of its own.
     """
     injector = Injector(config)
     registration_thread: threading.Thread | None = None
@@ -370,6 +394,16 @@ def create_bridge_app(
                     await anyio.to_thread.run_sync(
                         functools.partial(registration_thread.join, REGISTRATION_JOIN_TIMEOUT)
                     )
+                    # pop, not get: hand the id off exactly once, so main()'s
+                    # belt-and-braces finally (for exits that skip the
+                    # lifespan) can't double-unregister. Same off-loop
+                    # treatment as the join - unregister_from_bus is a
+                    # blocking call_tool POST - inside the same shield.
+                    webhook_id = registration_state.pop("webhook_id", None)
+                    if webhook_id is not None:
+                        await anyio.to_thread.run_sync(
+                            functools.partial(unregister_from_bus, config, webhook_id)
+                        )
 
     def process(body: bytes, signature: str | None) -> tuple[dict, int]:
         """Sync webhook handling (runs in a worker thread - the file appends
@@ -422,14 +456,23 @@ def create_bridge_app(
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
     async def hook_endpoint(request: Request) -> JSONResponse:
-        # Precheck the honest case cheaply; the post-read check below covers
+        # Precheck the honest case cheaply; the streamed count below covers
         # a missing or lying content-length (e.g. chunked encoding)
         content_length = request.headers.get("content-length")
         if content_length and content_length.isdigit() and int(content_length) > MAX_BODY_BYTES:
             return JSONResponse({"error": "body too large"}, status_code=413)
-        body = await request.body()
-        if len(body) > MAX_BODY_BYTES:
-            return JSONResponse({"error": "body too large"}, status_code=413)
+        # Stream with a running count, not request.body(): body() concatenates
+        # every chunk unconditionally, so a chunked POST (no content-length to
+        # precheck) could make the daemon buffer arbitrarily many bytes before
+        # a post-read check ever ran - the bound must hold WHILE reading
+        chunks: list[bytes] = []
+        received = 0
+        async for chunk in request.stream():
+            received += len(chunk)
+            if received > MAX_BODY_BYTES:
+                return JSONResponse({"error": "body too large"}, status_code=413)
+            chunks.append(chunk)
+        body = b"".join(chunks)
         signature = request.headers.get("x-event-bus-signature")
         payload, status = await run_in_threadpool(process, body, signature)
         return JSONResponse(payload, status_code=status)
@@ -828,6 +871,30 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"{bridge_hook_url(config)} advertises loopback - the bus can't reach it; "
             "set --hook-url to an address on the bound interface"
         )
+    # Address-family mismatch: 0.0.0.0 binds IPv4 only, so an IPv6 hook
+    # literal (a Tailscale IPv6 address, say) is refused at TCP while every
+    # quadrant warning above stays quiet - both sides can be non-loopback
+    # with port and path agreeing. Hostname hooks are exempt: DNS/MagicDNS
+    # publishes A records too and happy-eyeballs falls back to v4. Hostname
+    # binds ("localhost") are exempt the other way - the resolver decides
+    # their family.
+    try:
+        hook_is_v6 = (
+            ipaddress.ip_address(urllib.parse.urlsplit(bridge_hook_url(config)).hostname).version
+            == 6
+        )
+    except ValueError:
+        hook_is_v6 = False
+    try:
+        bind_is_v4 = ipaddress.ip_address(bind_host(config)).version == 4
+    except ValueError:
+        bind_is_v4 = False
+    if hook_is_v6 and bind_is_v4:
+        logger.warning(
+            f"Hook URL host is an IPv6 address but the listener binds "
+            f"{bind_host(config)} (IPv4 only) - the bus can't reach it; "
+            "set --bind to '::' (dual-stack) or an IPv6 address"
+        )
     return config
 
 
@@ -846,7 +913,8 @@ def main():
         uvicorn.run(app, host=bind_host(config), port=config.port)
     finally:
         # Lifespan shutdown already stopped and joined the registration
-        # thread; the stop here only covers exits that skipped the lifespan
+        # thread AND unregistered (popping the id) - this is pure
+        # belt-and-braces for exits that skipped the lifespan
         stop.set()
         if state.get("webhook_id") is not None:
             unregister_from_bus(config, state["webhook_id"])

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -1052,11 +1052,16 @@ def validate_config(config: BridgeConfig) -> None:
     calls it again for embedders (uvicorn --factory, an ASGI mount) that
     build a BridgeConfig by hand and never pass through argparse - the
     security posture (an exposed listener requires the HMAC secret) must
-    travel with the config, not with the entry point. Raises BridgeConfigError (a
-    ValueError - embedder-catchable, unlike SystemExit); config_from_args
-    translates it for the CLI. Error messages name flags and env vars
-    because the CLI is the common path; the invariants are runtime ones. The advisory topology WARNINGS stay in
-    config_from_args - they are startup diagnostics, not invariants.
+    travel with the config, not with the entry point. Raises
+    BridgeConfigError (a ValueError - embedder-catchable, unlike
+    SystemExit); config_from_args translates it for the CLI. NORMALIZES
+    port / cooldown_seconds / wake_dir on the config IN PLACE before
+    checking (int/float/Path - note int() truncates a float port rather
+    than rejecting it), so a caller keeping the config as its source of
+    truth reads back the coerced values. Error messages name flags and env
+    vars because the CLI is the common path; the invariants are runtime
+    ones. The advisory topology WARNINGS stay in config_from_args - they
+    are startup diagnostics, not invariants.
     """
     # Normalize BEFORE checking: the CLI hands strings through argparse
     # defaults, and a hand-built config may carry raw env values - a wrong

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -421,7 +421,18 @@ class Injector:
             # shared path, and the documented manual workflows invite a
             # later chmod on it. Create-time only; the append path pays
             # nothing once the file exists.
-            return os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600), "a")
+            # encoding="utf-8" explicitly: fdopen(..., "a") otherwise picks
+            # the locale codec (ASCII under a C-locale daemon), and the
+            # spool line is a UTF-8-JSON cross-process contract the drain
+            # hook reads. Safe today only because json.dumps defaults to
+            # ensure_ascii=True; pinning it here keeps a later
+            # ensure_ascii=False from raising UnicodeEncodeError mid-append
+            # under the held flock, 500ing an already-committed delivery.
+            return os.fdopen(
+                os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600),
+                "a",
+                encoding="utf-8",
+            )
 
         def _append() -> None:
             with _open_append_0600(lock_file) as lock_fd:
@@ -471,7 +482,14 @@ class Injector:
         """
         panes_file = self.config.wake_dir / "panes.json"
         try:
-            panes = json.loads(panes_file.read_text())
+            # encoding="utf-8" explicitly, NOT the locale codec read_text()
+            # defaults to: a supervisor hands the daemon no LC_ALL/LANG,
+            # glibc resolves the C locale, and the default codec becomes
+            # ASCII - a healthy panes.json with any byte >0x7f would then
+            # raise UnicodeDecodeError and wrongly route into the
+            # unparseable arm, leaving every session on the box permanently
+            # spool-unmapped. The writer contract (guide) says UTF-8.
+            panes = json.loads(panes_file.read_text(encoding="utf-8"))
         except FileNotFoundError:
             # A missing file IS this session's absent read: clear the
             # file-level keys AND this session's entry key, matching the
@@ -831,9 +849,15 @@ def create_bridge_app(
                 {"error": f"Content-Type must be {WEBHOOK_CONTENT_TYPE}"}, status_code=415
             )
         # Precheck the honest case cheaply; the streamed count below covers
-        # a missing or lying content-length (e.g. chunked encoding)
+        # a missing or lying content-length (e.g. chunked encoding).
+        # isdecimal(), NOT isdigit(): isdigit() is True for compatibility
+        # digits int() rejects (U+00B2 superscript two, which is exactly
+        # latin-1 byte 0xB2 - and Starlette decodes headers as latin-1), so
+        # an isdigit()+int() pair would 500 on a header value that h11
+        # rejects for the CLI but a mounting app might pass through.
+        # isdecimal() matches what int() actually accepts.
         content_length = request.headers.get("content-length")
-        if content_length and content_length.isdigit() and int(content_length) > MAX_BODY_BYTES:
+        if content_length and content_length.isdecimal() and int(content_length) > MAX_BODY_BYTES:
             return JSONResponse({"error": "body too large"}, status_code=413)
         # Stream with a running count, not request.body(): body() concatenates
         # every chunk unconditionally, so a chunked POST (no content-length to

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -411,7 +411,14 @@ class Injector:
         try:
             panes = json.loads(panes_file.read_text())
         except FileNotFoundError:
-            self._disarm_file_keys()  # normal unmapped state re-arms
+            # A missing file IS this session's absent read: clear the
+            # file-level keys AND this session's entry key, matching the
+            # absent-key arm below (a full delete-and-recreate clean-state
+            # cycle must re-arm the bad-entry warning - it is the
+            # repair-didn't-take signal). Still only THIS session's key, so
+            # no cross-session re-arm.
+            self._disarm_file_keys()
+            self._warned_panes_keys.discard(f"bad-pane-value:{session_id}")
             return None
         except ValueError as e:
             # Parse failures (JSONDecodeError, UnicodeDecodeError from a

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -729,10 +729,13 @@ def create_bridge_app(
             event = json.loads(body)
         # ValueError, not just JSONDecodeError: json.loads(bytes) DECODES
         # before parsing, and invalid UTF-8 raises UnicodeDecodeError (a
-        # ValueError but not a JSONDecodeError). The bus retries any >=400
+        # ValueError but not a JSONDecodeError). RecursionError is the
+        # sibling case OUTSIDE ValueError: ~500k nested brackets fit well
+        # under MAX_BODY_BYTES and blow the interpreter limit before any
+        # JSONDecodeError can be raised. The bus retries any >=400
         # identically, so a 400 buys a clean named error in both logs
         # instead of a traceback per attempt - not fewer retries.
-        except ValueError:
+        except (ValueError, RecursionError):
             return {"error": "invalid JSON"}, 400
         if not isinstance(event, dict):
             # Valid JSON that isn't an object (123, [], "x"): a named 400,
@@ -778,6 +781,22 @@ def create_bridge_app(
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
     async def hook_endpoint(request: Request) -> JSONResponse:
+        # The check that keeps the loopback-needs-no-secret posture true
+        # against BROWSERS: fetch(mode:"no-cors") from any web page the
+        # operator has open can POST to 127.0.0.1 as long as its
+        # Content-Type stays CORS-safelisted (a string body defaults to
+        # text/plain) - no preflight is sent, the opaque response doesn't
+        # matter, the write would already have happened: attacker-authored
+        # spool lines from a background tab. Requiring the bus's actual
+        # media type forces a preflight the bridge never answers, so the
+        # browser never sends the POST at all; the bus (httpx,
+        # "Content-Type: application/json") is unaffected. Parameters are
+        # tolerated ("application/json; charset=utf-8") - the guard is
+        # about which media types a browser can send preflight-free, not
+        # about strictness for its own sake.
+        content_type = request.headers.get("content-type", "")
+        if content_type.split(";", 1)[0].strip().lower() != "application/json":
+            return JSONResponse({"error": "Content-Type must be application/json"}, status_code=415)
         # Precheck the honest case cheaply; the streamed count below covers
         # a missing or lying content-length (e.g. chunked encoding)
         content_length = request.headers.get("content-length")
@@ -1122,7 +1141,16 @@ def validate_config(config: BridgeConfig) -> None:
     config.cooldown_seconds = _to_number(
         config.cooldown_seconds, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
     )
-    config.wake_dir = Path(config.wake_dir)
+    try:
+        config.wake_dir = Path(config.wake_dir)
+    except (TypeError, ValueError):
+        # The one normalization Path() doesn't cover with a named error -
+        # Path(None), Path(123), Path(b"...") raise bare TypeErrors, the
+        # exact shape this block's comment promises to prevent
+        raise BridgeConfigError(
+            f"Invalid wake dir {config.wake_dir!r} "
+            "(check --wake-dir / AGENT_EVENT_BUS_WAKE_DIR): expected a filesystem path"
+        ) from None
 
     # argparse `choices` only guards command-line values, and an embedder
     # skips argparse entirely - an unknown backend would silently mean
@@ -1189,6 +1217,21 @@ def validate_config(config: BridgeConfig) -> None:
                 "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): "
                 "expected http(s)://host[:port]/path"
             )
+        # SplitResult.port parses lazily - urlsplit itself accepts
+        # "http://host:80o82/hook" (scheme and hostname above read fine),
+        # and the bus stores the registered URL verbatim with no validation
+        # of its own, so a malformed port would register cleanly and then
+        # fail EVERY dispatch bus-side (httpx.InvalidURL) with /health
+        # green - the silent-inertness shape the scheme refusal above
+        # closes. Refuse it here so the embedding path gets the same named
+        # error as the CLI.
+        try:
+            parsed_hook.port
+        except ValueError:
+            raise BridgeConfigError(
+                f"Invalid hook URL {config.hook_url!r} "
+                "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): bad port"
+            ) from None
     hook = bridge_hook_url(config)
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
@@ -1298,16 +1341,12 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     # The bus POSTs to the hook URL's port while the listener binds --port;
     # a mismatch is legitimate behind a reverse proxy, but name it - it's
     # otherwise the same silent-inertness failure the guards above close.
-    # SplitResult.port raises for a malformed port - keep that a named
-    # config error like every other input.
+    # Cannot raise: validate_config already refused a malformed hook-URL
+    # port (the refusal lives there so the embedding path gets it too),
+    # and the derived loopback default is well-formed - only the advisory
+    # COMPARISON lives here, per the docstring split.
     hook_split = urllib.parse.urlsplit(hook)
-    try:
-        hook_port = hook_split.port
-    except ValueError:
-        raise SystemExit(
-            f"Invalid hook URL {hook!r} "
-            "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): bad port"
-        ) from None
+    hook_port = hook_split.port
     if hook_port is None:
         # A missing port is not "no opinion" - the bus POSTs to the scheme
         # default, so a forgotten :8082 is exactly the mismatch this warning

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -342,11 +342,26 @@ def create_bridge_app(
 
         # The bus always sends the derived signal_level; only actionable
         # events (DMs, help_needed, blockers, CI failures) justify a wake
-        if event.get("signal_level") != "actionable":
+        level = event.get("signal_level")
+        if level != "actionable":
+            if level is None:
+                # A bus predating derived levels (#129) sends none at all -
+                # every delivery would land here forever, so make the
+                # version skew visible instead of filtering silently
+                logger.info(
+                    f"Event {event.get('event_id')} carries no signal_level "
+                    "(bus predates derived levels?); filtering it"
+                )
+            else:
+                logger.debug(f"Ignoring event {event.get('event_id')}: level {level!r}")
             return {"status": "ignored", "reason": "below actionable"}, 200
 
         target = resolve_target_session(event)
         if target is None:
+            logger.debug(
+                f"Ignoring event {event.get('event_id')}: "
+                f"channel {event.get('channel')!r} has no target session"
+            )
             return {"status": "ignored", "reason": "no target session"}, 200
 
         action = injector.deliver(target, event)
@@ -511,16 +526,16 @@ def register_with_retry(
         delay = min(delay * 2, max_delay)
 
 
-def _env_number(name: str, default, cast):
-    """Read a numeric env var, turning a typo into a config error instead of
-    a bare ValueError traceback out of build_parser()."""
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
-        return default
+def _to_number(value, cast, flag: str, env: str):
+    """Cast a CLI/env-supplied numeric value at CONFIG time, not at
+    parser-build time - a typo in the env var must not break --help (the
+    first thing an operator reaches for when the daemon refuses to start)."""
     try:
-        return cast(raw)
-    except ValueError:
-        raise SystemExit(f"Invalid {name}={raw!r}: expected a number") from None
+        return cast(value)
+    except (TypeError, ValueError):
+        raise SystemExit(
+            f"Invalid value {value!r} (check {flag} / {env}): expected a number"
+        ) from None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -532,8 +547,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=_env_number("AGENT_EVENT_BUS_BRIDGE_PORT", DEFAULT_BRIDGE_PORT, int),
+        # Raw string default, cast in config_from_args - see _to_number
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_PORT") or str(DEFAULT_BRIDGE_PORT),
         help=f"Localhost port to listen on (default: {DEFAULT_BRIDGE_PORT})",
     )
     parser.add_argument(
@@ -544,8 +559,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--cooldown",
-        type=float,
-        default=_env_number("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", DEFAULT_COOLDOWN_SECONDS, float),
+        # Raw string default, cast in config_from_args - see _to_number
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_COOLDOWN") or str(DEFAULT_COOLDOWN_SECONDS),
         help="Minimum seconds between wakes per session (loop prevention)",
     )
     parser.add_argument(
@@ -583,14 +598,16 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         )
     config = BridgeConfig(
         bus_url=args.bus_url,
-        port=args.port,
+        port=_to_number(args.port, int, "--port", "AGENT_EVENT_BUS_BRIDGE_PORT"),
         backend=args.backend,
         # `or None`: an accidentally empty env var must not put registration
         # (which would skip the secret, so unsigned payloads) and verification
         # (which would demand signatures) on opposite sides - that 401s every
         # delivery silently
         secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
-        cooldown_seconds=args.cooldown,
+        cooldown_seconds=_to_number(
+            args.cooldown, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
+        ),
         wake_dir=args.wake_dir,
         hook_url=args.hook_url,
         bind=args.bind,

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -257,6 +257,9 @@ class Injector:
         # session's success re-armed a broken one into warn-per-DM. The
         # truly global case (no tmux at all) is the startup preflight's job.
         self._warned_wake_fail_keys: set[str] = set()
+        # First-sighting bound for the spool backend's happy-path INFO -
+        # see the log site in deliver() for why repeats demote to debug
+        self._spool_breadcrumb_logged = False
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event - though it IS
@@ -306,14 +309,22 @@ class Injector:
         self._spool(session_id, event)
 
         if self.config.backend != "tmux":
-            # The one default-level breadcrumb on the happy path: without it
-            # the spool backend's terminal shows the registration line and
-            # then permanent silence, indistinguishable from a bus that
-            # stopped dispatching. Spool backend ONLY: in the tmux backend
-            # this would emit one INFO per foreign-machine DM - the exact
-            # volume the unmapped arm's debug demotion exists to avoid - and
-            # a mapped wake already logs "Woke ..." at INFO.
-            logger.info(f"Spooled event {event.get('event_id')!r} for {session_id[:8]}...")
+            # The happy-path breadcrumb: without it the spool backend's
+            # terminal shows the registration line and then permanent
+            # silence, indistinguishable from a bus that stopped
+            # dispatching. FIRST delivery only: the volume driver is
+            # webhooks having no machine scoping (every bridge receives
+            # every session: DM, most for sessions this host will never
+            # wake), so per-DM INFO here is the same unbounded noise the
+            # unmapped arm's debug demotion avoids - one line proves the
+            # whole chain works, repeats land at debug under DEV_MODE.
+            # Unlocked: a rare race just duplicates the INFO.
+            message = f"Spooled event {event.get('event_id')!r} for {session_id[:8]}..."
+            if self._spool_breadcrumb_logged:
+                logger.debug(message)
+            else:
+                self._spool_breadcrumb_logged = True
+                logger.info(f"{message} (first delivery; further spools log at debug)")
             return "spool"
 
         # Pane lookup BEFORE the cooldown machinery: on a multi-machine bus
@@ -1230,7 +1241,8 @@ def validate_config(config: BridgeConfig) -> None:
         raise BridgeConfigError(
             f"Listener would bind {bind} with hook URL "
             f"{hook} - reachable off-box, so set "
-            "AGENT_EVENT_BUS_BRIDGE_SECRET (the HMAC signature is the only "
+            "AGENT_EVENT_BUS_BRIDGE_SECRET or secret= on the config - the env "
+            "var is only read on the CLI path (the HMAC signature is the only "
             "authentication on this hop). Check --bind / AGENT_EVENT_BUS_BRIDGE_BIND "
             "and --hook-url."
         )

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -79,6 +79,8 @@ class BridgeConfig:
     wake_dir: Path = field(default_factory=lambda: DEFAULT_WAKE_DIR)
     # URL the bus POSTs to; None means loopback (bus on this machine)
     hook_url: str | None = None
+    # Interface to bind; None derives it from the hook URL (see bind_host)
+    bind: str | None = None
 
 
 def verify_signature(body: bytes, signature_header: str | None, secret: str) -> bool:
@@ -348,6 +350,18 @@ def _is_loopback(url: str) -> bool:
         return host in LOOPBACK_HOSTS
 
 
+def bind_host(config: BridgeConfig) -> str:
+    """Which interface the listener binds. A loopback hook URL means the
+    local bus is the sole caller -> localhost only. A reachable hook URL
+    means a remote bus must reach us -> all interfaces, unless --bind pins
+    one (config_from_args guarantees an HMAC secret on that path)."""
+    if config.bind:
+        return config.bind
+    if _is_loopback(bridge_hook_url(config)):
+        return "127.0.0.1"
+    return "0.0.0.0"  # noqa: S104 - deliberate; secret enforced at config time
+
+
 def register_with_bus(config: BridgeConfig) -> int:
     """Register this bridge's webhook on the bus. Returns webhook_id;
     raises SystemExit on any failure (bus unreachable, or no id returned).
@@ -478,6 +492,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="URL the bus POSTs events to (default: http://127.0.0.1:<port>/hook; "
         "must be an address the bus host can reach when the bus is remote)",
     )
+    parser.add_argument(
+        "--bind",
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_BIND") or None,
+        help="Interface to bind (default: 127.0.0.1 for a loopback hook URL, "
+        "0.0.0.0 otherwise; pin e.g. your tailnet address to narrow exposure)",
+    )
     return parser
 
 
@@ -503,12 +523,36 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         cooldown_seconds=args.cooldown,
         wake_dir=args.wake_dir,
         hook_url=args.hook_url,
+        bind=args.bind,
     )
+    # Range checks cover CLI and env alike: an out-of-range port would be a
+    # uvicorn traceback naming neither, and a negative cooldown would
+    # silently disable the cooldown (now - ts < -5 is never true)
+    if not (1 <= config.port <= 65535):
+        raise SystemExit(
+            f"Invalid port {config.port} (check --port / AGENT_EVENT_BUS_BRIDGE_PORT): "
+            "expected 1-65535"
+        )
+    if config.cooldown_seconds < 0:
+        raise SystemExit(
+            f"Invalid cooldown {config.cooldown_seconds} "
+            "(check --cooldown / AGENT_EVENT_BUS_BRIDGE_COOLDOWN): must be >= 0"
+        )
     # A scheme-less bus URL ("bus.example:8080/mcp") parses with no hostname
     # and would read as loopback, skipping the topology guard below - catch
     # the misconfiguration here instead of in a later connection error
     if urllib.parse.urlsplit(config.bus_url).scheme not in ("http", "https"):
         raise SystemExit(f"Invalid bus URL {config.bus_url!r}: expected http:// or https://")
+    # Same check for the hook URL - it is what BOTH topology guards below
+    # read: a scheme-less value parses to hostname None, reads as loopback,
+    # skips the guards, and registers a URL the bus can never POST to
+    if config.hook_url is not None and (
+        urllib.parse.urlsplit(config.hook_url).scheme not in ("http", "https")
+    ):
+        raise SystemExit(
+            f"Invalid hook URL {config.hook_url!r} "
+            "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): expected http:// or https://"
+        )
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
     # delivered - and every machine would claim the same URL string, so the
@@ -519,7 +563,9 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             f"Bus at {config.bus_url} is remote but the advertised hook URL "
             f"{bridge_hook_url(config)} is loopback - the bus would POST to itself. "
             "Set --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL to an address the bus "
-            "host can reach (and set AGENT_EVENT_BUS_BRIDGE_SECRET)."
+            "host can reach (and set AGENT_EVENT_BUS_BRIDGE_SECRET). If the bus is "
+            "on THIS machine, address it as 127.0.0.1 or localhost - a hostname "
+            "that resolves to 127.0.1.1 reads as remote."
         )
     # A non-loopback hook URL means binding beyond localhost, where the HMAC
     # is the only authentication: an unsigned endpoint would let anyone who
@@ -555,15 +601,8 @@ def main():
     state: dict = {}
     stop = threading.Event()
     app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-    # Loopback hook URL -> bind localhost only (the local bus is the sole
-    # caller). A non-loopback hook URL means a remote bus must reach us, so
-    # bind wide - config_from_args guarantees an HMAC secret on this path.
-    if _is_loopback(bridge_hook_url(config)):
-        host = "127.0.0.1"
-    else:
-        host = "0.0.0.0"  # noqa: S104 - deliberate; secret enforced at config time
     try:
-        uvicorn.run(app, host=host, port=config.port)
+        uvicorn.run(app, host=bind_host(config), port=config.port)
     finally:
         # Lifespan shutdown already stopped and joined the registration
         # thread; the stop here only covers exits that skipped the lifespan

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -195,8 +195,10 @@ class Injector:
         self.config = config
         self._lock = threading.Lock()
         self._last_wake: dict[str, float] = {}
-        # Last panes.json warning emitted, for the warn-once guard below
-        self._last_panes_warning: str | None = None
+        # Last panes.json failure REASON warned about (not the message - a
+        # torn write varies its parse position per read), for the warn-once
+        # guard below
+        self._last_panes_warn_reason: str | None = None
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event. The dir is
@@ -219,8 +221,10 @@ class Injector:
         for a session on another machine, since webhooks have no machine
         scoping), or "spool-tmux-failed" (tmux backend, the send-keys
         attempt itself failed - the arm that means tmux on this box is
-        broken). The distinction rides the 200 response's `action` field,
-        the one in-band signal, since the unmapped arm logs only at debug.
+        broken). The action value is in-band for a direct caller of /hook
+        only - the bus discards the response body - so operator-facing
+        visibility is this module's log: failed wakes at warning, the quiet
+        arms at debug under DEV_MODE.
 
         The cooldown bounds successful injections only: spool writes are
         durable bookkeeping, not wakes, and a failed tmux attempt must not
@@ -265,13 +269,20 @@ class Injector:
                 for sid, ts in self._last_wake.items()
                 if (now - ts) < self.config.cooldown_seconds
             }
-            last = self._last_wake.get(session_id)
-            if last is not None:
-                return "spool-cooldown"
-            # Reserve the window before releasing the lock: two concurrent
-            # deliveries for the same session must not both pass the check
-            # and double-inject
-            self._last_wake[session_id] = now
+            in_cooldown = self._last_wake.get(session_id) is not None
+            if not in_cooldown:
+                # Reserve the window before releasing the lock: two
+                # concurrent deliveries for the same session must not both
+                # pass the check and double-inject
+                self._last_wake[session_id] = now
+        if in_cooldown:
+            # Logged outside the lock (a debug handler write is IO). Every
+            # other arm names itself somewhere; this one must too - it is
+            # the only case where the bridge chose not to wake a session it
+            # could have, which is exactly what a DEV_MODE operator asking
+            # "why didn't my session wake?" needs to see.
+            logger.debug(f"Cooldown active for {session_id[:8]}...; spooled only")
+            return "spool-cooldown"
 
         # tmux runs outside the lock (bounded at TMUX_TIMEOUT, but other
         # sessions' deliveries shouldn't wait on it). The pane can go stale
@@ -345,30 +356,39 @@ class Injector:
         try:
             panes = json.loads(panes_file.read_text())
         except FileNotFoundError:
-            self._last_panes_warning = None  # normal unmapped state re-arms
+            self._last_panes_warn_reason = None  # normal unmapped state re-arms
             return None
         except (OSError, ValueError) as e:
-            self._warn_panes_once(f"Unreadable panes.json ({e}); treating as unmapped")
+            self._warn_panes_once(
+                "unreadable", f"Unreadable panes.json ({e}); treating as unmapped"
+            )
             return None
         if not isinstance(panes, dict):
-            self._warn_panes_once("panes.json is not an object; treating as unmapped")
+            self._warn_panes_once(
+                "not-an-object", "panes.json is not an object; treating as unmapped"
+            )
             return None
-        self._last_panes_warning = None  # healthy read re-arms the warning
+        self._last_panes_warn_reason = None  # healthy read re-arms the warning
         pane = panes.get(session_id)
         return pane if isinstance(pane, str) and pane else None
 
-    def _warn_panes_once(self, message: str) -> None:
+    def _warn_panes_once(self, reason: str, message: str) -> None:
         """A persistently broken panes.json must not emit one WARNING per
         delivered DM - the same unbounded-volume shape as the unsafe-channel
         warning, driven by DM rate against a stuck local condition instead
-        of a hostile publisher. Warn on the first sighting of each distinct
-        condition, debug repeats; a healthy read (or the file going away)
-        re-arms it, so a NEW breakage always warns. Unlocked - a rare race
-        just duplicates a warning."""
-        if message == self._last_panes_warning:
+        of a hostile publisher. Keyed on the REASON, not the message: the
+        message embeds str(e), and a torn non-atomic write yields a
+        different parse position on every read - message-keyed dedupe would
+        warn once per delivery, the value-keyed defect in local-file form.
+        The full exception text still reaches the log on the first sighting
+        (and every repeat at debug under DEV_MODE). Warn on the first
+        sighting of each distinct reason, debug repeats; a healthy read (or
+        the file going away) re-arms it, so a NEW breakage always warns.
+        Unlocked - a rare race just duplicates a warning."""
+        if reason == self._last_panes_warn_reason:
             logger.debug(message)
         else:
-            self._last_panes_warning = message
+            self._last_panes_warn_reason = reason
             logger.warning(message)
 
     def _tmux_wake(self, session_id: str, pane: str) -> bool:

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -246,7 +246,6 @@ class Injector:
 
 def create_bridge_app(
     config: BridgeConfig,
-    injector: Injector | None = None,
     registration_state: dict | None = None,
     registration_stop: threading.Event | None = None,
 ) -> Starlette:
@@ -259,7 +258,7 @@ def create_bridge_app(
     register call already inside its HTTP POST, so without the join a clean
     exit could read webhook_id before the thread writes it and leak the row.
     """
-    injector = injector or Injector(config)
+    injector = Injector(config)
     registration_thread: threading.Thread | None = None
 
     @asynccontextmanager
@@ -620,12 +619,29 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         )
     # The bus POSTs to the hook URL's port while the listener binds --port;
     # a mismatch is legitimate behind a reverse proxy, but name it - it's
-    # otherwise the same silent-inertness failure the guards above close
-    hook_port = urllib.parse.urlsplit(bridge_hook_url(config)).port
+    # otherwise the same silent-inertness failure the guards above close.
+    # SplitResult.port raises for a malformed port - keep that a named
+    # config error like every other input.
+    try:
+        hook_port = urllib.parse.urlsplit(bridge_hook_url(config)).port
+    except ValueError:
+        raise SystemExit(
+            f"Invalid hook URL {bridge_hook_url(config)!r} "
+            "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): bad port"
+        ) from None
     if hook_port is not None and hook_port != config.port:
         logger.warning(
             f"Hook URL advertises port {hook_port} but the listener binds {config.port} - "
             "correct only if something forwards between them"
+        )
+    # Fourth quadrant: a non-loopback bind under a loopback hook URL means
+    # the bridge advertises 127.0.0.1 while nothing listens there - every
+    # dispatch is refused at TCP. Same warn-don't-refuse policy as above.
+    if not _is_host_loopback(bind_host(config)) and _is_loopback(bridge_hook_url(config)):
+        logger.warning(
+            f"Listener binds {bind_host(config)} but the hook URL "
+            f"{bridge_hook_url(config)} advertises loopback - the bus can't reach it; "
+            "set --hook-url to an address on the bound interface"
         )
     return config
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -218,11 +218,13 @@ class Injector:
         # NORMAL multi-machine steady state, where most DMs are unmapped)
         # would oscillate that into one WARNING per DM.
         self._warned_panes_keys: set[str] = set()
-        # Same idea for tmux wake failures, its own slot (the conditions
-        # are independent): a missing/broken tmux binary fails every wake
-        # with the same exception type forever, and per-DM WARNING for a
-        # stuck local condition is the volume shape bounded everywhere else
-        self._last_wake_fail_reason: str | None = None
+        # Same idea for tmux wake failures - and the same per-condition
+        # keying lesson as the panes guard: the condition is per (session,
+        # exception type), so a single slot would let a second broken
+        # session go silent behind the first's warning while a healthy
+        # session's success re-armed a broken one into warn-per-DM. The
+        # truly global case (no tmux at all) is the startup preflight's job.
+        self._warned_wake_fail_keys: set[str] = set()
         # Once at construction, not per delivery: keeps the lock hold to the
         # append itself, and a deliberate later permission change by the
         # operator isn't silently reverted on the next event - though it IS
@@ -244,10 +246,11 @@ class Injector:
     def deliver(self, session_id: str, event: dict) -> str:
         """Wake session_id for event. Returns the action taken: "tmux",
         "spool" (spool backend working as designed), "spool-cooldown",
-        "spool-unmapped" (tmux backend, no USABLE pane mapping: absent -
-        the NORMAL outcome for a session on another machine, since webhooks
-        have no machine scoping - or present but not a pane id, which
-        warns), or "spool-tmux-failed" (tmux backend, the send-keys
+        "spool-unmapped" (tmux backend, no usable pane mapping - normally
+        because the session lives on another machine, since webhooks have
+        no machine scoping, but also when panes.json is missing, unreadable,
+        malformed, or its entry is not a pane id; the misconfiguration
+        shapes warn, so check the log), or "spool-tmux-failed" (tmux backend, the send-keys
         attempt itself failed - the arm that means tmux on this box is
         broken). The action value is in-band for a direct caller of /hook
         only - the bus discards the response body - so operator-facing
@@ -352,37 +355,43 @@ class Injector:
         # rename could slip between our open and our flush and the line would
         # land in a file the drainer already read (and will delete)
         lock_file = self.config.wake_dir / f"{session_id}.lock"
+
+        def _append() -> None:
+            with lock_file.open("a") as lock_fd:
+                for _ in range(SPOOL_LOCK_ATTEMPTS):
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        break
+                    except BlockingIOError:
+                        time.sleep(SPOOL_LOCK_RETRY_SECONDS)
+                else:
+                    raise OSError(
+                        f"Could not lock spool for {session_id} within "
+                        f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
+                        "(stuck drainer?)"
+                    )
+                try:
+                    with spool_file.open("a") as f:
+                        f.write(json.dumps(event) + "\n")
+                finally:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
         try:
-            lock_handle = lock_file.open("a")
+            _append()
         except FileNotFoundError:
             # The wake dir can vanish at runtime - hand-clearing spools is
             # the documented interim workflow while pruning is a follow-up -
             # and without recovery every later delivery 500s until restart
             # (bus retries exhausted, wakes lost, /health still green).
-            # Recreate once and retry, keeping mkdir/chmod off the happy
-            # path; the resolve() check above already ran, so this cannot
-            # widen the path-safety surface.
+            # Recreate once and retry the WHOLE critical section: the dir
+            # can also disappear between the lock open and the spool open,
+            # so wrapping only the first open would leave the same 500.
+            # mkdir/chmod stay off the happy path, and the resolve() check
+            # above already ran, so this cannot widen the path-safety
+            # surface.
             self.config.wake_dir.mkdir(parents=True, exist_ok=True)
             self.config.wake_dir.chmod(0o700)
-            lock_handle = lock_file.open("a")
-        with lock_handle as lock_fd:
-            for _ in range(SPOOL_LOCK_ATTEMPTS):
-                try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    break
-                except BlockingIOError:
-                    time.sleep(SPOOL_LOCK_RETRY_SECONDS)
-            else:
-                raise OSError(
-                    f"Could not lock spool for {session_id} within "
-                    f"{SPOOL_LOCK_ATTEMPTS * SPOOL_LOCK_RETRY_SECONDS:.0f}s "
-                    "(stuck drainer?)"
-                )
-            try:
-                with spool_file.open("a") as f:
-                    f.write(json.dumps(event) + "\n")
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            _append()
 
     def _tmux_pane(self, session_id: str) -> str | None:
         """Look up the session's tmux pane from <wake_dir>/panes.json.
@@ -488,22 +497,28 @@ class Injector:
                 timeout=TMUX_TIMEOUT,
             )
             logger.info(f"Woke {session_id[:8]}... via tmux pane {pane}")
-            self._last_wake_fail_reason = None  # a working tmux re-arms
+            # A working wake re-arms THIS session's failure conditions only -
+            # clearing globally would oscillate a broken session's warning
+            # under interleaved healthy deliveries (the round-38 shape)
+            self._warned_wake_fail_keys = {
+                k for k in self._warned_wake_fail_keys if not k.startswith(f"{session_id}:")
+            }
             return True
         except (subprocess.SubprocessError, OSError) as e:
             # SubprocessError covers CalledProcessError/TimeoutExpired;
             # OSError covers a missing or non-executable tmux binary. An
             # exception escaping here would 500 the webhook and make the bus
             # retry an event that is already durably spooled (duplicate
-            # lines). Bounded like the panes guard - keyed on the exception
-            # TYPE, so a persistent condition (tmux gone) warns once and
-            # then debugs, while a different failure type warns fresh.
-            reason = type(e).__name__
+            # lines). Bounded like the panes guard - keyed per (session,
+            # exception type): a persistent condition warns once per session
+            # and then debugs, a different failure type warns fresh, and a
+            # second broken session is never silenced by the first's key.
+            key = f"{session_id}:{type(e).__name__}"
             message = f"tmux wake failed for {session_id[:8]}... ({e}); spooled only"
-            if reason == self._last_wake_fail_reason:
+            if key in self._warned_wake_fail_keys:
                 logger.debug(message)
             else:
-                self._last_wake_fail_reason = reason
+                self._warned_wake_fail_keys.add(key)
                 logger.warning(message)
             return False
 
@@ -535,6 +550,9 @@ def create_bridge_app(
             "registration_state and registration_stop come as a pair - "
             "pass both to enable bus registration, or neither"
         )
+    # Embedders build configs by hand - the invariants (including the
+    # exposed-listener secret requirement) must hold on this path too
+    validate_config(config)
     injector = Injector(config)
     registration_thread: threading.Thread | None = None
 
@@ -542,6 +560,14 @@ def create_bridge_app(
     async def lifespan(app):
         nonlocal registration_thread
         if registration_state is not None and registration_stop is not None:
+            # A re-entered lifespan must register again: the previous
+            # cycle's shutdown set() this event, and register_with_retry
+            # checks it before its first attempt - without the clear, a
+            # second cycle on the same app binds, serves /health, and never
+            # registers (the silent shape the pair check above closes for
+            # half-wired calls). main() constructs the event unset, so this
+            # is a no-op on the first cycle.
+            registration_stop.clear()
             registration_thread = threading.Thread(
                 target=register_with_retry,
                 args=(config, registration_state, registration_stop),
@@ -939,41 +965,26 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def config_from_args(args: argparse.Namespace) -> BridgeConfig:
-    """Build the runtime config from parsed args plus environment."""
-    # argparse enforces `choices` only for values given on the command line -
-    # an env-supplied default bypasses the check, and an unknown backend would
-    # otherwise silently mean "spool" (deliver only tests != "tmux")
-    if args.backend not in ("spool", "tmux"):
+def validate_config(config: BridgeConfig) -> None:
+    """Enforce the hard invariants on a BridgeConfig, wherever it came from.
+
+    config_from_args calls this on the CLI path, and create_bridge_app
+    calls it again for embedders (uvicorn --factory, an ASGI mount) that
+    build a BridgeConfig by hand and never pass through argparse - the
+    security posture (an exposed listener requires the HMAC secret) must
+    travel with the config, not with the entry point. Error messages name
+    flags and env vars because the CLI is the common path; the invariants
+    themselves are runtime ones. The advisory topology WARNINGS stay in
+    config_from_args - they are startup diagnostics, not invariants.
+    """
+    # argparse `choices` only guards command-line values, and an embedder
+    # skips argparse entirely - an unknown backend would silently mean
+    # "spool" (deliver only tests != "tmux")
+    if config.backend not in ("spool", "tmux"):
         raise SystemExit(
-            f"Invalid backend {args.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
+            f"Invalid backend {config.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
             "expected 'spool' or 'tmux'"
         )
-    # Preflight the binary: a tmux backend on a box without tmux would
-    # degrade every wake to spool-tmux-failed for the daemon's lifetime -
-    # one startup message beats discovering it per-DM. A tmux that breaks
-    # LATER is still handled (and bounded) by the wake-failure guard.
-    if args.backend == "tmux" and shutil.which("tmux") is None:
-        raise SystemExit(
-            "Backend is tmux but no tmux binary is on PATH "
-            "(check --backend / AGENT_EVENT_BUS_BRIDGE_BACKEND)"
-        )
-    config = BridgeConfig(
-        bus_url=args.bus_url,
-        port=_to_number(args.port, int, "--port", "AGENT_EVENT_BUS_BRIDGE_PORT"),
-        backend=args.backend,
-        # `or None`: an accidentally empty env var must not put registration
-        # (which would skip the secret, so unsigned payloads) and verification
-        # (which would demand signatures) on opposite sides - that 401s every
-        # delivery silently
-        secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
-        cooldown_seconds=_to_number(
-            args.cooldown, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
-        ),
-        wake_dir=args.wake_dir,
-        hook_url=args.hook_url,
-        bind=args.bind,
-    )
     # Range checks cover CLI and env alike: an out-of-range port would be a
     # uvicorn traceback naming neither, and a negative cooldown would
     # silently disable the cooldown (now - ts < -5 is never true)
@@ -1029,9 +1040,6 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
                 "(check --hook-url / AGENT_EVENT_BUS_BRIDGE_HOOK_URL): "
                 "expected http(s)://host[:port]/path"
             )
-    # One derivation for the whole topology block below: every guard
-    # reasons about the same (hook URL, effective bind) pair, and nothing
-    # in between mutates config. `bind` is hoisted after --bind validation.
     hook = bridge_hook_url(config)
     # A loopback hook URL registered on a remote bus makes the bus POST to
     # itself: registration succeeds, /health is green, nothing is ever
@@ -1077,6 +1085,43 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
             "authentication on this hop). Check --bind / AGENT_EVENT_BUS_BRIDGE_BIND "
             "and --hook-url."
         )
+
+
+def config_from_args(args: argparse.Namespace) -> BridgeConfig:
+    """Build the runtime config from parsed args plus environment."""
+    config = BridgeConfig(
+        bus_url=args.bus_url,
+        port=_to_number(args.port, int, "--port", "AGENT_EVENT_BUS_BRIDGE_PORT"),
+        backend=args.backend,
+        # `or None`: an accidentally empty env var must not put registration
+        # (which would skip the secret, so unsigned payloads) and verification
+        # (which would demand signatures) on opposite sides - that 401s every
+        # delivery silently
+        secret=os.environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None,
+        cooldown_seconds=_to_number(
+            args.cooldown, float, "--cooldown", "AGENT_EVENT_BUS_BRIDGE_COOLDOWN"
+        ),
+        wake_dir=args.wake_dir,
+        hook_url=args.hook_url,
+        bind=args.bind,
+    )
+    validate_config(config)
+    # Preflight the binary (CLI path only - embedders manage their own
+    # runtime env): a tmux backend on a box without tmux would degrade
+    # every wake to spool-tmux-failed for the daemon's lifetime - one
+    # startup message beats discovering it per-DM, and the check is
+    # PATH-sensitive, so it names the fix. A tmux that breaks LATER is
+    # still handled (and bounded) by the wake-failure guard.
+    if config.backend == "tmux" and shutil.which("tmux") is None:
+        raise SystemExit(
+            "Backend is tmux but no tmux binary is on PATH of THIS process "
+            "(a supervisor's minimal PATH can hide a tmux your shell sees; "
+            "check --backend / AGENT_EVENT_BUS_BRIDGE_BACKEND)"
+        )
+    # One derivation for the warning block below - the refusals above
+    # already validated both URLs, so these cannot raise
+    hook = bridge_hook_url(config)
+    bind = bind_host(config)
     # The inverse mismatch is silent inertness, not exposure: a loopback
     # bind under a reachable hook URL means the bus's POSTs are refused at
     # the TCP level. Legitimate behind a same-box TLS terminator, so warn

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -37,6 +37,7 @@ import re
 import subprocess
 import threading
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -56,6 +57,10 @@ DEFAULT_WAKE_DIR = Path.home() / ".claude" / "contrib" / "agent-event-bus" / "wa
 # tmux send-keys is bounded like the notifier subprocesses in helpers.py -
 # a hung tmux must not wedge the bridge
 TMUX_TIMEOUT = 5.0
+
+# Bound on joining the registration thread at shutdown: long enough for an
+# in-flight register call to commit, short enough not to hang exit
+REGISTRATION_JOIN_TIMEOUT = 10.0
 
 WAKE_PROMPT = "Check the event bus - a directed event arrived for this session."
 
@@ -206,9 +211,38 @@ class Injector:
             return False
 
 
-def create_bridge_app(config: BridgeConfig, injector: Injector | None = None) -> Starlette:
-    """Build the ASGI app: POST /hook (webhook receiver) + GET /health."""
+def create_bridge_app(
+    config: BridgeConfig,
+    injector: Injector | None = None,
+    registration_state: dict | None = None,
+    registration_stop: threading.Event | None = None,
+) -> Starlette:
+    """Build the ASGI app: POST /hook (webhook receiver) + GET /health.
+
+    When registration_state/registration_stop are given, the app's lifespan
+    owns bus registration: startup launches register_with_retry in a
+    background thread (so the listener binds first and a down bus can't kill
+    the daemon), and shutdown stops it and joins - stop can't interrupt a
+    register call already inside its HTTP POST, so without the join a clean
+    exit could read webhook_id before the thread writes it and leak the row.
+    """
     injector = injector or Injector(config)
+    registration_thread: threading.Thread | None = None
+
+    @asynccontextmanager
+    async def lifespan(app):
+        nonlocal registration_thread
+        if registration_state is not None and registration_stop is not None:
+            registration_thread = threading.Thread(
+                target=register_with_retry,
+                args=(config, registration_state, registration_stop),
+                daemon=True,
+            )
+            registration_thread.start()
+        yield
+        if registration_thread is not None:
+            registration_stop.set()
+            registration_thread.join(timeout=REGISTRATION_JOIN_TIMEOUT)
 
     def process(body: bytes, signature: str | None) -> tuple[dict, int]:
         """Sync webhook handling (runs in a worker thread - the file appends
@@ -249,7 +283,8 @@ def create_bridge_app(config: BridgeConfig, injector: Injector | None = None) ->
         routes=[
             Route("/hook", hook_endpoint, methods=["POST"]),
             Route("/health", health, methods=["GET"]),
-        ]
+        ],
+        lifespan=lifespan,
     )
 
 
@@ -332,6 +367,18 @@ def register_with_retry(
         delay = min(delay * 2, max_delay)
 
 
+def _env_number(name: str, default, cast):
+    """Read a numeric env var, turning a typo into a config error instead of
+    a bare ValueError traceback out of build_parser()."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return cast(raw)
+    except ValueError:
+        raise SystemExit(f"Invalid {name}={raw!r}: expected a number") from None
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="agent-event-bus re-awakening bridge (RFC #122)")
     parser.add_argument(
@@ -342,7 +389,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--port",
         type=int,
-        default=int(os.environ.get("AGENT_EVENT_BUS_BRIDGE_PORT", DEFAULT_BRIDGE_PORT)),
+        default=_env_number("AGENT_EVENT_BUS_BRIDGE_PORT", DEFAULT_BRIDGE_PORT, int),
         help=f"Localhost port to listen on (default: {DEFAULT_BRIDGE_PORT})",
     )
     parser.add_argument(
@@ -354,7 +401,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cooldown",
         type=float,
-        default=float(os.environ.get("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", DEFAULT_COOLDOWN_SECONDS)),
+        default=_env_number("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", DEFAULT_COOLDOWN_SECONDS, float),
         help="Minimum seconds between wakes per session (loop prevention)",
     )
     parser.add_argument(
@@ -368,6 +415,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 def config_from_args(args: argparse.Namespace) -> BridgeConfig:
     """Build the runtime config from parsed args plus environment."""
+    # argparse enforces `choices` only for values given on the command line -
+    # an env-supplied default bypasses the check, and an unknown backend would
+    # otherwise silently mean "spool" (deliver only tests != "tmux")
+    if args.backend not in ("spool", "tmux"):
+        raise SystemExit(
+            f"Invalid backend {args.backend!r} (check AGENT_EVENT_BUS_BRIDGE_BACKEND): "
+            "expected 'spool' or 'tmux'"
+        )
     return BridgeConfig(
         bus_url=args.bus_url,
         port=args.port,
@@ -392,21 +447,14 @@ def main():
 
     state: dict = {}
     stop = threading.Event()
-    app = create_bridge_app(config)
-    # Register from a startup hook: uvicorn binds right after startup
-    # completes, so the thread's first attempt races the bind by microseconds
-    # at most (and the bus retries deliveries anyway)
-    app.add_event_handler(
-        "startup",
-        lambda: threading.Thread(
-            target=register_with_retry, args=(config, state, stop), daemon=True
-        ).start(),
-    )
+    app = create_bridge_app(config, registration_state=state, registration_stop=stop)
     try:
         # Localhost only: the bus is the sole intended caller, and HMAC (when
         # a secret is set) authenticates it
         uvicorn.run(app, host="127.0.0.1", port=config.port)
     finally:
+        # Lifespan shutdown already stopped and joined the registration
+        # thread; the stop here only covers exits that skipped the lifespan
         stop.set()
         if state.get("webhook_id") is not None:
             unregister_from_bus(config, state["webhook_id"])

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -316,6 +316,29 @@ unregister_webhook(webhook_id=1)
 ### Retry Behavior
 Webhooks retry up to 2 times with exponential backoff if the endpoint returns 4xx/5xx or times out.
 
+## Re-awakening Bridge (experimental)
+
+`agent-event-bus-bridge` closes the pull-only delivery gap (RFC #122): a
+small localhost daemon that registers a webhook on the bus, filters to
+**actionable** events on **`session:` channels** (DMs), and wakes the target
+session. Broadcast events stay pull-only.
+
+```
+agent-event-bus-bridge                    # spool backend (default)
+agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
+```
+
+- **spool**: every wake event is appended to
+  `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
+  drain. This durable path is always on, in every backend.
+- **tmux**: additionally runs `tmux send-keys` into the session's pane, using
+  the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
+  session-side must maintain; unmapped sessions just spool.
+- Per-session cooldown (default 30s, `--cooldown`) bounds wake-ups; events
+  during cooldown are spooled, never dropped.
+- Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
+  hop (the bridge registers its webhook with the same secret).
+
 ## Best Practices
 
 1. **Register with client_id** - Enables session resumption

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -357,9 +357,11 @@ That lands with the supervision story.)
   `signal_level` is always `actionable` on a spooled line by construction
   (the bridge filters before spooling), so a hook need not re-check it -
   and pass-through means bus-side payload additions appear additively:
-  read the keys you know, ignore the rest. Each line is UTF-8 JSON
-  (`json.dumps`, one object per line); read it as UTF-8, not the drain
-  hook's locale codec. Drain contract:
+  read the keys you know, ignore the rest. Each line is UTF-8, STANDARD
+  JSON (`json.dumps`, one object per line) - the hook rejects the
+  non-standard `NaN`/`Infinity` literals at the door, so every spooled line
+  parses in `jq`, `JSON.parse`, and Go's `encoding/json`. Read it as UTF-8,
+  not the drain hook's locale codec. Drain contract:
   1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
@@ -472,7 +474,13 @@ That lands with the supervision story.)
   duplicate deliveries. The sweep matches the URL being registered NOW -
   after changing `--port` or `--hook-url`, drop the row at the old URL
   yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
-  the bus keeps dispatching to the dead address forever.
+  the bus keeps dispatching to the dead address forever. Because that sweep
+  can't tell a stale row from a *live peer's*, the CLI takes an flock'd
+  singleton (`bridge.singleton.lock` in the wake dir) at startup: a second
+  instance on the same wake dir refuses to start with a named error rather
+  than stealing the running bridge's registration and leaving it deaf. Two
+  bridges therefore need distinct `--wake-dir`s (they'd share spool files
+  otherwise). Embedders manage their own single-instance story.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
 - The hook body is capped at 1 MiB (the HMAC can only be checked after

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -362,7 +362,13 @@ That lands with the supervision story.)
   non-standard `NaN`/`Infinity` literals at the door, so every spooled line
   parses in `jq`, `JSON.parse`, and Go's `encoding/json`. Read it as UTF-8,
   not the drain hook's locale codec. Drain contract:
-  1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
+  1. Take an exclusive `flock` on `<sid>.lock`, creating it if absent
+     (`O_CREAT`, mode `0o600` to match the bridge and the create-mode rule
+     above). The bridge only creates `<sid>.lock` inside the first append
+     for that session, so a hook firing for a session with no spool yet -
+     the common case - opens a lock that does not exist; a drainer that
+     treats ENOENT as "nothing to drain" would skip locking on the very run
+     a spool appears concurrently. The bridge holds the same
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
      without the lock a just-appended line could land in a file the drainer
@@ -530,7 +536,10 @@ That lands with the supervision story.)
   otherwise) - a supervisor probing `http://127.0.0.1:<port>/health` sends
   a loopback `Host` and passes, but a rebound browser tab cannot even
   confirm a bridge runs here. Probe it by a loopback literal, the hook
-  URL's hostname, or the bound address, same as `/hook`.
+  URL's hostname, or the bound address *when `--bind` pins a specific one* -
+  under a wildcard bind (the derived default for a non-loopback hook URL)
+  the bind is not in the allowlist, so probe by the hook URL hostname or a
+  loopback literal.
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
@@ -577,7 +586,17 @@ non-loopback bind anyone who can reach the port can read it. Keep `--port` and t
 unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
 every `session:` DM; tmux wakes only work for sessions on the bridge's own
 machine, and spool files for foreign sessions accumulate until the pruning
-follow-up lands. Machine-scoped delivery is a v2 item.
+follow-up lands. That accumulation is unbounded in the adversarial case:
+`deliver` spools before any existence check and the id is only
+charset-validated, never checked against `list_sessions`, so any publisher
+on the bus can create a `<id>.jsonl`+`<id>.lock` pair for every distinct
+never-registered id it invents - two inodes and up to ~1 MiB each, at its
+publish rate. On a loopback-only bus that is the operator's own trust
+boundary; on the recommended tailnet topology it is any session on the
+shared bus. Pruning must bound this, not just the benign foreign-session
+case; the real fix is the `list_sessions`-based scoping tracked for v2,
+which drops unknown ids before they reach the filesystem. Machine-scoped
+delivery is a v2 item.
 
 Supervision is deliberately out of scope for the v1 prototype: there is no
 `make install-bridge`, launchd plist, or systemd unit yet - run the bridge in

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -475,12 +475,16 @@ That lands with the supervision story.)
   after changing `--port` or `--hook-url`, drop the row at the old URL
   yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
   the bus keeps dispatching to the dead address forever. Because that sweep
-  can't tell a stale row from a *live peer's*, the CLI takes an flock'd
-  singleton (`bridge.singleton.lock` in the wake dir) at startup: a second
-  instance on the same wake dir refuses to start with a named error rather
-  than stealing the running bridge's registration and leaving it deaf. Two
-  bridges therefore need distinct `--wake-dir`s (they'd share spool files
-  otherwise). Embedders manage their own single-instance story.
+  can't tell a stale row from a *live peer's*, the CLI takes two flock'd
+  singletons at startup (both released on exit): one keyed on the **hook
+  URL** (in a fixed lock dir, so a second instance registering the same URL
+  refuses *regardless of wake dir* - the URL is what the sweep contends on),
+  and one on the **wake dir** (`bridge.singleton.lock` there - two bridges
+  would otherwise interleave the same spool files). To run two bridges at
+  once they need BOTH a distinct hook URL (a different `--port` *and*
+  `--hook-url`) and a distinct `--wake-dir`; changing only `--wake-dir`
+  leaves the hook URL colliding, and changing only the port leaves the wake
+  dir colliding. Embedders manage their own single-instance story.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
 - The hook body is capped at 1 MiB (the HMAC can only be checked after

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -335,8 +335,10 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
      without the lock a just-appended line could land in a file the drainer
-     already read). The bridge's acquire is bounded (~5s), so keep your
-     hold to the renames below - never drain while holding the lock.
+     already read). The bridge's acquire is bounded (~2s - it must stay
+     under the bus's 5s webhook timeout), so keep your hold to the
+     renames below - never drain while holding the lock; even a ~2s hold
+     turns a concurrent delivery into a bus-side timeout and retry.
   2. Under the lock, claim a batch by rename (renames only, so the hold
      stays short). Pick a claim id `<uniq>` unique to THIS drain - pid
      plus a timestamp, or an mktemp-style suffix. Pid alone is NOT
@@ -397,6 +399,12 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   the bus keeps dispatching to the dead address forever.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
+- `GET /health` reports `registered`: whether the *startup* registration
+  succeeded. The row is not re-verified afterwards, so unregistering the
+  webhook by hand (or restoring the bus DB from a backup) leaves
+  `registered: true` on a bridge the bus no longer dispatches to - restart
+  the bridge after manual webhook surgery. Periodic re-assertion is a
+  follow-up.
 
 Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -477,14 +477,20 @@ That lands with the supervision story.)
   the bus keeps dispatching to the dead address forever. Because that sweep
   can't tell a stale row from a *live peer's*, the CLI takes two flock'd
   singletons at startup (both released on exit): one keyed on the **hook
-  URL** (in a fixed lock dir, so a second instance registering the same URL
-  refuses *regardless of wake dir* - the URL is what the sweep contends on),
-  and one on the **wake dir** (`bridge.singleton.lock` there - two bridges
-  would otherwise interleave the same spool files). To run two bridges at
-  once they need BOTH a distinct hook URL (a different `--port` *and*
-  `--hook-url`) and a distinct `--wake-dir`; changing only `--wake-dir`
-  leaves the hook URL colliding, and changing only the port leaves the wake
-  dir colliding. Embedders manage their own single-instance story.
+  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR` or
+  `/tmp`, HOME-independent so a second instance registering the same URL
+  refuses *regardless of wake dir or `$HOME`* - the URL is what the sweep
+  contends on), and one on the **wake dir** (`bridge.singleton.lock` there -
+  two bridges would otherwise interleave the same spool files). To run two
+  bridges at once they need BOTH a distinct hook URL (a different `--port`
+  *and* `--hook-url`) and a distinct `--wake-dir`; changing only
+  `--wake-dir` leaves the hook URL colliding, and changing only the port
+  leaves the wake dir colliding. One case is out of scope for v1: two
+  *different Unix users* on one machine sharing a bus (the loopback-trusting
+  auth lets a second account's default bus URL land on the first's bus) get
+  different uid-scoped lock dirs, so they do not contend - give each user's
+  bridge a distinct `--port`/`--hook-url` there. Embedders manage their own
+  single-instance story.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
 - The hook body is capped at 1 MiB (the HMAC can only be checked after
@@ -499,15 +505,20 @@ That lands with the supervision story.)
   can POST preflight-free via `fetch(mode:"no-cors")` only with a
   CORS-safelisted content type (text/plain et al); requiring the bus's
   media type forces a preflight the bridge never answers. (2) It requires
-  a recognized `Host` (421 otherwise): loopback literals plus the hook
-  URL's hostname. This closes DNS rebinding, where the attacker page is
-  *same-origin* (served from `evil.example:<port>`, A record then flipped
-  to 127.0.0.1) so CORS never applies - but the browser fills `Host` from
-  the page's URL, so a rebound request necessarily carries the attacker's
-  hostname. Neither guard authenticates the *sender* - that is the
-  secret's job, and off-box topologies still require it. When poking the
-  endpoint with `curl`, send the JSON content type and address the bridge
-  by a loopback literal or the hook URL's hostname.
+  a recognized `Host` (421 otherwise): loopback literals, the hook URL's
+  hostname, and the bound interface's address when `--bind` pins a
+  non-wildcard one (so a monitoring probe can address it by IP). This closes
+  DNS rebinding, where the attacker page is *same-origin* (served from
+  `evil.example:<port>`, A record then flipped to 127.0.0.1) so CORS never
+  applies - but the browser fills `Host` from the page's URL, so a rebound
+  request necessarily carries the attacker's hostname, never a loopback
+  literal or the bound address; allowlisting the bind address weakens
+  nothing. Both guards run in middleware ahead of routing, so a 405/404
+  cannot confirm a bridge is here either. Neither authenticates the
+  *sender* - that is the secret's job, and off-box topologies still require
+  it. When poking the endpoint with `curl`, send the JSON content type and
+  address the bridge by a loopback literal, the hook URL's hostname, or the
+  bound address.
 - `GET /health` reports `registered`: whether the *startup* registration
   succeeded. The row is not re-verified afterwards, so unregistering the
   webhook by hand (or restoring the bus DB from a backup) leaves
@@ -516,8 +527,8 @@ That lands with the supervision story.)
   follow-up. `/health` carries the same `Host` allowlist as `/hook` (421
   otherwise) - a supervisor probing `http://127.0.0.1:<port>/health` sends
   a loopback `Host` and passes, but a rebound browser tab cannot even
-  confirm a bridge runs here. Probe it by a loopback literal or the hook
-  URL's hostname, same as `/hook`.
+  confirm a bridge runs here. Probe it by a loopback literal, the hook
+  URL's hostname, or the bound address, same as `/hook`.
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -339,7 +339,10 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   is a follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
-  session-side must maintain; unmapped sessions just spool.
+  session-side must maintain; unmapped sessions just spool. A stale mapping
+  types the wake prompt into whatever now owns the pane (usually a shell
+  after the session exits), so the maintainer of `panes.json` should prune
+  entries when sessions end.
 - Per-session cooldown (default 30s, `--cooldown`) bounds *successful*
   wake-ups; events during cooldown are spooled, never dropped, and a failed
   tmux attempt doesn't burn the window.

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -324,9 +324,13 @@ small localhost daemon that registers a webhook on the bus, filters to
 session. Broadcast events stay pull-only.
 
 ```
-agent-event-bus-bridge                    # spool backend (default)
-agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
+uv run agent-event-bus-bridge                    # spool backend (default)
+uv run agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 ```
+
+(`uv run` from the repo checkout: the console script lives in the project
+venv - unlike `agent-event-bus-cli`, nothing symlinks it onto PATH yet.
+That lands with the supervision story.)
 
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -321,7 +321,10 @@ Webhooks retry up to 2 times with exponential backoff if the endpoint returns 4x
 `agent-event-bus-bridge` closes the pull-only delivery gap (RFC #122): a
 small localhost daemon that registers a webhook on the bus, filters to
 **actionable** events on **`session:` channels** (DMs), and wakes the target
-session. Broadcast events stay pull-only.
+session. Broadcast events stay pull-only. Address DMs by **`session_id`**
+(the UUID) - `display_id` is display-only bus-wide, so a
+`session:<display-id>` event still spools (every `session:` channel is
+actionable) but into a file no drain hook ever reads.
 
 ```
 uv run agent-event-bus-bridge                    # spool backend (default)

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -323,8 +323,9 @@ small localhost daemon that registers a webhook on the bus, filters to
 **actionable** events on **`session:` channels** (DMs), and wakes the target
 session. Broadcast events stay pull-only. Address DMs by **`session_id`**
 (the UUID) - `display_id` is display-only bus-wide, so a
-`session:<display-id>` event still spools (every `session:` channel is
-actionable) but into a file no drain hook ever reads.
+`session:<display-id>` event still spools (a `session:` channel is
+actionable unless the publisher overrides `signal_level`) but into a file
+no drain hook ever reads.
 
 ```
 uv run agent-event-bus-bridge                    # spool backend (default)

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -459,7 +459,11 @@ Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
 `--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
 `--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
-`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_BRIDGE_SECRET` is
+`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_WAKE_DIR`
+deliberately lacks the `_BRIDGE_` infix its siblings carry: the wake dir is
+the one bridge setting a *non-bridge* process (the drain hook) must also
+read, so its name must not read as bridge-internal.
+`AGENT_EVENT_BUS_BRIDGE_SECRET` is
 deliberately env-only - a `--secret` flag would expose the value in `ps`
 output and shell history. `DEV_MODE=1` turns on debug logging (the
 per-event reasons a delivery did nothing) - the same switch the bus server

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -331,17 +331,24 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
   drain. This durable path is always on, in every backend. Drain contract:
-  rename first, then read - `mv <sid>.jsonl <sid>.jsonl.draining`, drain the
-  renamed file, delete it. (Read-then-truncate would race the bridge's
-  appends: an event landing between the read and the truncate would be
-  destroyed after the bus already got its 200, with no retry. The bridge
-  opens the spool fresh on every append, so with a rename an append lands
-  either before it - drained now - or after it, starting a fresh spool for
-  the next drain; nothing is lost in either interleaving.) Dedupe on
-  `event_id` when acting: a delivery that spools but then errors is retried
-  by the bus, so the same event can legitimately appear on more than one
-  line. The wake dir is created 0o700 (spool files carry full event
-  payloads); pruning spools for dead sessions is a follow-up.
+  1. If `<sid>.jsonl.draining` already exists, drain and delete it first - a
+     drain that died mid-protocol (hook timeout, session exit, reboot)
+     leaves one behind, and nothing else will ever read it.
+  2. Take an exclusive `flock` on `<sid>.lock`, `mv <sid>.jsonl
+     <sid>.jsonl.draining`, release the lock. The bridge holds the same
+     flock around every append, so the rename can't slip between the
+     bridge's open and its flush (an fd follows the inode, not the name -
+     without the lock a just-appended line could land in a file the drainer
+     already read).
+  3. Drain the renamed file, then delete it.
+  (Read-then-truncate instead of this would race the bridge's appends: an
+  event landing between the read and the truncate would be destroyed after
+  the bus already got its 200, with no retry.) Dedupe on `event_id` when
+  acting: a delivery that spools but then errors is retried by the bus, and
+  a recovered `.draining` may overlap with what a dead drain already acted
+  on, so the same event can legitimately appear more than once. The wake
+  dir is created 0o700 (spool files carry full event payloads); pruning
+  spools and lock files for dead sessions is a follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. A stale mapping

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -375,7 +375,11 @@ That lands with the supervision story.)
      drain-unique, so no two drains can ever target or delete the same
      name - and if the age test ever claims a merely *stalled*
      drainer's file, the `event_id` dedupe covers the double-action
-     while deletion stays claimant-only.
+     while deletion stays claimant-only. Skip lines that do not parse:
+     a host crash inside the writeback window can truncate the last
+     append, and the following append is glued onto the remnant - a
+     drainer that raises on `json.loads` would re-raise on every
+     attempt against its own claimed file, forever.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Spooled payloads are
@@ -425,8 +429,9 @@ That lands with the supervision story.)
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
-  backend, no `panes.json` entry - the *normal* outcome for a session on
-  another machine), or `spool-tmux-failed` (the `send-keys` attempt itself
+  backend, no usable `panes.json` entry: absent - the *normal* outcome for
+  a session on another machine - or present but not a pane id, which
+  warns), or `spool-tmux-failed` (the `send-keys` attempt itself
   failed). Only the last one means tmux is broken on this host. The bus
   discards the response body (it logs just the status code, at debug), so
   `action` is visible only to a direct caller of `/hook` - the bridge's own

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -331,12 +331,17 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
   drain. This durable path is always on, in every backend. Drain contract:
-  the consuming hook owns the file - read it, act, then truncate it (the
-  bridge only ever appends). Dedupe on `event_id` when acting: a delivery
-  that spools but then errors is retried by the bus, so the same event can
-  legitimately appear on more than one line. The wake dir is created 0o700
-  (spool files carry full event payloads); pruning spools for dead sessions
-  is a follow-up.
+  rename first, then read - `mv <sid>.jsonl <sid>.jsonl.draining`, drain the
+  renamed file, delete it. (Read-then-truncate would race the bridge's
+  appends: an event landing between the read and the truncate would be
+  destroyed after the bus already got its 200, with no retry. The bridge
+  opens the spool fresh on every append, so with a rename an append lands
+  either before it - drained now - or after it, starting a fresh spool for
+  the next drain; nothing is lost in either interleaving.) Dedupe on
+  `event_id` when acting: a delivery that spools but then errors is retried
+  by the bus, so the same event can legitimately appear on more than one
+  line. The wake dir is created 0o700 (spool files carry full event
+  payloads); pruning spools for dead sessions is a follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. A stale mapping

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -391,7 +391,10 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   job: bound how often you act on a drained spool, and dedupe on `event_id`.
 - Startup is idempotent: stale active webhooks at this bridge's URL (from
   unclean exits) are removed before registering, so restarts never stack
-  duplicate deliveries.
+  duplicate deliveries. The sweep matches the URL being registered NOW -
+  after changing `--port` or `--hook-url`, drop the row at the old URL
+  yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
+  the bus keeps dispatching to the dead address forever.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
 

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -399,7 +399,12 @@ That lands with the supervision story.)
   fresh inode and mutual exclusion is silently gone.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
-  session-side must maintain; unmapped sessions just spool. A stale mapping
+  session-side must maintain; unmapped sessions just spool. Requires a tmux
+  binary on the daemon's PATH at startup - the bridge REFUSES TO START
+  otherwise, and the check is PATH-sensitive: a supervisor's minimal PATH
+  (launchd defaults to `/usr/bin:/bin:/usr/sbin:/sbin`) can hide a Homebrew
+  tmux your shell sees, so put tmux on the daemon's PATH, not just yours.
+  A tmux that breaks *later* degrades per-wake to spool instead. A stale mapping
   types the wake prompt into whatever now owns the pane (usually a shell
   after the session exits), so the maintainer of `panes.json` should prune
   entries when sessions end.
@@ -431,9 +436,10 @@ That lands with the supervision story.)
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
-  backend, no usable `panes.json` entry: absent - the *normal* outcome for
-  a session on another machine - or present but not a pane id, which
-  warns), or `spool-tmux-failed` (the `send-keys` attempt itself
+  backend, no usable pane mapping - *normally* because the session lives
+  on another machine, but also when `panes.json` is missing, unreadable,
+  malformed, or its entry is not a pane id; the misconfiguration shapes
+  warn, so check the log), or `spool-tmux-failed` (the `send-keys` attempt itself
   failed). Only the last one means tmux is broken on this host. The bus
   discards the response body (it logs just the status code, at debug), so
   `action` is visible only to a direct caller of `/hook` - the bridge's own

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -350,7 +350,9 @@ That lands with the supervision story.)
   `signal_level` is always `actionable` on a spooled line by construction
   (the bridge filters before spooling), so a hook need not re-check it -
   and pass-through means bus-side payload additions appear additively:
-  read the keys you know, ignore the rest. Drain contract:
+  read the keys you know, ignore the rest. Each line is UTF-8 JSON
+  (`json.dumps`, one object per line); read it as UTF-8, not the drain
+  hook's locale codec. Drain contract:
   1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
@@ -426,7 +428,10 @@ That lands with the supervision story.)
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. The writer's
   contract matters as much as the drainer's: write atomically (temp file in
-  the same directory + `os.replace`) and serialize the read-modify-write
+  the same directory + `os.replace`), write UTF-8 (the bridge reads it as
+  UTF-8, not its locale codec - a supervisor-launched daemon often runs
+  under the C locale, where a bytewise-different codec would misread any
+  non-ASCII), and serialize the read-modify-write
   under an flock on a sibling `panes.lock` - concurrent SessionStart hooks
   otherwise silently lose entries (the loser reads as absent, the
   documented *normal* outcome, so nothing errors on either side), and a

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -379,7 +379,14 @@ That lands with the supervision story.)
      a host crash inside the writeback window can truncate the last
      append, and the following append is glued onto the remnant - a
      drainer that raises on `json.loads` would re-raise on every
-     attempt against its own claimed file, forever.
+     attempt against its own claimed file, forever. Claimed names are
+     stable only within the staleness window: stall in this step past it
+     and a concurrent drain legitimately re-claims your files (staleness
+     is age, not liveness - deliberately, per step 2), so glob your own
+     `.draining.<uniq>.*` afresh here rather than replaying a list
+     recorded in step 2, and treat `ENOENT` on any open or unlink as
+     benign - another drain judged you stale and claimed the file; its
+     `event_id` dedupe covers the overlap.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Spooled payloads are
@@ -392,7 +399,10 @@ That lands with the supervision story.)
   so the same event can legitimately appear more than once. The wake dir is
   *set* to 0o700 on every start - created or not, so a pre-existing
   directory pointed at via `--wake-dir` is narrowed too (spool files carry
-  full event payloads); pruning spools and
+  full event payloads). Spool and lock files are created 0o600 for the
+  same reason, independent of the process umask - and rename preserves
+  the mode, so your `.draining.*` claims inherit it; anything you
+  *create* in the wake dir yourself should match. Pruning spools and
   lock files for dead sessions is a follow-up - with one constraint: flock
   binds to an inode, so unlink a `<sid>.lock` only while holding its flock
   and only when no `<sid>.jsonl*` remains, or the next appender locks a

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -330,14 +330,27 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
-  drain. This durable path is always on, in every backend.
+  drain. This durable path is always on, in every backend. Drain contract:
+  the consuming hook owns the file - read it, act, then truncate it (the
+  bridge only ever appends). The wake dir is created 0o700 (spool files
+  carry full event payloads); pruning spools for dead sessions is a
+  follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool.
-- Per-session cooldown (default 30s, `--cooldown`) bounds wake-ups; events
-  during cooldown are spooled, never dropped.
+- Per-session cooldown (default 30s, `--cooldown`) bounds *successful*
+  wake-ups; events during cooldown are spooled, never dropped, and a failed
+  tmux attempt doesn't burn the window.
+- Startup is idempotent: stale active webhooks at this bridge's URL (from
+  unclean exits) are removed before registering, so restarts never stack
+  duplicate deliveries.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
+
+Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
+`--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,
+`--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
+`--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`.
 
 ## Best Practices
 

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -373,7 +373,7 @@ authentication on that hop - and it authenticates but neither encrypts nor
 expires, so run the hop over an encrypted transport (your tailnet, or a TLS
 terminator); replay freshness is an RFC-level follow-up. `--bind` can pin
 the listener to a single interface (e.g. the tailnet address) instead of
-all interfaces. Keep `--port` and the port in `--hook-url` in agreement
+all interfaces - any non-loopback bind requires the secret too. Keep `--port` and the port in `--hook-url` in agreement
 unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
 every `session:` DM; tmux wakes only work for sessions on the bridge's own
 machine, and spool files for foreign sessions accumulate until the pruning

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -390,7 +390,9 @@ That lands with the supervision story.)
   `event_id` when acting: a delivery that spools but then errors is retried by the bus, and
   a recovered orphan may overlap with what a dead drain already acted on,
   so the same event can legitimately appear more than once. The wake dir is
-  created 0o700 (spool files carry full event payloads); pruning spools and
+  *set* to 0o700 on every start - created or not, so a pre-existing
+  directory pointed at via `--wake-dir` is narrowed too (spool files carry
+  full event payloads); pruning spools and
   lock files for dead sessions is a follow-up - with one constraint: flock
   binds to an inode, so unlink a `<sid>.lock` only while holding its flock
   and only when no `<sid>.jsonl*` remains, or the next appender locks a

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -337,7 +337,11 @@ That lands with the supervision story.)
 
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
-  drain. This durable path is always on, in every backend. Drain contract:
+  drain. This path is always on, in every backend, and durable against
+  bridge and session crashes - but the append is not fsync'ed, so a
+  host-level crash (kernel panic, power loss) inside the writeback window
+  can lose a wake the bus already counted delivered; fsync-on-append is an
+  accepted follow-up. Drain contract:
   1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
@@ -433,7 +437,9 @@ Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
 `--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_BRIDGE_SECRET` is
 deliberately env-only - a `--secret` flag would expose the value in `ps`
-output and shell history.
+output and shell history. `DEV_MODE=1` turns on debug logging (the
+per-event reasons a delivery did nothing) - the same switch the bus server
+honors.
 
 **Remote-bus topology**: the defaults assume the bus runs on the same
 machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -354,6 +354,12 @@ Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
 `--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`.
 
+Supervision is deliberately out of scope for the v1 prototype: there is no
+`make install-bridge`, launchd plist, or systemd unit yet - run the bridge in
+a terminal (or your own supervisor) while experimenting. Startup ordering is
+already safe for a future supervisor (registration retries until the bus is
+up); unit files land once the prototype proves out (RFC #122).
+
 ## Best Practices
 
 1. **Register with client_id** - Enables session resumption

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -410,11 +410,18 @@ That lands with the supervision story.)
   full event payloads). Spool and lock files are created 0o600 for the
   same reason, independent of the process umask - and rename preserves
   the mode, so your `.draining.*` claims inherit it; anything you
-  *create* in the wake dir yourself should match. Pruning spools and
-  lock files for dead sessions is a follow-up - with one constraint: flock
-  binds to an inode, so unlink a `<sid>.lock` only while holding its flock
-  and only when no `<sid>.jsonl*` remains, or the next appender locks a
-  fresh inode and mutual exclusion is silently gone.
+  *create* in the wake dir yourself should match. Pruning spools for dead
+  sessions is a follow-up whose safe target is `<sid>.jsonl*` only -
+  `<sid>.lock` files are never reclaimed in v1. The obvious recipe
+  (unlink the lock while holding its flock, once no `<sid>.jsonl*`
+  remains) has an unobservable precondition: during a contended first
+  delivery for a new session, an appender already holds an open fd on the
+  lock and is blocked in its retry loop *before any `.jsonl` exists* -
+  flock binds to an inode, so unlinking there hands that appender an
+  orphaned inode whose lock excludes nobody, and the tearing the flock
+  prevents comes back with no way to observe it. Lock files are zero
+  bytes: retaining them is noise, not cost - the payload-bearing spool
+  files are the thing worth pruning.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. The writer's
@@ -453,6 +460,14 @@ That lands with the supervision story.)
   can make the bridge hold). The bus does not cap event payloads, so a DM
   larger than that is refused (413, retried twice, then dropped) and stays
   pull-only: it reaches the session by polling, never as a wake.
+- `POST /hook` requires `Content-Type: application/json` (415 otherwise) -
+  what the bus's dispatch always sends. This is a security boundary, not
+  pedantry: without it, a web page open in the operator's browser could
+  POST to the loopback listener preflight-free via `fetch(mode:"no-cors")`
+  with a CORS-safelisted content type, writing attacker-authored spool
+  lines with no secret configured. Requiring the bus's media type forces a
+  preflight the bridge never answers. Remember the header when poking the
+  endpoint with `curl`.
 - `GET /health` reports `registered`: whether the *startup* registration
   succeeded. The row is not re-verified afterwards, so unregistering the
   webhook by hand (or restoring the bus DB from a backup) leaves

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -359,7 +359,8 @@ Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,
 `--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
 `--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
-`--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`.
+`--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
+`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`.
 
 **Remote-bus topology**: the defaults assume the bus runs on the same
 machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
@@ -368,9 +369,12 @@ bridge refuses to start unless `--hook-url` advertises an address the bus
 host can reach (e.g. your Tailscale hostname). The listener then binds
 non-loopback, and the bridge refuses to start without
 `AGENT_EVENT_BUS_BRIDGE_SECRET`: the HMAC signature is the only
-authentication on that hop. Keep `--port` and the port in `--hook-url` in
-agreement unless a proxy genuinely forwards between them (a mismatch is
-logged). Note webhooks have no machine scoping - every bridge receives
+authentication on that hop - and it authenticates but neither encrypts nor
+expires, so run the hop over an encrypted transport (your tailnet, or a TLS
+terminator); replay freshness is an RFC-level follow-up. `--bind` can pin
+the listener to a single interface (e.g. the tailnet address) instead of
+all interfaces. Keep `--port` and the port in `--hook-url` in agreement
+unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
 every `session:` DM; tmux wakes only work for sessions on the bridge's own
 machine, and spool files for foreign sessions accumulate until the pruning
 follow-up lands. Machine-scoped delivery is a v2 item.

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -338,17 +338,21 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      already read). The bridge's acquire is bounded (~5s), so keep your
      hold to the renames below - never drain while holding the lock.
   2. Under the lock, claim a batch by rename (renames only, so the hold
-     stays short). Every claim must target a *unique* name -
-     `<sid>.jsonl.draining.$$.<seq>` with a per-file sequence number -
-     because rename silently replaces an existing target, so two claims
-     onto one name would destroy a batch. Claim any stale
-     `<sid>.jsonl.draining.*` (a drain that died mid-protocol - hook
-     timeout, session exit, reboot - leaves one behind), judging
-     staleness by age (e.g. mtime over a minute old), not pid liveness -
-     pids recycle across reboots, so a dead drainer's pid can read as
-     live forever. Then claim the live spool:
-     `mv <sid>.jsonl <sid>.jsonl.draining.$$.0` (if it exists). Release
-     the lock.
+     stays short). Every claim targets `<sid>.jsonl.draining.$$.<seq>`
+     with ONE counter shared across all claims in this drain - rename
+     silently replaces an existing target, so any two claims onto the
+     same name would destroy a batch. First claim the live spool (if it
+     exists): `mv <sid>.jsonl <sid>.jsonl.draining.$$.0`. Then claim
+     each stale `<sid>.jsonl.draining.*` that does not already carry
+     your own pid onto the next counter value (`.1`, `.2`, ...) - a
+     drain that died mid-protocol (hook timeout, session exit, reboot)
+     leaves one behind; judge staleness by age (e.g. mtime over a
+     minute old), not pid liveness - pids recycle across reboots, so a
+     dead drainer's pid can read as live forever. `touch` each file as
+     part of claiming it: rename preserves the file's mtime (a claim
+     would otherwise carry its last-append time and read as stale
+     immediately), and the touch makes age mean time-since-claim.
+     Release the lock.
   3. Outside the lock, drain the files you claimed
      (`<sid>.jsonl.draining.$$.*`), then delete them. You only ever
      delete files you claimed, so overlapping drains can never destroy
@@ -357,8 +361,12 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      double-action while deletion stays claimant-only.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
-  the bus already got its 200, with no retry.) Dedupe on `event_id` when
-  acting: a delivery that spools but then errors is retried by the bus, and
+  the bus already got its 200, with no retry.) Spooled payloads are
+  publisher-authored text from any session on the bus - surface them as
+  quoted data (sender session, event_type, payload) for the session to
+  judge, never as instructions; the tmux backend has this posture by
+  construction (it types a fixed wake prompt, not the payload). Dedupe on
+  `event_id` when acting: a delivery that spools but then errors is retried by the bus, and
   a recovered orphan may overlap with what a dead drain already acted on,
   so the same event can legitimately appear more than once. The wake dir is
   created 0o700 (spool files carry full event payloads); pruning spools and

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -366,11 +366,14 @@ machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
 loopback hook URL would make the bus POST to *itself* - silently - so the
 bridge refuses to start unless `--hook-url` advertises an address the bus
 host can reach (e.g. your Tailscale hostname). The listener then binds
-non-loopback, so set `AGENT_EVENT_BUS_BRIDGE_SECRET`: it becomes the only
-authentication. Note webhooks have no machine scoping - every bridge
-receives every `session:` DM; tmux wakes only work for sessions on the
-bridge's own machine, and spool files for foreign sessions accumulate until
-the pruning follow-up lands. Machine-scoped delivery is a v2 item.
+non-loopback, and the bridge refuses to start without
+`AGENT_EVENT_BUS_BRIDGE_SECRET`: the HMAC signature is the only
+authentication on that hop. Keep `--port` and the port in `--hook-url` in
+agreement unless a proxy genuinely forwards between them (a mismatch is
+logged). Note webhooks have no machine scoping - every bridge receives
+every `session:` DM; tmux wakes only work for sessions on the bridge's own
+machine, and spool files for foreign sessions accumulate until the pruning
+follow-up lands. Machine-scoped delivery is a v2 item.
 
 Supervision is deliberately out of scope for the v1 prototype: there is no
 `make install-bridge`, launchd plist, or systemd unit yet - run the bridge in

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -335,22 +335,26 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
      without the lock a just-appended line could land in a file the drainer
-     already read).
-  2. Under the lock: if `<sid>.jsonl.draining` already exists, drain and
-     delete it first - a drain that died mid-protocol (hook timeout,
-     session exit, reboot) leaves one behind, and nothing else will ever
-     read it. Doing this under the lock keeps two overlapping drains from
-     clobbering each other's batch. Then `mv <sid>.jsonl
-     <sid>.jsonl.draining` and release the lock.
-  3. Drain the renamed file (outside the lock), then delete it.
+     already read). The bridge's acquire is bounded (~5s), so keep your
+     hold to the renames below - never drain while holding the lock.
+  2. Under the lock, claim a batch by rename (renames only, so the hold
+     stays short): any `<sid>.jsonl.draining.<pid>` whose pid is dead is an
+     orphan from a drain that died mid-protocol (hook timeout, session
+     exit, reboot) - rename each onto your own pid. A file whose pid is
+     alive belongs to a drainer still in step 3: leave it. Then
+     `mv <sid>.jsonl <sid>.jsonl.draining.$$` (if it exists) and release
+     the lock.
+  3. Outside the lock, drain the files you renamed, then delete them. You
+     only ever delete files carrying your own pid, so overlapping drains
+     can never destroy each other's batch.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Dedupe on `event_id` when
   acting: a delivery that spools but then errors is retried by the bus, and
-  a recovered `.draining` may overlap with what a dead drain already acted
-  on, so the same event can legitimately appear more than once. The wake
-  dir is created 0o700 (spool files carry full event payloads); pruning
-  spools and lock files for dead sessions is a follow-up.
+  a recovered orphan may overlap with what a dead drain already acted on,
+  so the same event can legitimately appear more than once. The wake dir is
+  created 0o700 (spool files carry full event payloads); pruning spools and
+  lock files for dead sessions is a follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. A stale mapping

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -460,14 +460,22 @@ That lands with the supervision story.)
   can make the bridge hold). The bus does not cap event payloads, so a DM
   larger than that is refused (413, retried twice, then dropped) and stays
   pull-only: it reaches the session by polling, never as a wake.
-- `POST /hook` requires `Content-Type: application/json` (415 otherwise) -
-  what the bus's dispatch always sends. This is a security boundary, not
-  pedantry: without it, a web page open in the operator's browser could
-  POST to the loopback listener preflight-free via `fetch(mode:"no-cors")`
-  with a CORS-safelisted content type, writing attacker-authored spool
-  lines with no secret configured. Requiring the bus's media type forces a
-  preflight the bridge never answers. Remember the header when poking the
-  endpoint with `curl`.
+- `POST /hook` carries two browser guards, because "loopback needs no
+  secret" is only true if a page in the operator's browser cannot reach
+  the handler. (1) It requires `Content-Type: application/json` (415
+  otherwise) - what the bus's dispatch always sends. A *cross-origin* page
+  can POST preflight-free via `fetch(mode:"no-cors")` only with a
+  CORS-safelisted content type (text/plain et al); requiring the bus's
+  media type forces a preflight the bridge never answers. (2) It requires
+  a recognized `Host` (421 otherwise): loopback literals plus the hook
+  URL's hostname. This closes DNS rebinding, where the attacker page is
+  *same-origin* (served from `evil.example:<port>`, A record then flipped
+  to 127.0.0.1) so CORS never applies - but the browser fills `Host` from
+  the page's URL, so a rebound request necessarily carries the attacker's
+  hostname. Neither guard authenticates the *sender* - that is the
+  secret's job, and off-box topologies still require it. When poking the
+  endpoint with `curl`, send the JSON content type and address the bridge
+  by a loopback literal or the hook URL's hostname.
 - `GET /health` reports `registered`: whether the *startup* registration
   succeeded. The row is not re-verified afterwards, so unregistering the
   webhook by hand (or restoring the bus DB from a backup) leaves

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -331,16 +331,18 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
   drain. This durable path is always on, in every backend. Drain contract:
-  1. If `<sid>.jsonl.draining` already exists, drain and delete it first - a
-     drain that died mid-protocol (hook timeout, session exit, reboot)
-     leaves one behind, and nothing else will ever read it.
-  2. Take an exclusive `flock` on `<sid>.lock`, `mv <sid>.jsonl
-     <sid>.jsonl.draining`, release the lock. The bridge holds the same
-     flock around every append, so the rename can't slip between the
+  1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
+     flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -
      without the lock a just-appended line could land in a file the drainer
      already read).
-  3. Drain the renamed file, then delete it.
+  2. Under the lock: if `<sid>.jsonl.draining` already exists, drain and
+     delete it first - a drain that died mid-protocol (hook timeout,
+     session exit, reboot) leaves one behind, and nothing else will ever
+     read it. Doing this under the lock keeps two overlapping drains from
+     clobbering each other's batch. Then `mv <sid>.jsonl
+     <sid>.jsonl.draining` and release the lock.
+  3. Drain the renamed file (outside the lock), then delete it.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Dedupe on `event_id` when

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -325,7 +325,14 @@ session. Broadcast events stay pull-only. Address DMs by **`session_id`**
 (the UUID) - `display_id` is display-only bus-wide, so a
 `session:<display-id>` event still spools (a `session:` channel is
 actionable unless the publisher overrides `signal_level`) but into a file
-no drain hook ever reads.
+no drain hook ever reads. One more addressability caveat: a session
+registered with a `client_id` adopts it as its `session_id` verbatim, and
+the bridge can only wake ids matching `[A-Za-z0-9_-]{1,64}` (the id
+becomes a spool filename). A `client_id` carrying a `.`, `/`, space, or
+over 64 chars (a cwd- or `repo:branch`-derived key) registers fine but is
+unwakeable - its DMs resolve to no target and log only a rate-limited
+"unsafe session id" warning. Keep `client_id` within that charset until
+bus-side validation lands.
 
 ```
 uv run agent-event-bus-bridge                    # spool backend (default)
@@ -431,7 +438,15 @@ That lands with the supervision story.)
   the same directory + `os.replace`), write UTF-8 (the bridge reads it as
   UTF-8, not its locale codec - a supervisor-launched daemon often runs
   under the C locale, where a bytewise-different codec would misread any
-  non-ASCII), and serialize the read-modify-write
+  non-ASCII), write each value as a non-empty printable pane id (`"%0"`)
+  and OMIT the entry entirely when `$TMUX_PANE` is unset rather than
+  writing `null` or `""` - `panes[sid] = os.environ.get("TMUX_PANE")`
+  emits `null` outside tmux, which the bridge treats as a *present-but-bad*
+  value (it warns and names the entry to fix), a different diagnosis and
+  repair than the quiet *absent* path an omitted entry takes; a value with
+  a control character (e.g. an embedded NUL) is rejected the same way
+  before it can reach the `send-keys` argv - and serialize the
+  read-modify-write
   under an flock on a sibling `panes.lock` - concurrent SessionStart hooks
   otherwise silently lose entries (the loser reads as absent, the
   documented *normal* outcome, so nothing errors on either side), and a
@@ -486,7 +501,11 @@ That lands with the supervision story.)
   webhook by hand (or restoring the bus DB from a backup) leaves
   `registered: true` on a bridge the bus no longer dispatches to - restart
   the bridge after manual webhook surgery. Periodic re-assertion is a
-  follow-up.
+  follow-up. `/health` carries the same `Host` allowlist as `/hook` (421
+  otherwise) - a supervisor probing `http://127.0.0.1:<port>/health` sends
+  a loopback `Host` and passes, but a rebound browser tab cannot even
+  confirm a bridge runs here. Probe it by a loopback literal or the hook
+  URL's hostname, same as `/hook`.
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -410,6 +410,14 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   `registered: true` on a bridge the bus no longer dispatches to - restart
   the bridge after manual webhook surgery. Periodic re-assertion is a
   follow-up.
+- Each delivered `200` carries an `action` field naming what happened:
+  `spool` (spool backend, working as designed), `tmux` (wake injected),
+  `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
+  backend, no `panes.json` entry - the *normal* outcome for a session on
+  another machine), or `spool-tmux-failed` (the `send-keys` attempt itself
+  failed). Only the last one means tmux is broken on this host; the
+  unmapped arm logs only at debug, so the response body is where that
+  distinction surfaces at the default log level.
 
 Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -342,7 +342,15 @@ That lands with the supervision story.)
   bridge and session crashes - but the append is not fsync'ed, so a
   host-level crash (kernel panic, power loss) inside the writeback window
   can lose a wake the bus already counted delivered; fsync-on-append is an
-  accepted follow-up. Drain contract:
+  accepted follow-up. Each line is the bus's webhook payload passed through
+  verbatim: `event_id`, `event_type`, `payload`, `session_id` (the
+  **sender**, not the wake target - the target is the file's name, also in
+  the `session:<id>` channel), `timestamp`, `channel`, `correlation_id`,
+  `signal_level`, plus `title`/`tags` only when the publisher set them.
+  `signal_level` is always `actionable` on a spooled line by construction
+  (the bridge filters before spooling), so a hook need not re-check it -
+  and pass-through means bus-side payload additions appear additively:
+  read the keys you know, ignore the rest. Drain contract:
   1. Take an exclusive `flock` on `<sid>.lock`. The bridge holds the same
      flock around every append, so the rename below can't slip between the
      bridge's open and its flush (an fd follows the inode, not the name -

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -338,27 +338,30 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      already read). The bridge's acquire is bounded (~5s), so keep your
      hold to the renames below - never drain while holding the lock.
   2. Under the lock, claim a batch by rename (renames only, so the hold
-     stays short). Every claim targets `<sid>.jsonl.draining.$$.<seq>`
-     with ONE counter shared across all claims in this drain - rename
-     silently replaces an existing target, so any two claims onto the
-     same name would destroy a batch. First claim the live spool (if it
-     exists): `mv <sid>.jsonl <sid>.jsonl.draining.$$.0`. Then claim
-     each stale `<sid>.jsonl.draining.*` that does not already carry
-     your own pid onto the next counter value (`.1`, `.2`, ...) - a
-     drain that died mid-protocol (hook timeout, session exit, reboot)
-     leaves one behind; judge staleness by age (e.g. mtime over a
-     minute old), not pid liveness - pids recycle across reboots, so a
-     dead drainer's pid can read as live forever. `touch` each file as
+     stays short). Pick a claim id `<uniq>` unique to THIS drain - pid
+     plus a timestamp, or an mktemp-style suffix. Pid alone is NOT
+     unique: pids recycle (across reboots, or between two drains of the
+     same session), and rename silently replaces an existing target, so
+     a recycled pid would destroy a dead drain's batch with its own
+     claim. Every claim targets `<sid>.jsonl.draining.<uniq>.<seq>`
+     with one counter shared across the drain's claims. First claim the
+     live spool (if it exists):
+     `mv <sid>.jsonl <sid>.jsonl.draining.<uniq>.0`. Then claim each
+     stale `<sid>.jsonl.draining.*` not carrying your own claim id onto
+     the next counter value (`.1`, `.2`, ...) - a drain that died
+     mid-protocol (hook timeout, session exit, reboot) leaves one
+     behind; judge staleness by age (e.g. mtime over a minute old), not
+     pid liveness, for the same recycling reason. `touch` each file as
      part of claiming it: rename preserves the file's mtime (a claim
      would otherwise carry its last-append time and read as stale
      immediately), and the touch makes age mean time-since-claim.
      Release the lock.
   3. Outside the lock, drain the files you claimed
-     (`<sid>.jsonl.draining.$$.*`), then delete them. You only ever
-     delete files you claimed, so overlapping drains can never destroy
-     each other's batch - and if the age test ever claims a merely
-     *stalled* drainer's file, the `event_id` dedupe covers the
-     double-action while deletion stays claimant-only.
+     (`<sid>.jsonl.draining.<uniq>.*`), then delete them. Claim ids are
+     drain-unique, so no two drains can ever target or delete the same
+     name - and if the age test ever claims a merely *stalled*
+     drainer's file, the `event_id` dedupe covers the double-action
+     while deletion stays claimant-only.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Spooled payloads are

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -426,9 +426,11 @@ That lands with the supervision story.)
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
   backend, no `panes.json` entry - the *normal* outcome for a session on
   another machine), or `spool-tmux-failed` (the `send-keys` attempt itself
-  failed). Only the last one means tmux is broken on this host; the
-  unmapped arm logs only at debug, so the response body is where that
-  distinction surfaces at the default log level.
+  failed). Only the last one means tmux is broken on this host. The bus
+  discards the response body (it logs just the status code, at debug), so
+  `action` is visible only to a direct caller of `/hook` - the bridge's own
+  log is the operator-facing surface: failed wakes at warning, the quiet
+  arms (`spool-unmapped`, `spool-cooldown`) at debug under `DEV_MODE=1`.
 
 Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -338,15 +338,23 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
      already read). The bridge's acquire is bounded (~5s), so keep your
      hold to the renames below - never drain while holding the lock.
   2. Under the lock, claim a batch by rename (renames only, so the hold
-     stays short): any `<sid>.jsonl.draining.<pid>` whose pid is dead is an
-     orphan from a drain that died mid-protocol (hook timeout, session
-     exit, reboot) - rename each onto your own pid. A file whose pid is
-     alive belongs to a drainer still in step 3: leave it. Then
-     `mv <sid>.jsonl <sid>.jsonl.draining.$$` (if it exists) and release
+     stays short). Every claim must target a *unique* name -
+     `<sid>.jsonl.draining.$$.<seq>` with a per-file sequence number -
+     because rename silently replaces an existing target, so two claims
+     onto one name would destroy a batch. Claim any stale
+     `<sid>.jsonl.draining.*` (a drain that died mid-protocol - hook
+     timeout, session exit, reboot - leaves one behind), judging
+     staleness by age (e.g. mtime over a minute old), not pid liveness -
+     pids recycle across reboots, so a dead drainer's pid can read as
+     live forever. Then claim the live spool:
+     `mv <sid>.jsonl <sid>.jsonl.draining.$$.0` (if it exists). Release
      the lock.
-  3. Outside the lock, drain the files you renamed, then delete them. You
-     only ever delete files carrying your own pid, so overlapping drains
-     can never destroy each other's batch.
+  3. Outside the lock, drain the files you claimed
+     (`<sid>.jsonl.draining.$$.*`), then delete them. You only ever
+     delete files you claimed, so overlapping drains can never destroy
+     each other's batch - and if the age test ever claims a merely
+     *stalled* drainer's file, the `event_id` dedupe covers the
+     double-action while deletion stays claimant-only.
   (Read-then-truncate instead of this would race the bridge's appends: an
   event landing between the read and the truncate would be destroyed after
   the bus already got its 200, with no retry.) Dedupe on `event_id` when
@@ -354,7 +362,10 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   a recovered orphan may overlap with what a dead drain already acted on,
   so the same event can legitimately appear more than once. The wake dir is
   created 0o700 (spool files carry full event payloads); pruning spools and
-  lock files for dead sessions is a follow-up.
+  lock files for dead sessions is a follow-up - with one constraint: flock
+  binds to an inode, so unlink a `<sid>.lock` only while holding its flock
+  and only when no `<sid>.jsonl*` remains, or the next appender locks a
+  fresh inode and mutual exclusion is silently gone.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool. A stale mapping

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -416,7 +416,9 @@ Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
 `--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
 `--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
-`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`.
+`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_BRIDGE_SECRET` is
+deliberately env-only - a `--secret` flag would expose the value in `ps`
+output and shell history.
 
 **Remote-bus topology**: the defaults assume the bus runs on the same
 machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
@@ -429,7 +431,10 @@ authentication on that hop - and it authenticates but neither encrypts nor
 expires, so run the hop over an encrypted transport (your tailnet, or a TLS
 terminator); replay freshness is an RFC-level follow-up. `--bind` can pin
 the listener to a single interface (e.g. the tailnet address) instead of
-all interfaces - any non-loopback bind requires the secret too. Keep `--port` and the port in `--hook-url` in agreement
+all interfaces - any non-loopback bind requires the secret too. `/health`
+is intentionally unauthenticated (readiness probes shouldn't need the
+secret); it exposes only `status`/`service`/`registered`, but on a
+non-loopback bind anyone who can reach the port can read it. Keep `--port` and the port in `--hook-url` in agreement
 unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
 every `session:` DM; tmux wakes only work for sessions on the bridge's own
 machine, and spool files for foreign sessions accumulate until the pruning

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -343,9 +343,12 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   types the wake prompt into whatever now owns the pane (usually a shell
   after the session exits), so the maintainer of `panes.json` should prune
   entries when sessions end.
-- Per-session cooldown (default 30s, `--cooldown`) bounds *successful*
-  wake-ups; events during cooldown are spooled, never dropped, and a failed
-  tmux attempt doesn't burn the window.
+- Per-session cooldown (default 30s, `--cooldown`) bounds *successful tmux
+  injections*; events during cooldown are spooled, never dropped, and a
+  failed tmux attempt doesn't burn the window. In the default spool backend
+  the cooldown never engages - a spool line only becomes a wake when the
+  drain hook acts on it, so loop prevention there is the consuming hook's
+  job: bound how often you act on a drained spool, and dedupe on `event_id`.
 - Startup is idempotent: stale active webhooks at this bridge's URL (from
   unclean exits) are removed before registering, so restarts never stack
   duplicate deliveries.
@@ -355,7 +358,19 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
 Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
 `--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,
 `--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
-`--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`.
+`--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
+`--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`.
+
+**Remote-bus topology**: the defaults assume the bus runs on the same
+machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
+loopback hook URL would make the bus POST to *itself* - silently - so the
+bridge refuses to start unless `--hook-url` advertises an address the bus
+host can reach (e.g. your Tailscale hostname). The listener then binds
+non-loopback, so set `AGENT_EVENT_BUS_BRIDGE_SECRET`: it becomes the only
+authentication. Note webhooks have no machine scoping - every bridge
+receives every `session:` DM; tmux wakes only work for sessions on the
+bridge's own machine, and spool files for foreign sessions accumulate until
+the pruning follow-up lands. Machine-scoped delivery is a v2 item.
 
 Supervision is deliberately out of scope for the v1 prototype: there is no
 `make install-bridge`, launchd plist, or systemd unit yet - run the bridge in

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -399,7 +399,15 @@ That lands with the supervision story.)
   fresh inode and mutual exclusion is silently gone.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
-  session-side must maintain; unmapped sessions just spool. Requires a tmux
+  session-side must maintain; unmapped sessions just spool. The writer's
+  contract matters as much as the drainer's: write atomically (temp file in
+  the same directory + `os.replace`) and serialize the read-modify-write
+  under an flock on a sibling `panes.lock` - concurrent SessionStart hooks
+  otherwise silently lose entries (the loser reads as absent, the
+  documented *normal* outcome, so nothing errors on either side), and a
+  non-atomic in-place write produces the torn read the bridge degrades on.
+  A broken writer never surfaces as an error - only as wakes that quietly
+  never happen. Requires a tmux
   binary on the daemon's PATH at startup - the bridge REFUSES TO START
   otherwise, and the check is PATH-sensitive: a supervisor's minimal PATH
   (launchd defaults to `/usr/bin:/bin:/usr/sbin:/sbin`) can hide a Homebrew

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -477,10 +477,12 @@ That lands with the supervision story.)
   the bus keeps dispatching to the dead address forever. Because that sweep
   can't tell a stale row from a *live peer's*, the CLI takes two flock'd
   singletons at startup (both released on exit): one keyed on the **hook
-  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR` or
-  `/tmp`, HOME-independent so a second instance registering the same URL
-  refuses *regardless of wake dir or `$HOME`* - the URL is what the sweep
-  contends on), and one on the **wake dir** (`bridge.singleton.lock` there -
+  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR`, else
+  the system temp dir - `$TMPDIR`, or `/tmp` when unset; the dir is
+  create-and-verified private, not adopted - HOME-independent so a second
+  instance registering the same URL refuses *regardless of wake dir or
+  `$HOME`* - the URL is what the sweep contends on), and one on the **wake
+  dir** (`bridge.singleton.lock` there -
   two bridges would otherwise interleave the same spool files). To run two
   bridges at once they need BOTH a distinct hook URL (a different `--port`
   *and* `--hook-url`) and a distinct `--wake-dir`; changing only

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -332,9 +332,11 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
   drain. This durable path is always on, in every backend. Drain contract:
   the consuming hook owns the file - read it, act, then truncate it (the
-  bridge only ever appends). The wake dir is created 0o700 (spool files
-  carry full event payloads); pruning spools for dead sessions is a
-  follow-up.
+  bridge only ever appends). Dedupe on `event_id` when acting: a delivery
+  that spools but then errors is retried by the bus, so the same event can
+  legitimately appear on more than one line. The wake dir is created 0o700
+  (spool files carry full event payloads); pruning spools for dead sessions
+  is a follow-up.
 - **tmux**: additionally runs `tmux send-keys` into the session's pane, using
   the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
   session-side must maintain; unmapped sessions just spool.

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -399,6 +399,11 @@ agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
   the bus keeps dispatching to the dead address forever.
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
   hop (the bridge registers its webhook with the same secret).
+- The hook body is capped at 1 MiB (the HMAC can only be checked after
+  buffering the whole body, so the cap bounds what an unauthenticated peer
+  can make the bridge hold). The bus does not cap event payloads, so a DM
+  larger than that is refused (413, retried twice, then dropped) and stays
+  pull-only: it reaches the session by polling, never as a wake.
 - `GET /health` reports `registered`: whether the *startup* registration
   succeeded. The row is not re-verified afterwards, so unregistering the
   webhook by hand (or restoring the bus DB from a backup) leaves

--- a/src/agent_event_bus/helpers.py
+++ b/src/agent_event_bus/helpers.py
@@ -13,6 +13,15 @@ logger = logging.getLogger("agent-event-bus")
 # worker that called it (issue #112).
 NOTIFY_TIMEOUT = 5.0  # seconds
 
+# The webhook signature header - a wire contract with three readers (the
+# server's _dispatch_webhook sets it, the bridge's hook endpoint reads it,
+# the bridge tests build theirs from it). It lives HERE, not in server.py,
+# because server.py is not side-effect-free at module scope (it opens and
+# migrates the bus database, attaches the bus log handler, and builds the
+# FastMCP app) - and the bridge, a pure HTTP client of the bus, must be
+# able to import the name without any of that. helpers.py is import-clean.
+SIGNATURE_HEADER = "X-Event-Bus-Signature"
+
 
 def _sanitize_name(name: str) -> str:
     """Sanitize a name by replacing problematic characters."""

--- a/src/agent_event_bus/helpers.py
+++ b/src/agent_event_bus/helpers.py
@@ -22,6 +22,14 @@ NOTIFY_TIMEOUT = 5.0  # seconds
 # able to import the name without any of that. helpers.py is import-clean.
 SIGNATURE_HEADER = "X-Event-Bus-Signature"
 
+# The webhook media type - the same three-reader coupling as the header
+# above (the server's _dispatch_webhook sends it, the bridge's hook
+# endpoint REQUIRES it as its anti-browser guard, the bridge tests build
+# theirs from it). A rename touching only some readers would 415 every
+# delivery silently, so it is single-sourced here for the same
+# import-cleanliness reason.
+WEBHOOK_CONTENT_TYPE = "application/json"
+
 
 def _sanitize_name(name: str) -> str:
     """Sanitize a name by replacing problematic characters."""

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -813,8 +813,14 @@ def _compute_signature(payload: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
 
 
-async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
-    """Send event to a single webhook. Returns True on success."""
+def _webhook_payload(event: Event) -> dict:
+    """The JSON body every webhook receives for an event - a wire contract
+    with external consumers, split out so it is directly assertable. The
+    bridge resolves its wake target from `channel`, filters on
+    `signal_level`, and dedupes spool lines on `event_id`
+    (tests/test_bridge.py pins those keys against THIS function), so
+    removing or renaming a key is a breaking change; additions are
+    additive - consumers read the keys they know."""
     payload = {
         "event_id": event.id,
         "event_type": event.event_type,
@@ -830,7 +836,12 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
         for key in ("title", "tags"):
             if key in event.meta:
                 payload[key] = event.meta[key]
-    payload_bytes = json.dumps(payload).encode()
+    return payload
+
+
+async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
+    """Send event to a single webhook. Returns True on success."""
+    payload_bytes = json.dumps(_webhook_payload(event)).encode()
 
     headers = {"Content-Type": "application/json"}
     if webhook.secret:

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -33,6 +33,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from agent_event_bus.helpers import (
+    SIGNATURE_HEADER,
     _dev_notify,
     extract_repo_from_cwd,
     is_client_alive,
@@ -81,8 +82,10 @@ WEBHOOK_MAX_RETRIES = 2  # Number of retries for failed webhooks
 # One name, three readers: _dispatch_webhook sets it, the bridge reads it,
 # and the bridge tests build theirs from this constant - a rename that
 # touched only some of them would 401 every delivery silently (the bus
-# retries twice, then drops), with every mocked test still green.
-SIGNATURE_HEADER = "X-Event-Bus-Signature"
+# retries twice, then drops), with every mocked test still green. Defined
+# in helpers.py (import-clean) so the bridge can read it without pulling
+# in this module's import-time side effects; re-exported here as the
+# canonical bus-side name.
 
 # Known signal levels (RFC #121 / #129). Validation is soft: unknown values
 # are stored as-is with a warning, never rejected.

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -32,8 +32,17 @@ from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+# SIGNATURE_HEADER: one name, three readers (this module's _dispatch_webhook
+# sets it, the bridge's hook endpoint reads it, the bridge tests build theirs
+# from it) - a rename touching only some of them would 401 every delivery
+# silently. Defined in helpers.py (import-clean) so the bridge can read it
+# without this module's import-time side effects; the `as` form marks the
+# EXPLICIT re-export the tests resolve through server - an import cleanup
+# must not drop it.
 from agent_event_bus.helpers import (
-    SIGNATURE_HEADER,
+    SIGNATURE_HEADER as SIGNATURE_HEADER,
+)
+from agent_event_bus.helpers import (
     _dev_notify,
     extract_repo_from_cwd,
     is_client_alive,
@@ -79,13 +88,6 @@ if (
 MAX_PAYLOAD_PREVIEW = 50  # Max chars to show in notification previews
 WEBHOOK_TIMEOUT = 5.0  # Seconds to wait for webhook response
 WEBHOOK_MAX_RETRIES = 2  # Number of retries for failed webhooks
-# One name, three readers: _dispatch_webhook sets it, the bridge reads it,
-# and the bridge tests build theirs from this constant - a rename that
-# touched only some of them would 401 every delivery silently (the bus
-# retries twice, then drops), with every mocked test still green. Defined
-# in helpers.py (import-clean) so the bridge can read it without pulling
-# in this module's import-time side effects; re-exported here as the
-# canonical bus-side name.
 
 # Known signal levels (RFC #121 / #129). Validation is soft: unknown values
 # are stored as-is with a warning, never rejected.

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -43,6 +43,7 @@ from agent_event_bus.helpers import (
     SIGNATURE_HEADER as SIGNATURE_HEADER,
 )
 from agent_event_bus.helpers import (
+    WEBHOOK_CONTENT_TYPE,
     _dev_notify,
     extract_repo_from_cwd,
     is_client_alive,
@@ -843,7 +844,9 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
     """Send event to a single webhook. Returns True on success."""
     payload_bytes = json.dumps(_webhook_payload(event)).encode()
 
-    headers = {"Content-Type": "application/json"}
+    # Single-sourced with the bridge's hook-endpoint requirement (its
+    # anti-browser guard 415s any other media type) - see helpers.py
+    headers = {"Content-Type": WEBHOOK_CONTENT_TYPE}
     if webhook.secret:
         signature = _compute_signature(payload_bytes, webhook.secret)
         headers[SIGNATURE_HEADER] = f"sha256={signature}"

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -78,6 +78,11 @@ if (
 MAX_PAYLOAD_PREVIEW = 50  # Max chars to show in notification previews
 WEBHOOK_TIMEOUT = 5.0  # Seconds to wait for webhook response
 WEBHOOK_MAX_RETRIES = 2  # Number of retries for failed webhooks
+# One name, three readers: _dispatch_webhook sets it, the bridge reads it,
+# and the bridge tests build theirs from this constant - a rename that
+# touched only some of them would 401 every delivery silently (the bus
+# retries twice, then drops), with every mocked test still green.
+SIGNATURE_HEADER = "X-Event-Bus-Signature"
 
 # Known signal levels (RFC #121 / #129). Validation is soft: unknown values
 # are stored as-is with a warning, never rejected.
@@ -825,7 +830,7 @@ async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:
     headers = {"Content-Type": "application/json"}
     if webhook.secret:
         signature = _compute_signature(payload_bytes, webhook.secret)
-        headers["X-Event-Bus-Signature"] = f"sha256={signature}"
+        headers[SIGNATURE_HEADER] = f"sha256={signature}"
 
     client = _get_webhook_client()
     for attempt in range(WEBHOOK_MAX_RETRIES + 1):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -81,6 +81,12 @@ class TestSignature:
         assert verify_signature(body, None, "s3cret") is False
         assert verify_signature(body, "not-a-signature", "s3cret") is False
 
+    def test_non_ascii_signature_header_rejected_not_raised(self):
+        """str compare_digest raises TypeError on non-ASCII input, and
+        Starlette decodes headers as latin-1 - a hostile header byte above
+        0x7f must be a clean reject (401), not an escape into a 500."""
+        assert verify_signature(b'{"x": 1}', "sha256=caf\xe9", "s3cret") is False
+
     def test_hook_rejects_unsigned_when_secret_configured(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", secret="s3cret")
         client = TestClient(create_bridge_app(config))
@@ -342,6 +348,8 @@ class TestInjectorCooldown:
         assert len(lines) == 8
         for line in lines:
             json.loads(line)
+        # The cross-process drain lock exists alongside the spool
+        assert (config.wake_dir / "t.lock").exists()
 
     def test_wake_dir_is_private(self, config):
         Injector(config).deliver("target-1", make_event())
@@ -705,6 +713,20 @@ class TestHookUrlTopology:
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "-5")
         with pytest.raises(SystemExit, match="COOLDOWN"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_empty_wake_dir_env_falls_back_to_default(self, monkeypatch):
+        """An empty env var would make Path('') == cwd - the bridge would
+        chmod and spool into whatever directory launched it, while the
+        drain hook reads the real wake dir and finds nothing."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_WAKE_DIR", "")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert config.wake_dir == bridge.DEFAULT_WAKE_DIR
+
+    def test_relative_wake_dir_is_refused(self):
+        """A daemon's cwd is whatever its supervisor hands it."""
+        args = bridge.build_parser().parse_args(["--wake-dir", "wake"])
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_WAKE_DIR"):
+            bridge.config_from_args(args)
 
     def test_hook_url_env_is_adopted(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:9090/hook")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -660,11 +660,19 @@ class TestTmuxBackend:
             panes.write_bytes(b"[1, 2,")
             injector.deliver("target-1", make_event())
             assert len(warnings()) == 1  # the varying repeat was debug
+            # Re-break with the SAME reason after each re-arm path, so the
+            # re-arm lines are load-bearing: a different reason would warn
+            # regardless and mask a deleted re-arm
             panes.write_text("{}")  # healthy read re-arms the guard
             injector.deliver("target-1", make_event())
-            panes.write_text("[]")  # breaks again (new reason) - warns
+            panes.write_bytes(b"[1,")  # same reason again - warns only if re-armed
             injector.deliver("target-1", make_event())
-        assert len(warnings()) == 2
+            assert len(warnings()) == 2
+            panes.unlink()  # normal unmapped state re-arms too
+            injector.deliver("target-1", make_event())
+            panes.write_bytes(b"{again")  # same reason - warns only if re-armed
+            injector.deliver("target-1", make_event())
+        assert len(warnings()) == 3
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
@@ -1413,6 +1421,9 @@ class TestBindHost:
                 config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", bind]))
             assert bridge.bind_host(config) == bind
             assert not any("advertises loopback" in r.message for r in caplog.records)
+            # '::' is dual-stack, so the pinned-v6-bind family warning must
+            # not fire for it either
+            assert not any("IPv6 only" in r.message for r in caplog.records)
 
     def test_pinned_bind_with_loopback_hook_warns(self, monkeypatch, caplog):
         """The real fourth quadrant: a PINNED non-loopback bind does not
@@ -1466,6 +1477,32 @@ class TestBindHost:
             config = bridge.config_from_args(args)
         assert bridge.bind_host(config) == "0.0.0.0"
         assert any("IPv6" in r.message and "0.0.0.0" in r.message for r in caplog.records)
+
+    def test_ipv4_hook_with_pinned_ipv6_bind_warns(self, caplog):
+        """Mirror of the v6-hook/v4-bind arm: --bind ::1 under the default
+        v4 loopback hook URL is all-loopback, so neither the exposure nor
+        the quadrant guards fire - but the listener binds IPv6 only while
+        the bus POSTs to 127.0.0.1, refused at TCP. A PINNED v6 bind must
+        warn; '::' stays quiet because dual-stack picks up v4."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "::1"]))
+        assert any("IPv4 address" in r.message and "::1" in r.message for r in caplog.records)
+
+    def test_unbalanced_ipv6_bracket_is_a_named_config_error(self, monkeypatch):
+        """urlsplit itself raises ValueError('Invalid IPv6 URL') on an
+        unbalanced bracket - one call before every named guard, and it must
+        be a named config error like the rest, not a bare traceback."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "http://[::1:8080/mcp")
+        with pytest.raises(SystemExit, match="bus URL"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+        monkeypatch.delenv("AGENT_EVENT_BUS_URL")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://[fd7a:115c::1:8082/hook")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_HOOK_URL"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
 
     def test_ipv6_hook_with_ipv6_bind_is_quiet(self, monkeypatch, caplog):
         import logging

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -967,6 +967,17 @@ class TestEnvValidation:
         config = bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert config.backend == "tmux"
 
+    def test_empty_backend_and_bus_url_env_fall_back_to_defaults(self, monkeypatch):
+        """The last two env vars without the `or DEFAULT` normalization: an
+        accidentally empty export must mean the default, not a refused
+        empty string - same accident the secret and wake-dir already
+        handle."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_BACKEND", "")
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert config.backend == "spool"
+        assert config.bus_url == bridge.DEFAULT_URL
+
     def test_env_port_typo_is_a_config_error(self, monkeypatch):
         """Named error at CONFIG time - parser-build must stay clean so
         --help keeps working under a typo'd env var."""
@@ -1224,19 +1235,32 @@ class TestBindHost:
             with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
                 bridge.config_from_args(args)
 
-    def test_non_loopback_bind_with_secret_is_accepted(self, monkeypatch, caplog):
-        """Accepted - but this is also the fourth quadrant (wide bind,
-        loopback hook URL): the bus POSTs to 127.0.0.1 where nothing
-        listens, so the warning must actually fire."""
+    def test_wildcard_bind_with_loopback_hook_is_quiet(self, monkeypatch, caplog):
+        """A wildcard bind listens on loopback TOO, so the local bus's POST
+        to 127.0.0.1 lands exactly as advertised - the fourth-quadrant
+        warning must NOT fire (its advice would replace a working
+        loopback-only hop with an externally routable one). The secret is
+        still required: 0.0.0.0 genuinely exposes the port."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        for bind in ("0.0.0.0", "::"):
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+                config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", bind]))
+            assert bridge.bind_host(config) == bind
+            assert not any("advertises loopback" in r.message for r in caplog.records)
+
+    def test_pinned_bind_with_loopback_hook_warns(self, monkeypatch, caplog):
+        """The real fourth quadrant: a PINNED non-loopback bind does not
+        listen on 127.0.0.1, so the advertised loopback hook URL is refused
+        at TCP - the warning must fire naming both values."""
         import logging
 
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
         with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
-            config = bridge.config_from_args(
-                bridge.build_parser().parse_args(["--bind", "0.0.0.0"])
-            )
-        assert bridge.bind_host(config) == "0.0.0.0"
-        assert any("0.0.0.0" in r.message and "127.0.0.1" in r.message for r in caplog.records)
+            bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "100.100.1.2"]))
+        assert any("100.100.1.2" in r.message and "127.0.0.1" in r.message for r in caplog.records)
 
     def test_loopback_bind_is_accepted_without_secret(self):
         config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "127.0.0.1"]))

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1301,10 +1301,10 @@ class TestTmuxBackend:
             os.close(writer)
 
     def test_oversized_panes_json_degrades_to_spool(self, tmp_path, monkeypatch):
-        """The read is bounded (MAX_PANES_BYTES), so a runaway file can't pull
-        unbounded bytes into memory per DM; the truncated read is invalid
-        JSON and degrades to spool."""
-        monkeypatch.setattr(bridge, "MAX_PANES_BYTES", 64)
+        """The read is bounded (MAX_PANES_CHARS), so a runaway file can't
+        pull unbounded data into memory per DM; the truncated read is
+        invalid JSON and degrades to spool."""
+        monkeypatch.setattr(bridge, "MAX_PANES_CHARS", 64)
         injector, config = make_tmux_injector(tmp_path)
         big = {"target-1": "%0", "_pad": "x" * 500}  # valid, but past the cap
         (config.wake_dir / "panes.json").write_text(json.dumps(big), encoding="utf-8")
@@ -1390,6 +1390,41 @@ class TestTmuxBackend:
             panes.mkdir()  # IsADirectoryError on read
             injector.deliver("target-1", make_event())
         assert len(warnings()) == 4
+
+    def test_unexpected_panes_error_degrades_and_warns_once(self, tmp_path, caplog):
+        """The never-500 catch-all: an exception OUTSIDE (ValueError,
+        RecursionError, TypeError, OSError) - here a KeyError from a
+        monkeypatched json.loads - must still degrade to spool (never 500 an
+        already-spooled delivery), warn once, demote repeats, and re-arm on a
+        healthy read. Pins the arm itself AND the 'unexpected' key's
+        membership in the re-arm sets (a healthy read clears it)."""
+        import logging
+
+        injector, config = make_tmux_injector(tmp_path)  # panes.json maps target-1
+        real_loads = bridge.json.loads
+        boom = {"raise": True}
+
+        def flaky_loads(s, *a, **k):
+            if boom["raise"]:
+                raise KeyError("outside the enumerated arms")
+            return real_loads(s, *a, **k)
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.json, "loads", flaky_loads):
+                # Never 500: the KeyError degrades to spool, not an escape
+                assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+                assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+                assert len(warnings()) == 1  # the repeat demoted to debug
+                # A healthy read clears 'unexpected' (it's in _PANES_READ_KEYS)
+                boom["raise"] = False
+                with patch.object(bridge.subprocess, "run", tmux_ok):
+                    assert injector.deliver("target-1", make_event()) == "tmux"
+                boom["raise"] = True
+                injector.deliver("target-1", make_event())  # warns only if re-armed
+            assert len(warnings()) == 2
 
     def test_bad_pane_value_warns_and_degrades_to_spool(self, tmp_path, caplog):
         """A present-but-wrong-typed pane value (0 instead of "%0", "",

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -97,16 +97,22 @@ def config(tmp_path):
     return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
 
 
-# The bus's httpx dispatch always sends this (server.py _dispatch_webhook);
-# the endpoint requires it so browser fetch() cannot reach the handler
-# preflight-free - a client-level default keeps every test speaking the
-# bus's wire shape without per-call noise
-JSON_CT = {"Content-Type": "application/json"}
+# The bus's httpx dispatch always sends this media type (single-sourced in
+# helpers.py); the endpoint requires it so browser fetch() cannot reach the
+# handler preflight-free - a client-level default keeps every test speaking
+# the bus's wire shape without per-call noise. Built from the real
+# constant, contract-test style.
+JSON_CT = {"Content-Type": bridge.WEBHOOK_CONTENT_TYPE}
+
+# The endpoint also allowlists Host (the DNS-rebinding guard), so tests
+# must arrive under a loopback literal the way real local callers do -
+# TestClient's default base_url would send "Host: testserver"
+LOOPBACK_BASE = "http://127.0.0.1"
 
 
 @pytest.fixture
 def client(config):
-    return TestClient(create_bridge_app(config), headers=JSON_CT)
+    return TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE, headers=JSON_CT)
 
 
 class TestSignature:
@@ -128,7 +134,7 @@ class TestSignature:
 
     def test_hook_rejects_unsigned_when_secret_configured(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", secret="s3cret")
-        client = TestClient(create_bridge_app(config), headers=JSON_CT)
+        client = TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE, headers=JSON_CT)
         body = json.dumps(make_event()).encode()
 
         assert client.post("/hook", content=body).status_code == 401
@@ -313,6 +319,52 @@ class TestHookFiltering:
         assert payload["session_id"] == "sender-1"
         assert bridge.resolve_target_session(payload) == "target-1"
 
+    def test_bus_dispatch_sends_the_media_type_the_hook_requires(self):
+        """Round 54 made Content-Type a hard delivery precondition, which
+        promotes it to a cross-module wire contract - and the client
+        fixture supplies the header itself, so without this pin the bus
+        could drop or change it and every bridge test would stay green
+        while every real delivery 415d with /health still registered:true.
+        Captured off the REAL dispatch path, not asserted from a local
+        literal (the constant is single-sourced in helpers.py, but
+        single-sourcing can't catch the header being dropped entirely)."""
+        import asyncio
+        from datetime import datetime
+
+        from agent_event_bus import server
+        from agent_event_bus.storage import Event as BusEvent
+        from agent_event_bus.storage import Webhook
+
+        captured: dict = {}
+
+        class FakeResponse:
+            status_code = 200
+
+        class FakeClient:
+            async def post(self, url, content=None, headers=None):
+                captured.update(headers or {})
+                return FakeResponse()
+
+        dm = BusEvent(
+            id=1,
+            event_type="note",
+            payload="hi",
+            session_id="sender-1",
+            timestamp=datetime(2026, 8, 8),
+            channel="session:target-1",
+        )
+        webhook = Webhook(
+            id=1,
+            url="http://127.0.0.1:8082/hook",
+            channel_filter=None,
+            event_types=None,
+            created_at=datetime(2026, 8, 8),
+        )
+        with patch.object(server, "_get_webhook_client", FakeClient):
+            assert asyncio.run(server._dispatch_webhook(webhook, dm)) is True
+        media = captured["Content-Type"].split(";", 1)[0].strip().lower()
+        assert media == bridge.WEBHOOK_CONTENT_TYPE == "application/json"
+
     def test_trailing_slash_hook_is_404_not_redirect(self, client):
         """redirect_slashes must stay off: the bus's httpx client doesn't
         follow redirects and counts any status under 400 as delivered, so a
@@ -390,7 +442,9 @@ class TestHookFiltering:
         happened. Requiring application/json (what the bus's httpx
         dispatch actually sends) forces a preflight the bridge never
         answers, so the browser never sends the POST at all."""
-        client = TestClient(create_bridge_app(config))  # no default headers
+        # Loopback base (passes the Host guard) but no default headers -
+        # this test exercises the Content-Type half in isolation
+        client = TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE)
         body = json.dumps(make_event()).encode()
         # The exact shape a page can emit without a preflight: fetch()
         # string-body default, form enctype, and no header at all
@@ -406,6 +460,46 @@ class TestHookFiltering:
         )
         assert ok.status_code == 200
         assert ok.json()["status"] == "delivered"
+
+    def test_dns_rebinding_host_is_rejected(self, config):
+        """The Content-Type guard rests on the attacker page being
+        cross-origin; DNS rebinding removes that premise (page served from
+        evil.example:<our port>, A record then flipped to 127.0.0.1 - the
+        POST is same-origin, so CORS never applies and application/json is
+        sent verbatim). What rebinding cannot forge is Host: the browser
+        fills it from the page's URL, so a rebound request necessarily
+        carries the attacker's hostname. The allowlist is loopback
+        literals plus the hook URL's hostname - the names legitimate
+        callers actually arrive under."""
+        client = TestClient(create_bridge_app(config), headers=JSON_CT)  # Host: testserver
+        body = json.dumps(make_event()).encode()
+        # The rebound shape: right media type, wrong Host
+        for host in ("evil.example:8082", "evil.example", "testserver"):
+            resp = client.post("/hook", content=body, headers={"Host": host})
+            assert resp.status_code == 421, host
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+        # Every name a legitimate local caller can arrive under - including
+        # the bracketed-IPv6 forms TrustedHostMiddleware would mangle
+        for host in ("127.0.0.1:8082", "localhost:8082", "localhost", "[::1]:8082", "[::1]"):
+            resp = client.post("/hook", content=body, headers={"Host": host})
+            assert resp.status_code == 200, host
+
+    def test_hook_url_hostname_is_an_allowed_host(self, tmp_path):
+        """A remote-hook topology's bus POSTs with Host = the hook URL's
+        hostname (httpx fills it from the URL the bridge registered) - the
+        allowlist must admit exactly that name or every real delivery
+        would 421 while /health stays green."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://bridge.tailnet.example:8082/hook",
+            secret="s3cret",
+        )
+        client = TestClient(create_bridge_app(config), headers=JSON_CT)
+        body = json.dumps(make_event()).encode()
+        signed = {"Host": "bridge.tailnet.example:8082", SIGNATURE_HEADER: sign(body, "s3cret")}
+        resp = client.post("/hook", content=body, headers=signed)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delivered"
 
     def test_non_object_json_rejected(self, client):
         """Valid JSON that isn't an object must be a 400, not an

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -3,6 +3,8 @@
 import hashlib
 import hmac
 import json
+import threading
+import time
 from unittest.mock import patch
 
 import pytest
@@ -80,6 +82,42 @@ class TestTargetResolution:
         assert resolve_target_session(make_event(channel="all")) is None
         assert resolve_target_session(make_event(channel="repo:myrepo")) is None
         assert resolve_target_session(make_event(channel="session:")) is None
+
+    def test_uuid_and_display_ids_accepted(self):
+        uuid = "067fd316-8cc7-5cb1-861f-4d9d67ba7ee8"
+        assert resolve_target_session(make_event(channel=f"session:{uuid}")) == uuid
+        assert resolve_target_session(make_event(channel="session:brave_trex-2")) == "brave_trex-2"
+
+
+class TestPathSafety:
+    """The session id comes verbatim off the wire (the event's channel string,
+    which the bus warns on but never rejects) and becomes a spool filename -
+    traversal and absolute components must never reach the filesystem."""
+
+    def test_unsafe_session_ids_resolve_to_none(self):
+        for channel in (
+            "session:../../victim/x",
+            "session:/etc/cron.d/x",
+            "session:a/b",
+            "session:a\x00b",
+            "session:..",
+        ):
+            assert resolve_target_session(make_event(channel=channel)) is None
+
+    def test_traversal_channel_is_ignored_and_writes_nothing(self, client, config, tmp_path):
+        evil = make_event(channel="session:../../escape")
+        resp = client.post("/hook", content=json.dumps(evil).encode())
+
+        assert resp.json() == {"status": "ignored", "reason": "no target session"}
+        assert list(tmp_path.rglob("*.jsonl")) == []
+
+    def test_spool_refuses_escaping_path(self, config):
+        """Belt-and-braces: even if a bad id reached _spool directly, the
+        resolved-parent check must refuse to write outside the wake dir."""
+        injector = Injector(config)
+        with pytest.raises(ValueError, match="escapes wake dir"):
+            injector._spool("../escape", make_event())
+        assert not (config.wake_dir.parent / "escape.jsonl").exists()
 
 
 class TestHookFiltering:
@@ -159,6 +197,46 @@ class TestInjectorCooldown:
                 clock["now"] += 25.0  # 35s after the successful wake
                 assert injector.deliver("target-1", make_event()) == "tmux"
 
+    def test_concurrent_deliveries_wake_only_once(self, tmp_path):
+        """Two concurrent deliveries for the same session must produce one
+        tmux wake - the reservation closes the check-then-act window between
+        reading the cooldown and recording the wake."""
+        injector, _ = make_tmux_injector(tmp_path)
+        release = threading.Event()
+        wakes = []
+
+        def slow_tmux(cmd, **kwargs):
+            wakes.append(cmd)
+            release.wait(timeout=5)
+
+            class Result:
+                returncode = 0
+
+            return Result()
+
+        results = []
+        threads = [
+            threading.Thread(
+                target=lambda: results.append(injector.deliver("target-1", make_event()))
+            )
+            for _ in range(2)
+        ]
+        with patch.object(bridge.subprocess, "run", slow_tmux):
+            for t in threads:
+                t.start()
+            # Wait until one thread is parked inside tmux and the other has
+            # already returned (proving they overlapped), then release
+            for _ in range(500):
+                if wakes and results:
+                    break
+                time.sleep(0.01)
+            release.set()
+            for t in threads:
+                t.join()
+
+        assert sorted(results) == ["spool-cooldown", "tmux"]
+        assert len(wakes) == 1
+
     def test_failed_wake_does_not_burn_cooldown(self, tmp_path):
         """A transient tmux failure must not silence the session for a full
         cooldown - the next event retries immediately."""
@@ -182,8 +260,6 @@ class TestInjectorCooldown:
     def test_concurrent_spool_appends_do_not_tear(self, config):
         """Concurrent webhook deliveries append under the lock; every line
         must stay valid JSON even when payloads exceed the IO buffer."""
-        import threading
-
         injector = Injector(config)
         event = make_event(payload="x" * 100_000)  # > default 8 KiB buffer
 
@@ -252,6 +328,18 @@ class TestTmuxBackend:
 
         assert action == "spool"
 
+    def test_tmux_oserror_falls_back_to_spool(self, tmp_path):
+        """A non-executable tmux binary (PermissionError) must degrade to
+        spool, not escape as a 500 that makes the bus re-POST an event which
+        is already durably spooled (duplicate lines)."""
+        injector, _ = make_tmux_injector(tmp_path)
+
+        def tmux_perm(cmd, **kwargs):
+            raise PermissionError("tmux not executable")
+
+        with patch.object(bridge.subprocess, "run", tmux_perm):
+            assert injector.deliver("target-1", make_event()) == "spool"
+
 
 class TestBusRegistration:
     def test_registers_webhook_with_bridge_url_and_secret(self, tmp_path):
@@ -273,6 +361,8 @@ class TestBusRegistration:
         register = next(c for c in calls if c["tool"] == "register_webhook")
         assert register["arguments"]["url"] == "http://127.0.0.1:9999/hook"
         assert register["arguments"]["secret"] == "s3cret"
+        # v1 only acts on DMs, so the bus drops broadcast traffic server-side
+        assert register["arguments"]["channel"] == "session:"
         assert register["url"] == "http://bus/mcp"
 
     def test_startup_removes_stale_webhooks_at_same_url(self, tmp_path):
@@ -298,18 +388,50 @@ class TestBusRegistration:
         # Only the stale hook at OUR url is removed, not other consumers'
         assert unregisters == [{"webhook_id": 7}]
 
-    def test_empty_secret_env_is_normalized_to_none(self, tmp_path, monkeypatch):
+    def test_empty_secret_env_is_normalized_to_none(self, monkeypatch):
         """An accidentally empty secret must not split registration (skips
         the secret -> unsigned payloads) from verification (demands
-        signatures) - the combination 401s every delivery silently."""
+        signatures) - the combination 401s every delivery silently. Exercises
+        the real config construction, so removing the normalization from
+        config_from_args fails this test."""
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "")
-        secret = __import__("os").environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None
-        config = BridgeConfig(wake_dir=tmp_path / "wake", secret=secret)
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert config.secret is None
 
-        # Verification is disabled, matching registration's omitted secret
-        client = TestClient(create_bridge_app(config))
-        resp = client.post("/hook", content=json.dumps(make_event()).encode())
-        assert resp.status_code == 200
+    def test_secret_env_is_adopted(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert config.secret == "s3cret"
+
+    def test_registration_retries_until_bus_is_up(self, tmp_path):
+        """call_tool exits the process on connection errors, and at boot the
+        bus is often not up yet - the daemon must retry, not die."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        attempts = []
+
+        def flaky_register(cfg):
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise SystemExit(1)
+            return 42
+
+        state: dict = {}
+        with patch.object(bridge, "register_with_bus", flaky_register):
+            bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
+
+        assert state["webhook_id"] == 42
+        assert len(attempts) == 3
+
+    def test_registration_retry_honors_shutdown(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        stop = threading.Event()
+        stop.set()
+
+        def never_called(cfg):
+            raise AssertionError("should not register after stop")
+
+        with patch.object(bridge, "register_with_bus", never_called):
+            bridge.register_with_retry(config, {}, stop, initial_delay=0.01)
 
     def test_unregister_swallows_bus_unreachable(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -592,8 +592,9 @@ class TestTmuxBackend:
 
         # Distinct from "spool" AND from "spool-tmux-failed": unmapped is
         # the normal outcome for a foreign-machine session (webhooks have no
-        # machine scoping), so it must not read as a broken tmux setup - and
-        # it logs only at debug, so the action field is the in-band signal
+        # machine scoping), so it must not read as a broken tmux setup. The
+        # distinct return value is what a direct /hook caller sees; the
+        # debug line under DEV_MODE is what an operator sees.
         assert action == "spool-unmapped"
         mock_run.assert_not_called()
 
@@ -672,7 +673,15 @@ class TestTmuxBackend:
             injector.deliver("target-1", make_event())
             panes.write_bytes(b"{again")  # same reason - warns only if re-armed
             injector.deliver("target-1", make_event())
-        assert len(warnings()) == 3
+            assert len(warnings()) == 3
+            # Escalation across classes: a parse failure turning into a
+            # persistent I/O failure is a DIFFERENT reason and must warn,
+            # not be demoted as a repeat - there may never be a healthy
+            # read to re-arm once the file is a directory
+            panes.unlink()
+            panes.mkdir()  # IsADirectoryError on read
+            injector.deliver("target-1", make_event())
+        assert len(warnings()) == 4
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
@@ -691,8 +700,8 @@ class TestBusRegistration:
         )
         calls = []
 
-        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
-            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
+        def fake_call_tool(tool_name, arguments, url=None, debug=False, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url, "debug": debug})
             if tool_name == "list_webhooks":
                 return []
             return {"webhook_id": 42}
@@ -701,6 +710,12 @@ class TestBusRegistration:
             webhook_id = bridge.register_with_bus(config)
 
         assert webhook_id == 42
+        # debug=True is the whole mechanism behind the named-cause logs:
+        # without it call_tool swallows a 401/timeout/bad body into a bare
+        # SystemExit(1) with the reason on stderr. Every registration call
+        # must carry it, or the daemon silently reverts to logging
+        # "SystemExit(1)" for every failure alike.
+        assert all(c["debug"] is True for c in calls)
         register = next(c for c in calls if c["tool"] == "register_webhook")
         assert register["arguments"]["url"] == "http://127.0.0.1:9999/hook"
         assert register["arguments"]["secret"] == "s3cret"
@@ -793,15 +808,20 @@ class TestBusRegistration:
         config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
         calls = []
 
-        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
-            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
+        def fake_call_tool(tool_name, arguments, url=None, debug=False, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url, "debug": debug})
             return {"success": True}
 
         with patch.object(bridge, "call_tool", fake_call_tool):
             bridge.unregister_from_bus(config, 42)
 
         assert calls == [
-            {"tool": "unregister_webhook", "arguments": {"webhook_id": 42}, "url": "http://bus/mcp"}
+            {
+                "tool": "unregister_webhook",
+                "arguments": {"webhook_id": 42},
+                "url": "http://bus/mcp",
+                "debug": True,
+            }
         ]
 
     def test_startup_removes_stale_webhooks_at_same_url(self, tmp_path):
@@ -844,9 +864,13 @@ class TestBusRegistration:
         config = bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert config.secret == "s3cret"
 
-    def test_registration_retries_until_bus_is_up(self, tmp_path):
+    def test_registration_retries_until_bus_is_up(self, tmp_path, caplog):
         """call_tool exits the process on connection errors, and at boot the
-        bus is often not up yet - the daemon must retry, not die."""
+        bus is often not up yet - the daemon must retry, not die. The bare
+        SystemExit(1) must render as the connection error it provably is
+        (debug=True re-raises everything else), not as "SystemExit(1)"."""
+        import logging
+
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         attempts = []
 
@@ -857,11 +881,13 @@ class TestBusRegistration:
             return 42
 
         state: dict = {}
-        with patch.object(bridge, "register_with_bus", flaky_register):
-            bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "register_with_bus", flaky_register):
+                bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
 
         assert state["webhook_id"] == 42
         assert len(attempts) == 3
+        assert any("bus unreachable (connection error)" in r.message for r in caplog.records)
 
     def test_registration_without_id_is_retryable(self, tmp_path):
         """A bus that answers but returns no webhook_id must be a retryable
@@ -907,9 +933,13 @@ class TestBusRegistration:
             with pytest.raises(SystemExit, match="list_webhooks"):
                 bridge.register_with_bus(config)
 
-    def test_registration_retries_on_unexpected_errors(self, tmp_path):
+    def test_registration_retries_on_unexpected_errors(self, tmp_path, caplog):
         """Any surprise inside register_with_bus must degrade to
-        backoff-and-retry, not a dead thread and a deaf daemon."""
+        backoff-and-retry, not a dead thread and a deaf daemon - and the
+        log must carry the real cause (the repr arm), not misrender it as
+        a connection error."""
+        import logging
+
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         attempts = []
 
@@ -920,11 +950,16 @@ class TestBusRegistration:
             return 42
 
         state: dict = {}
-        with patch.object(bridge, "register_with_bus", flaky_register):
-            bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "register_with_bus", flaky_register):
+                bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
 
         assert state["webhook_id"] == 42
         assert len(attempts) == 2
+        assert any(
+            "ValueError" in r.message and "unexpected shape" in r.message for r in caplog.records
+        )
+        assert not any("bus unreachable" in r.message for r in caplog.records)
 
     def test_registration_retry_honors_shutdown(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")
@@ -945,6 +980,49 @@ class TestBusRegistration:
 
         with patch.object(bridge, "call_tool", fake_call_tool):
             bridge.unregister_from_bus(config, 42)  # must not raise
+
+    def test_unregister_logs_real_cause_for_non_connection_failures(self, tmp_path, caplog):
+        """The except-Exception arm: with debug=True a 401/timeout/bad body
+        re-raises out of call_tool - shutdown must stay best-effort AND the
+        one log line an operator has when a row leaks must carry the real
+        cause, not the connection-error misdiagnosis."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+
+        def raising_call_tool(*args, **kwargs):
+            raise RuntimeError("401 Unauthorized")
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "call_tool", raising_call_tool):
+                bridge.unregister_from_bus(config, 42)  # must not raise
+        assert any("401" in r.message and "#42" in r.message for r in caplog.records)
+        assert not any("bus unreachable" in r.message for r in caplog.records)
+
+    def test_call_tool_debug_contract(self):
+        """A bare SystemExit(1) meaning 'connection error' is a cross-module
+        contract with cli.call_tool: its ConnectionError arm exits WITHOUT
+        consulting debug, while the trailing except honours debug=True and
+        re-raises. Pin both halves against the real call_tool - the same
+        idiom as sign() and the signal-level and session-filter contract
+        tests - since either half moving would turn the named-cause log
+        lines into confident misdiagnoses with every mocked test green."""
+        import requests
+
+        from agent_event_bus import cli
+
+        with patch.object(
+            cli.requests, "post", side_effect=requests.exceptions.ConnectionError("refused")
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp", debug=True)
+        assert exc.value.code == 1
+
+        with patch.object(
+            cli.requests, "post", side_effect=requests.exceptions.HTTPError("401 Client Error")
+        ):
+            with pytest.raises(requests.exceptions.HTTPError, match="401"):
+                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp", debug=True)
 
 
 class TestDaemonLifecycle:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -282,14 +282,21 @@ class TestHookFiltering:
 
         assert client.post("/hook", content=chunks()).status_code == 413
 
-    def test_actionable_dm_delivered_to_spool(self, client, config):
-        resp = client.post("/hook", content=json.dumps(make_event()).encode())
+    def test_actionable_dm_delivered_to_spool(self, client, config, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="agent-event-bus-bridge"):
+            resp = client.post("/hook", content=json.dumps(make_event()).encode())
 
         assert resp.json()["status"] == "delivered"
         assert resp.json()["action"] == "spool"
         lines = (config.wake_dir / "target-1.jsonl").read_text().splitlines()
         assert len(lines) == 1
         assert json.loads(lines[0])["payload"] == "need a review"
+        # The happy-path breadcrumb is an operability guarantee - the spool
+        # backend's terminal must show more than the registration line, so
+        # pin the INFO line carrying the event id like the warnings around it
+        assert any("Spooled event 1" in r.message for r in caplog.records)
 
     def test_health(self, client):
         assert client.get("/health").json()["status"] == "ok"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -39,6 +39,26 @@ def make_event(**overrides) -> dict:
     return event
 
 
+BRIDGE_ENV = (
+    "AGENT_EVENT_BUS_URL",
+    "AGENT_EVENT_BUS_BRIDGE_PORT",
+    "AGENT_EVENT_BUS_BRIDGE_BACKEND",
+    "AGENT_EVENT_BUS_BRIDGE_COOLDOWN",
+    "AGENT_EVENT_BUS_BRIDGE_SECRET",
+    "AGENT_EVENT_BUS_BRIDGE_HOOK_URL",
+    "AGENT_EVENT_BUS_WAKE_DIR",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_bridge_env(monkeypatch):
+    """Config tests parse the real environment via build_parser defaults, and
+    client machines are told to export AGENT_EVENT_BUS_URL - the suite must
+    not change meaning based on the developer's shell profile."""
+    for name in BRIDGE_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture
 def config(tmp_path):
     return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
@@ -136,6 +156,12 @@ class TestHookFiltering:
 
     def test_invalid_json_rejected(self, client):
         assert client.post("/hook", content=b"not-json{").status_code == 400
+
+    def test_non_object_json_rejected(self, client):
+        """Valid JSON that isn't an object must be a 400, not an
+        AttributeError-turned-500 with bus retries behind it."""
+        for body in (b"123", b'["x"]', b'"bare"', b"null"):
+            assert client.post("/hook", content=body).status_code == 400
 
     def test_actionable_dm_delivered_to_spool(self, client, config):
         resp = client.post("/hook", content=json.dumps(make_event()).encode())
@@ -602,22 +628,60 @@ class TestHookUrlTopology:
 
     def test_remote_bus_with_reachable_hook_is_accepted(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_URL", "https://bus.tailnet.example/mcp")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
         args = bridge.build_parser().parse_args(
             ["--hook-url", "http://laptop.tailnet.example:8082/hook"]
         )
         config = bridge.config_from_args(args)
         assert bridge.bridge_hook_url(config) == "http://laptop.tailnet.example:8082/hook"
 
-    def test_local_bus_with_loopback_hook_is_accepted(self, monkeypatch):
-        monkeypatch.delenv("AGENT_EVENT_BUS_URL", raising=False)
+    def test_non_loopback_hook_without_secret_is_refused(self, monkeypatch):
+        """Binding beyond localhost with no HMAC secret would let anyone who
+        reaches the port append attacker-authored lines to a session spool -
+        a hard refusal, matching the loopback-vs-remote guard (the bus
+        itself defaults to auth-required)."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "https://bus.tailnet.example/mcp")
+        args = bridge.build_parser().parse_args(
+            ["--hook-url", "http://laptop.tailnet.example:8082/hook"]
+        )
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
+            bridge.config_from_args(args)
+
+    def test_local_bus_with_loopback_hook_is_accepted(self):
         config = bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert bridge.bridge_hook_url(config).startswith("http://127.0.0.1:")
 
+    def test_loopback_range_bus_is_local(self, monkeypatch):
+        """127.0.0.0/8 is all loopback - Debian/Ubuntu resolve the machine's
+        hostname to 127.0.1.1, so a bus URL built from `hostname` must not
+        read as remote."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "http://127.0.1.1:8080/mcp")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert bridge.bridge_hook_url(config).startswith("http://127.0.0.1:")
+
+    def test_schemeless_bus_url_is_refused(self, monkeypatch):
+        """A scheme-less URL parses with no hostname and would read as
+        loopback, silently skipping the topology guard."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "bus.example:8080/mcp")
+        with pytest.raises(SystemExit, match="http"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
     def test_hook_url_env_is_adopted(self, monkeypatch):
-        monkeypatch.delenv("AGENT_EVENT_BUS_URL", raising=False)
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:9090/hook")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
         config = bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert bridge.bridge_hook_url(config) == "http://box.local:9090/hook"
+
+    def test_hook_port_mismatch_warns(self, monkeypatch, caplog):
+        """The bus POSTs to the hook URL's port while the listener binds
+        --port; a mismatch is legitimate behind a proxy but must be named."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:9090/hook")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert any("9090" in r.message and "8082" in r.message for r in caplog.records)
 
     def test_registration_advertises_hook_url_override(self, tmp_path):
         config = BridgeConfig(

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -658,6 +658,35 @@ class TestBusRegistration:
         assert register["arguments"]["channel"] == "session:"
         assert register["url"] == "http://bus/mcp"
 
+    def test_session_filter_prefix_match_contract(self, tmp_path):
+        """The registered channel="session:" filter only cuts traffic if
+        the bus prefix-matches it - pin that through the REAL matcher, the
+        same idiom as sign() and the signal-level contract test. If
+        get_matching_webhooks were ever tightened to exact match (a bare
+        "session:" is not a channel anyone publishes to), the bridge would
+        receive nothing while every mocked test here stayed green."""
+        from datetime import datetime
+
+        from agent_event_bus.storage import Event as BusEvent
+        from agent_event_bus.storage import SQLiteStorage
+
+        storage = SQLiteStorage(str(tmp_path / "contract.db"))
+        storage.add_webhook(url="http://127.0.0.1:8082/hook", channel_filter="session:")
+
+        def bus_event(channel):
+            return BusEvent(
+                id=1,
+                event_type="note",
+                payload="hi",
+                session_id="sender-1",
+                timestamp=datetime(2026, 8, 8),
+                channel=channel,
+            )
+
+        assert storage.get_matching_webhooks(bus_event("session:abc"))
+        assert not storage.get_matching_webhooks(bus_event("repo:foo"))
+        assert not storage.get_matching_webhooks(bus_event("all"))
+
     def test_unregister_unexpected_result_warns_not_asserts(self, tmp_path, caplog):
         """Shutdown-side twin of the sweep's result check: best-effort, so a
         bus that answers but doesn't delete is a warning (the next startup
@@ -1191,15 +1220,44 @@ class TestHookUrlTopology:
             )
 
     def test_hook_url_scheme_default_matching_port_is_quiet(self, monkeypatch, caplog):
-        """https behind a TLS terminator with --port 443 is the legitimate
-        shape - the substituted default must not warn when it matches."""
+        """The substituted default must not warn when it matches - kept on
+        http so the separate https-no-terminator warning doesn't muddy the
+        pure port-substitution case."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local/hook")
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args(["--port", "80"]))
+        assert not any("advertises port" in r.message for r in caplog.records)
+
+    def test_https_hook_with_agreeing_port_warns_no_terminator(self, monkeypatch, caplog):
+        """The listener never speaks TLS, and a terminator fronts one port
+        while forwarding to another - so https with the ports AGREEING
+        means no terminator exists and every dispatch dies in the
+        handshake, with every other topology guard quiet."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        monkeypatch.setenv(
+            "AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "https://bridge.tailnet.example:8082/hook"
+        )
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert any("TLS terminator" in r.message for r in caplog.records)
+
+    def test_https_hook_with_mismatched_port_no_tls_warning(self, monkeypatch, caplog):
+        """https fronting 443 while forwarding to --port is the legitimate
+        terminator shape: the port-mismatch warning names it, and the TLS
+        warning must stay quiet rather than double-warn."""
         import logging
 
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "https://box.local/hook")
         with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
-            bridge.config_from_args(bridge.build_parser().parse_args(["--port", "443"]))
-        assert not any("advertises port" in r.message for r in caplog.records)
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert not any("TLS terminator" in r.message for r in caplog.records)
+        assert any("advertises port 443 " in r.message for r in caplog.records)
 
     def test_hook_path_mismatch_warns(self, monkeypatch, caplog):
         """POST /hook is the only route served - any other advertised path
@@ -1345,6 +1403,37 @@ class TestBindHost:
         with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
             bridge.config_from_args(args)
         assert not any("IPv6" in r.message for r in caplog.records)
+
+    def test_dev_mode_enables_debug_logging(self, monkeypatch, tmp_path):
+        """CLAUDE.md advertises DEV_MODE=1 as THE debug switch for this
+        package (server.py honors it); without a level path every
+        logger.debug in the module - the only per-event visibility into
+        why a delivery did nothing - is dead code in the shipped daemon."""
+        import logging
+        import sys
+
+        import uvicorn
+
+        monkeypatch.setattr(
+            sys, "argv", ["agent-event-bus-bridge", "--wake-dir", str(tmp_path / "wake")]
+        )
+
+        def run_quiet(app, host=None, port=None):
+            return None
+
+        try:
+            monkeypatch.delenv("DEV_MODE", raising=False)
+            with patch.object(uvicorn, "run", run_quiet):
+                bridge.main()
+            assert not bridge.logger.isEnabledFor(logging.DEBUG)
+            monkeypatch.setenv("DEV_MODE", "1")
+            with patch.object(uvicorn, "run", run_quiet):
+                bridge.main()
+            assert bridge.logger.isEnabledFor(logging.DEBUG)
+        finally:
+            # main() sets a level on the module logger; don't leak it into
+            # tests that rely on the default NOTSET-inherits-root behavior
+            bridge.logger.setLevel(logging.NOTSET)
 
     def test_main_passes_bind_through_and_unregisters(self, monkeypatch, tmp_path):
         """End-to-end main(): the default local config binds loopback, the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,215 @@
+"""Tests for the webhook-to-injection bridge (RFC #122 prototype)."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_event_bus import bridge
+from agent_event_bus.bridge import (
+    BridgeConfig,
+    Injector,
+    create_bridge_app,
+    resolve_target_session,
+    verify_signature,
+)
+
+
+def sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def make_event(**overrides) -> dict:
+    event = {
+        "event_id": 1,
+        "event_type": "help_needed",
+        "payload": "need a review",
+        "session_id": "sender-1",
+        "timestamp": "2026-08-08T00:00:00",
+        "channel": "session:target-1",
+        "correlation_id": None,
+        "signal_level": "actionable",
+    }
+    event.update(overrides)
+    return event
+
+
+@pytest.fixture
+def config(tmp_path):
+    return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
+
+
+@pytest.fixture
+def client(config):
+    return TestClient(create_bridge_app(config))
+
+
+class TestSignature:
+    def test_valid_signature_accepted(self):
+        body = b'{"x": 1}'
+        assert verify_signature(body, sign(body, "s3cret"), "s3cret") is True
+
+    def test_bad_signature_rejected(self):
+        body = b'{"x": 1}'
+        assert verify_signature(body, sign(body, "wrong"), "s3cret") is False
+        assert verify_signature(body, None, "s3cret") is False
+        assert verify_signature(body, "not-a-signature", "s3cret") is False
+
+    def test_hook_rejects_unsigned_when_secret_configured(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake", secret="s3cret")
+        client = TestClient(create_bridge_app(config))
+        body = json.dumps(make_event()).encode()
+
+        assert client.post("/hook", content=body).status_code == 401
+
+        signed = client.post(
+            "/hook", content=body, headers={"X-Event-Bus-Signature": sign(body, "s3cret")}
+        )
+        assert signed.status_code == 200
+        assert signed.json()["status"] == "delivered"
+
+
+class TestTargetResolution:
+    def test_dm_channel_targets_that_session(self):
+        assert resolve_target_session(make_event(channel="session:abc")) == "abc"
+
+    def test_broadcast_and_repo_channels_have_no_target(self):
+        assert resolve_target_session(make_event(channel="all")) is None
+        assert resolve_target_session(make_event(channel="repo:myrepo")) is None
+        assert resolve_target_session(make_event(channel="session:")) is None
+
+
+class TestHookFiltering:
+    def test_below_actionable_ignored(self, client, config):
+        for level in ("lifecycle", "info"):
+            resp = client.post("/hook", content=json.dumps(make_event(signal_level=level)).encode())
+            assert resp.json() == {"status": "ignored", "reason": "below actionable"}
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+
+    def test_untargeted_actionable_ignored(self, client):
+        resp = client.post("/hook", content=json.dumps(make_event(channel="repo:myrepo")).encode())
+        assert resp.json() == {"status": "ignored", "reason": "no target session"}
+
+    def test_invalid_json_rejected(self, client):
+        assert client.post("/hook", content=b"not-json{").status_code == 400
+
+    def test_actionable_dm_delivered_to_spool(self, client, config):
+        resp = client.post("/hook", content=json.dumps(make_event()).encode())
+
+        assert resp.json()["status"] == "delivered"
+        assert resp.json()["action"] == "spool"
+        lines = (config.wake_dir / "target-1.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["payload"] == "need a review"
+
+    def test_health(self, client):
+        assert client.get("/health").json()["status"] == "ok"
+
+
+class TestInjectorCooldown:
+    def test_second_wake_within_cooldown_spools_only(self, config):
+        injector = Injector(config)
+        event = make_event()
+
+        assert injector.deliver("target-1", event) == "spool"
+        assert injector.deliver("target-1", event) == "spool-cooldown"
+
+        # Both events were spooled - cooldown bounds wakes, not durability
+        lines = (config.wake_dir / "target-1.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+
+    def test_cooldown_is_per_session(self, config):
+        injector = Injector(config)
+
+        assert injector.deliver("target-1", make_event()) == "spool"
+        assert injector.deliver("target-2", make_event()) == "spool"
+
+    def test_wake_allowed_after_cooldown_expires(self, config):
+        config.cooldown_seconds = 0.0
+        injector = Injector(config)
+
+        assert injector.deliver("target-1", make_event()) == "spool"
+        assert injector.deliver("target-1", make_event()) == "spool"
+
+
+class TestTmuxBackend:
+    def test_mapped_pane_gets_send_keys(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        config.wake_dir.mkdir(parents=True)
+        (config.wake_dir / "panes.json").write_text(json.dumps({"target-1": "%7"}))
+        injector = Injector(config)
+
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+
+            class Result:
+                returncode = 0
+
+            return Result()
+
+        with patch.object(bridge.subprocess, "run", fake_run):
+            action = injector.deliver("target-1", make_event())
+
+        assert action == "tmux"
+        assert commands[0][:4] == ["tmux", "send-keys", "-t", "%7"]
+        # The event is also spooled (durable path is unconditional)
+        assert (config.wake_dir / "target-1.jsonl").exists()
+
+    def test_unmapped_session_falls_back_to_spool(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+
+        with patch.object(bridge.subprocess, "run") as mock_run:
+            action = injector.deliver("target-1", make_event())
+
+        assert action == "spool"
+        mock_run.assert_not_called()
+
+    def test_tmux_failure_falls_back_to_spool(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        config.wake_dir.mkdir(parents=True)
+        (config.wake_dir / "panes.json").write_text(json.dumps({"target-1": "%7"}))
+        injector = Injector(config)
+
+        def fake_run(cmd, **kwargs):
+            raise bridge.subprocess.CalledProcessError(1, cmd)
+
+        with patch.object(bridge.subprocess, "run", fake_run):
+            action = injector.deliver("target-1", make_event())
+
+        assert action == "spool"
+
+
+class TestBusRegistration:
+    def test_registers_webhook_with_bridge_url_and_secret(self, tmp_path):
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake", port=9999, secret="s3cret", bus_url="http://bus/mcp"
+        )
+        calls = []
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
+            return {"webhook_id": 42}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            webhook_id = bridge.register_with_bus(config)
+
+        assert webhook_id == 42
+        assert calls[0]["tool"] == "register_webhook"
+        assert calls[0]["arguments"]["url"] == "http://127.0.0.1:9999/hook"
+        assert calls[0]["arguments"]["secret"] == "s3cret"
+        assert calls[0]["url"] == "http://bus/mcp"
+
+    def test_unregister_swallows_bus_unreachable(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+
+        def fake_call_tool(*args, **kwargs):
+            raise SystemExit(1)
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            bridge.unregister_from_bus(config, 42)  # must not raise

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -101,6 +101,9 @@ class TestPathSafety:
             "session:a/b",
             "session:a\x00b",
             "session:..",
+            # Charset-clean but too long: would be an unretryable OSError
+            # (name too long) out of the spool open
+            "session:" + "a" * 300,
         ):
             assert resolve_target_session(make_event(channel=channel)) is None
 
@@ -518,8 +521,15 @@ class TestDaemonLifecycle:
         stop = threading.Event()
         with patch.object(bridge, "register_with_bus", fake_register):
             app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-            with TestClient(app):
+            with TestClient(app) as client:
                 assert registered.wait(timeout=5), "startup never fired registration"
+                # /health surfaces the registration outcome - the one signal
+                # that separates "working" from "listening but never registered"
+                for _ in range(500):
+                    if client.get("/health").json().get("registered"):
+                        break
+                    time.sleep(0.01)
+                assert client.get("/health").json()["registered"] is True
         # Shutdown stopped and joined the thread, so the result is visible
         assert state["webhook_id"] == 42
         assert stop.is_set()
@@ -547,7 +557,10 @@ class TestDaemonLifecycle:
 
     def test_app_without_registration_has_inert_lifespan(self, config):
         with TestClient(create_bridge_app(config)) as client:
-            assert client.get("/health").status_code == 200
+            payload = client.get("/health").json()
+        assert payload["status"] == "ok"
+        # No registration state -> no claim either way
+        assert "registered" not in payload
 
 
 class TestEnvValidation:
@@ -574,3 +587,54 @@ class TestEnvValidation:
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "30s")
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_COOLDOWN"):
             bridge.build_parser()
+
+
+class TestHookUrlTopology:
+    """A loopback hook URL registered on a remote bus makes the bus POST to
+    itself - a silent no-op with a green health check - and every machine
+    would claim the same URL string, letting one bridge's startup dedupe
+    remove another machine's live webhook."""
+
+    def test_remote_bus_with_loopback_hook_is_refused(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "https://bus.tailnet.example/mcp")
+        with pytest.raises(SystemExit, match="hook-url"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_remote_bus_with_reachable_hook_is_accepted(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "https://bus.tailnet.example/mcp")
+        args = bridge.build_parser().parse_args(
+            ["--hook-url", "http://laptop.tailnet.example:8082/hook"]
+        )
+        config = bridge.config_from_args(args)
+        assert bridge.bridge_hook_url(config) == "http://laptop.tailnet.example:8082/hook"
+
+    def test_local_bus_with_loopback_hook_is_accepted(self, monkeypatch):
+        monkeypatch.delenv("AGENT_EVENT_BUS_URL", raising=False)
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert bridge.bridge_hook_url(config).startswith("http://127.0.0.1:")
+
+    def test_hook_url_env_is_adopted(self, monkeypatch):
+        monkeypatch.delenv("AGENT_EVENT_BUS_URL", raising=False)
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:9090/hook")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert bridge.bridge_hook_url(config) == "http://box.local:9090/hook"
+
+    def test_registration_advertises_hook_url_override(self, tmp_path):
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            bus_url="https://bus.tailnet.example/mcp",
+            hook_url="http://laptop.tailnet.example:8082/hook",
+        )
+        calls = []
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments})
+            if tool_name == "list_webhooks":
+                return []
+            return {"webhook_id": 44}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            assert bridge.register_with_bus(config) == 44
+
+        register = next(c for c in calls if c["tool"] == "register_webhook")
+        assert register["arguments"]["url"] == "http://laptop.tailnet.example:8082/hook"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -481,6 +481,46 @@ class TestHookFiltering:
         assert start["status"] == 200  # fell through the precheck, delivered
         assert (config.wake_dir / "target-1.jsonl").exists()
 
+    def test_client_disconnect_mid_body_is_a_named_400(self, config):
+        """A peer that aborts mid-body makes request.stream() raise
+        ClientDisconnect (uvicorn delivers http.disconnect); uncaught it
+        500s with a traceback. Every other wire failure returns a named
+        4xx, so this one must too. Driven at the ASGI layer - httpx can't
+        model a half-sent body cleanly."""
+        import asyncio
+
+        app = create_bridge_app(config)
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "path": "/hook",
+            "raw_path": b"/hook",
+            "query_string": b"",
+            "headers": [(b"host", b"127.0.0.1:8082"), (b"content-type", b"application/json")],
+        }
+
+        async def drive():
+            sent = []
+            messages = [
+                {"type": "http.request", "body": b'{"partial":', "more_body": True},
+                {"type": "http.disconnect"},
+            ]
+
+            async def receive():
+                return messages.pop(0)
+
+            async def send(message):
+                sent.append(message)
+
+            await app(scope, receive, send)
+            return sent
+
+        sent = asyncio.run(drive())
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 400
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+
     def test_unserializable_payload_is_a_named_400_not_500(self, config):
         """json.dumps in _spool has the same recursion sibling the
         json.loads arm catches, one screen up - and it runs a few frames
@@ -491,18 +531,23 @@ class TestHookFiltering:
         forcing the encoder failure rather than tuning a fragile
         cross-version depth band."""
         client = TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE, headers=JSON_CT)
-        with patch.object(bridge.Injector, "deliver", side_effect=RecursionError):
+        # _spool re-raises the encoder failure as the dedicated type; process
+        # maps ONLY that (never a post-spool RecursionError) to the 400
+        with patch.object(
+            bridge.Injector, "deliver", side_effect=bridge._UnserializablePayloadError
+        ):
             resp = client.post("/hook", content=json.dumps(make_event()).encode())
         assert resp.status_code == 400
         assert resp.json() == {"error": "invalid JSON"}
 
     def test_spool_serialization_failure_creates_no_file_or_lock(self, config):
-        """_spool serializes BEFORE it opens the file or takes the flock,
-        so a RecursionError out of json.dumps leaves nothing behind - the
-        spool line and lock file must not exist, and no lock is held."""
+        """_spool serializes BEFORE it opens the file or takes the flock, so
+        a json.dumps recursion failure - re-raised as _UnserializablePayloadError
+        so process() maps only the pre-durable case to a 400 - leaves
+        nothing behind: no spool line, no lock file, no held lock."""
         injector = Injector(config)
         with patch.object(bridge.json, "dumps", side_effect=RecursionError):
-            with pytest.raises(RecursionError):
+            with pytest.raises(bridge._UnserializablePayloadError):
                 injector.deliver("target-1", make_event())
         assert not (config.wake_dir / "target-1.jsonl").exists()
         assert not (config.wake_dir / "target-1.lock").exists()
@@ -521,6 +566,19 @@ class TestHookFiltering:
         # The open of the symlinked lock raises ELOOP; deliver does not
         # swallow it (only the /hook path maps spool failures to a status)
         with pytest.raises(OSError):
+            injector.deliver("target-1", make_event())
+        assert not outside.exists()  # never followed through the link
+
+    def test_symlinked_spool_file_is_refused_with_a_clear_message(self, config, tmp_path):
+        """The <sid>.jsonl sibling of the lock symlink takes a different
+        branch: spool_file.resolve() follows the link first, so the
+        containment check fires before O_NOFOLLOW ever runs. The refusal
+        must name the symlink (the id is charset-clean, so the cause is a
+        planted link, not a hostile id) and never follow it."""
+        injector = Injector(config)  # creates + chmods the wake dir
+        outside = tmp_path / "outside-spool"
+        (config.wake_dir / "target-1.jsonl").symlink_to(outside)
+        with pytest.raises(ValueError, match="symlink"):
             injector.deliver("target-1", make_event())
         assert not outside.exists()  # never followed through the link
 
@@ -1104,6 +1162,39 @@ class TestTmuxBackend:
             # The non-ASCII decoy parses and the real pane id is used
             assert injector.deliver("target-1", make_event()) == "tmux"
         assert seen["encoding"] == "utf-8"
+
+    def test_valid_nondict_read_clears_stale_read_keys(self, tmp_path, caplog):
+        """A valid-JSON-but-non-dict read (a list) proves the read AND parse
+        conditions cleared even though the shape is wrong, so it must disarm
+        unparseable/unreadable while it arms not-an-object - otherwise a
+        genuinely-new later read/parse failure demotes to debug behind a
+        stale key, silent at the default level."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            # 1. Unreadable (a directory) -> arms 'unreadable', warns
+            panes.mkdir()
+            injector.deliver("target-1", make_event())
+            assert len(warnings()) == 1
+            # 2. A valid JSON list -> not-an-object arm; the valid parse must
+            # clear the stale 'unreadable' key even though it returns early
+            panes.rmdir()
+            panes.write_text(json.dumps(["not", "a", "dict"]))
+            injector.deliver("target-1", make_event())
+            assert len(warnings()) == 2  # not-an-object, a fresh condition
+            # 3. Unreadable again -> genuinely new; must WARN, not debug
+            # behind a key step 2 should have cleared
+            panes.unlink()
+            panes.mkdir()
+            injector.deliver("target-1", make_event())
+            assert len(warnings()) == 3
 
     def test_persistent_panes_failure_warns_once(self, tmp_path, caplog):
         """A stuck-broken panes.json must not emit one WARNING per DM - and
@@ -1857,6 +1948,18 @@ class TestDaemonLifecycle:
         non_path = BridgeConfig(wake_dir=123)
         with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_WAKE_DIR"):
             create_bridge_app(non_path)
+        # The three string inputs: a non-str bus_url/hook_url raises a bare
+        # AttributeError out of urlsplit; a non-str bind (int) validates as a
+        # bogus 0.0.0.x and fails only later in uvicorn.run - both must be
+        # the named config error instead
+        for kwargs, env in (
+            ({"bus_url": 123}, "AGENT_EVENT_BUS_URL"),
+            ({"hook_url": tmp_path}, "AGENT_EVENT_BUS_BRIDGE_HOOK_URL"),
+            ({"bind": 123, "secret": "s"}, "AGENT_EVENT_BUS_BRIDGE_BIND"),
+        ):
+            bad_str = BridgeConfig(wake_dir=tmp_path / "wake", **kwargs)
+            with pytest.raises(bridge.BridgeConfigError, match=env):
+                create_bridge_app(bad_str)
 
     def test_half_wired_registration_pair_is_rejected(self, config):
         """Passing only one of registration_state/registration_stop would
@@ -2266,6 +2369,39 @@ class TestBindHost:
     def test_loopback_bind_is_accepted_without_secret(self):
         config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "127.0.0.1"]))
         assert bridge.bind_host(config) == "127.0.0.1"
+
+    def test_pinned_bind_differing_loopback_literal_warns(self, caplog):
+        """The missing quadrant member: a PINNED --bind on one loopback
+        literal under a hook URL naming a DIFFERENT same-family loopback
+        literal. Both loopback (quadrant checks quiet), same family (family
+        checks quiet), exposed False (no secret) - yet the bus POSTs where
+        nothing listens. A derived bind can't hit this; a pinned one can."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(
+                bridge.build_parser().parse_args(
+                    ["--bind", "127.0.0.1", "--hook-url", "http://127.0.1.1:8082/hook"]
+                )
+            )
+        assert any("127.0.0.1" in r.message and "127.0.1.1" in r.message for r in caplog.records)
+
+    def test_matching_loopback_literal_is_quiet(self, caplog):
+        """The same loopback literal on both sides is the normal pinned
+        case - no warning. localhost is exempt too (no single literal to
+        compare), which the differing-literal check must not trip on."""
+        import logging
+
+        for bind, hook in (
+            ("127.0.0.1", "http://127.0.0.1:8082/hook"),
+            ("127.0.0.1", "http://localhost:8082/hook"),
+        ):
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+                bridge.config_from_args(
+                    bridge.build_parser().parse_args(["--bind", bind, "--hook-url", hook])
+                )
+            assert not any("different loopback" in r.message for r in caplog.records), (bind, hook)
 
     def test_invalid_bind_is_refused(self):
         args = bridge.build_parser().parse_args(["--bind", "localhost:8082"])

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -109,30 +109,98 @@ class TestHookFiltering:
         assert client.get("/health").json()["status"] == "ok"
 
 
-class TestInjectorCooldown:
-    def test_second_wake_within_cooldown_spools_only(self, config):
-        injector = Injector(config)
-        event = make_event()
+def make_tmux_injector(tmp_path, sessions=("target-1",), cooldown=30.0):
+    """A tmux-backend injector with pane mappings for the given sessions."""
+    config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux", cooldown_seconds=cooldown)
+    config.wake_dir.mkdir(parents=True)
+    panes = {sid: f"%{i}" for i, sid in enumerate(sessions)}
+    (config.wake_dir / "panes.json").write_text(json.dumps(panes))
+    return Injector(config), config
 
-        assert injector.deliver("target-1", event) == "spool"
-        assert injector.deliver("target-1", event) == "spool-cooldown"
+
+def tmux_ok(cmd, **kwargs):
+    class Result:
+        returncode = 0
+
+    return Result()
+
+
+class TestInjectorCooldown:
+    """The cooldown bounds successful injections only - spool writes are
+    durable bookkeeping, and failed wakes must not burn the window."""
+
+    def test_second_wake_within_cooldown_spools_only(self, tmp_path):
+        injector, config = make_tmux_injector(tmp_path)
+
+        with patch.object(bridge.subprocess, "run", tmux_ok):
+            assert injector.deliver("target-1", make_event()) == "tmux"
+            assert injector.deliver("target-1", make_event()) == "spool-cooldown"
 
         # Both events were spooled - cooldown bounds wakes, not durability
         lines = (config.wake_dir / "target-1.jsonl").read_text().splitlines()
         assert len(lines) == 2
 
-    def test_cooldown_is_per_session(self, config):
+    def test_cooldown_is_per_session(self, tmp_path):
+        injector, _ = make_tmux_injector(tmp_path, sessions=("target-1", "target-2"))
+
+        with patch.object(bridge.subprocess, "run", tmux_ok):
+            assert injector.deliver("target-1", make_event()) == "tmux"
+            assert injector.deliver("target-2", make_event()) == "tmux"
+
+    def test_wake_allowed_after_cooldown_expires(self, tmp_path):
+        injector, _ = make_tmux_injector(tmp_path, cooldown=30.0)
+
+        clock = {"now": 1000.0}
+        with patch.object(bridge.time, "monotonic", lambda: clock["now"]):
+            with patch.object(bridge.subprocess, "run", tmux_ok):
+                assert injector.deliver("target-1", make_event()) == "tmux"
+                clock["now"] += 10.0
+                assert injector.deliver("target-1", make_event()) == "spool-cooldown"
+                clock["now"] += 25.0  # 35s after the successful wake
+                assert injector.deliver("target-1", make_event()) == "tmux"
+
+    def test_failed_wake_does_not_burn_cooldown(self, tmp_path):
+        """A transient tmux failure must not silence the session for a full
+        cooldown - the next event retries immediately."""
+        injector, _ = make_tmux_injector(tmp_path)
+
+        def tmux_fail(cmd, **kwargs):
+            raise bridge.subprocess.CalledProcessError(1, cmd)
+
+        with patch.object(bridge.subprocess, "run", tmux_fail):
+            assert injector.deliver("target-1", make_event()) == "spool"
+
+        with patch.object(bridge.subprocess, "run", tmux_ok):
+            assert injector.deliver("target-1", make_event()) == "tmux"
+
+    def test_spool_backend_never_cooldowns(self, config):
         injector = Injector(config)
 
         assert injector.deliver("target-1", make_event()) == "spool"
-        assert injector.deliver("target-2", make_event()) == "spool"
+        assert injector.deliver("target-1", make_event()) == "spool"
 
-    def test_wake_allowed_after_cooldown_expires(self, config):
-        config.cooldown_seconds = 0.0
+    def test_concurrent_spool_appends_do_not_tear(self, config):
+        """Concurrent webhook deliveries append under the lock; every line
+        must stay valid JSON even when payloads exceed the IO buffer."""
+        import threading
+
         injector = Injector(config)
+        event = make_event(payload="x" * 100_000)  # > default 8 KiB buffer
 
-        assert injector.deliver("target-1", make_event()) == "spool"
-        assert injector.deliver("target-1", make_event()) == "spool"
+        threads = [threading.Thread(target=injector.deliver, args=("t", event)) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        lines = (config.wake_dir / "t.jsonl").read_text().splitlines()
+        assert len(lines) == 8
+        for line in lines:
+            json.loads(line)
+
+    def test_wake_dir_is_private(self, config):
+        Injector(config).deliver("target-1", make_event())
+        assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
 
 
 class TestTmuxBackend:
@@ -194,16 +262,54 @@ class TestBusRegistration:
 
         def fake_call_tool(tool_name, arguments, url=None, **kwargs):
             calls.append({"tool": tool_name, "arguments": arguments, "url": url})
+            if tool_name == "list_webhooks":
+                return []
             return {"webhook_id": 42}
 
         with patch.object(bridge, "call_tool", fake_call_tool):
             webhook_id = bridge.register_with_bus(config)
 
         assert webhook_id == 42
-        assert calls[0]["tool"] == "register_webhook"
-        assert calls[0]["arguments"]["url"] == "http://127.0.0.1:9999/hook"
-        assert calls[0]["arguments"]["secret"] == "s3cret"
-        assert calls[0]["url"] == "http://bus/mcp"
+        register = next(c for c in calls if c["tool"] == "register_webhook")
+        assert register["arguments"]["url"] == "http://127.0.0.1:9999/hook"
+        assert register["arguments"]["secret"] == "s3cret"
+        assert register["url"] == "http://bus/mcp"
+
+    def test_startup_removes_stale_webhooks_at_same_url(self, tmp_path):
+        """Unclean exits leave active webhooks behind; each would duplicate
+        every wake, so startup must clean up matching URLs first."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", port=9999)
+        calls = []
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments})
+            if tool_name == "list_webhooks":
+                return [
+                    {"webhook_id": 7, "url": "http://127.0.0.1:9999/hook"},
+                    {"webhook_id": 8, "url": "http://elsewhere/hook"},
+                ]
+            return {"webhook_id": 43}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            webhook_id = bridge.register_with_bus(config)
+
+        assert webhook_id == 43
+        unregisters = [c["arguments"] for c in calls if c["tool"] == "unregister_webhook"]
+        # Only the stale hook at OUR url is removed, not other consumers'
+        assert unregisters == [{"webhook_id": 7}]
+
+    def test_empty_secret_env_is_normalized_to_none(self, tmp_path, monkeypatch):
+        """An accidentally empty secret must not split registration (skips
+        the secret -> unsigned payloads) from verification (demands
+        signatures) - the combination 401s every delivery silently."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "")
+        secret = __import__("os").environ.get("AGENT_EVENT_BUS_BRIDGE_SECRET") or None
+        config = BridgeConfig(wake_dir=tmp_path / "wake", secret=secret)
+
+        # Verification is disabled, matching registration's omitted secret
+        client = TestClient(create_bridge_app(config))
+        resp = client.post("/hook", content=json.dumps(make_event()).encode())
+        assert resp.status_code == 200
 
     def test_unregister_swallows_bus_unreachable(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -276,6 +276,36 @@ class TestHookFiltering:
         )
         assert _get_signal_level(dm) == "actionable"
 
+    def test_bus_webhook_payload_key_contract(self):
+        """The wake pipeline reads exactly three keys off the bus's POST -
+        channel (the ONLY thing resolve_target_session reads), signal_level
+        (the actionable filter), event_id (the drain hook's dedupe key) -
+        and every hook test here builds its own body via make_event(), so
+        without this pin the bus could drop or rename a key and the whole
+        suite would stay green while every real delivery resolved no
+        target. Same shape as the _get_signal_level pin above: assert
+        against the bus's real payload builder, then close the loop by
+        resolving a target from its actual output."""
+        from datetime import datetime
+
+        from agent_event_bus.server import _webhook_payload
+        from agent_event_bus.storage import Event as BusEvent
+
+        dm = BusEvent(
+            id=7,
+            event_type="note",
+            payload="hi",
+            session_id="sender-1",
+            timestamp=datetime(2026, 8, 8),
+            channel="session:target-1",
+        )
+        payload = _webhook_payload(dm)
+        assert payload["event_id"] == 7
+        assert payload["signal_level"] == "actionable"
+        # sender attribution, distinct from the wake target
+        assert payload["session_id"] == "sender-1"
+        assert bridge.resolve_target_session(payload) == "target-1"
+
     def test_trailing_slash_hook_is_404_not_redirect(self, client):
         """redirect_slashes must stay off: the bus's httpx client doesn't
         follow redirects and counts any status under 400 as delivered, so a
@@ -379,6 +409,22 @@ class TestHookFiltering:
         # backend's terminal must show more than the registration line, so
         # pin the INFO line carrying the event id like the warnings around it
         assert any("Spooled event 1" in r.message for r in caplog.records)
+
+    def test_spool_breadcrumb_demotes_after_first_delivery(self, config, caplog):
+        """The INFO breadcrumb proves the chain works ONCE - webhooks have
+        no machine scoping, so on a multi-machine bus the default backend
+        would otherwise log one INFO per foreign-machine DM, the exact
+        volume the tmux unmapped arm was demoted to debug to avoid.
+        Repeats must still be visible under DEV_MODE, not skipped."""
+        import logging
+
+        injector = Injector(config)
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            injector.deliver("target-1", make_event())
+            injector.deliver("target-1", make_event(event_id=2))
+            injector.deliver("other-session", make_event(event_id=3))
+        spooled = [r for r in caplog.records if "Spooled event" in r.message]
+        assert [r.levelno for r in spooled] == [logging.INFO, logging.DEBUG, logging.DEBUG]
 
     def test_spool_and_lock_files_created_0o600(self, config):
         """Spool lines carry full publisher-authored payloads, and the wake

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -143,30 +143,34 @@ class TestPathSafety:
         ):
             assert resolve_target_session(make_event(channel=channel)) is None
 
-    def test_unsafe_id_warning_is_bounded_per_channel(self, caplog, monkeypatch):
-        """The rejection arm is publisher-drivable, so a repeated garbage
-        channel must not write one WARNING per event: first sighting warns,
-        repeats are debug, and the dedup set clears at its cap so warnings
-        resume instead of the set growing without bound."""
+    def test_unsafe_id_warning_is_rate_limited(self, caplog, monkeypatch):
+        """The rejection arm is publisher-drivable and the channel string is
+        publisher-CHOSEN, so a bound keyed on the value (the old dedup set)
+        still let a publisher who varies the id force one WARNING per event.
+        The bound must be content-independent: one warning per interval,
+        repeats at debug, and a persistent condition re-warns next interval
+        instead of going dark forever."""
         import logging
 
-        monkeypatch.setattr(bridge, "_warned_unsafe_channels", set())
-        monkeypatch.setattr(bridge, "_WARNED_UNSAFE_CHANNELS_CAP", 2)
+        monkeypatch.setitem(bridge._unsafe_warn_state, "last", -float("inf"))
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(bridge.time, "monotonic", lambda: clock["now"])
 
         def warnings():
             return [r for r in caplog.records if r.levelno == logging.WARNING]
 
         with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
-            assert resolve_target_session(make_event(channel="session:a/b")) is None
-            assert resolve_target_session(make_event(channel="session:a/b")) is None
-            assert len(warnings()) == 1  # the repeat was debug, not warning
-            assert "session:a/b" in warnings()[0].message
-            # Two more distinct channels reach the cap and clear the set...
-            assert resolve_target_session(make_event(channel="session:c/d")) is None
-            assert resolve_target_session(make_event(channel="session:e/f")) is None
-            # ...so the first channel warns again instead of staying dark
-            assert resolve_target_session(make_event(channel="session:a/b")) is None
-        assert len(warnings()) == 4
+            # Varying strings within one interval: one warning, rest debug -
+            # the shape the per-channel set could not bound
+            assert resolve_target_session(make_event(channel="session:x/1")) is None
+            assert resolve_target_session(make_event(channel="session:x/2")) is None
+            assert resolve_target_session(make_event(channel="session:x/3")) is None
+            assert len(warnings()) == 1
+            assert "session:x/1" in warnings()[0].message
+            # Past the interval the arm warns again
+            clock["now"] += bridge._UNSAFE_WARN_INTERVAL_SECONDS
+            assert resolve_target_session(make_event(channel="session:x/4")) is None
+        assert len(warnings()) == 2
 
     def test_traversal_channel_is_ignored_and_writes_nothing(self, client, config, tmp_path):
         evil = make_event(channel="session:../../escape")
@@ -1003,6 +1007,38 @@ class TestDaemonLifecycle:
                 # Context exit runs lifespan shutdown while slow_register sleeps
         # The join observed the in-flight commit, so the unregister got it
         assert unregistered == [43]
+
+    def test_health_reports_unregistered_while_registration_pending(self, tmp_path):
+        """The registered:false arm - the state a supervisor readiness probe
+        gates on while register_with_retry backs off against a down bus -
+        was the one /health shape without a test. Pins that the field means
+        COMMITTED, not merely configured."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        release = threading.Event()
+
+        def blocked_register(cfg):
+            release.wait(timeout=10)
+            return 77
+
+        state: dict = {}
+        stop = threading.Event()
+        unregistered: list = []
+        with patch.object(bridge, "register_with_bus", blocked_register):
+            with patch.object(
+                bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+            ):
+                app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+                with TestClient(app) as client:
+                    # Registration is in flight, deterministically not yet
+                    # committed (blocked on `release`)
+                    assert client.get("/health").json()["registered"] is False
+                    release.set()
+                    for _ in range(500):
+                        if client.get("/health").json()["registered"]:
+                            break
+                        time.sleep(0.01)
+                    assert client.get("/health").json()["registered"] is True
+        assert unregistered == [77]
 
     def test_app_without_registration_has_inert_lifespan(self, config):
         with TestClient(create_bridge_app(config)) as client:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -46,6 +46,7 @@ BRIDGE_ENV = (
     "AGENT_EVENT_BUS_BRIDGE_COOLDOWN",
     "AGENT_EVENT_BUS_BRIDGE_SECRET",
     "AGENT_EVENT_BUS_BRIDGE_HOOK_URL",
+    "AGENT_EVENT_BUS_BRIDGE_BIND",
     "AGENT_EVENT_BUS_WAKE_DIR",
 )
 
@@ -666,6 +667,27 @@ class TestHookUrlTopology:
         with pytest.raises(SystemExit, match="http"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
 
+    def test_schemeless_hook_url_is_refused(self, monkeypatch):
+        """The hook URL is what BOTH topology guards read - a scheme-less
+        value parses to hostname None, reads as loopback, skips the guards,
+        and registers a URL the bus can never POST to (silently inert with
+        /health reporting registered)."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "laptop.example:8082/hook")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_HOOK_URL"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_out_of_range_port_is_refused(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "99999")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_negative_cooldown_is_refused(self, monkeypatch):
+        """A negative cooldown casts cleanly but silently disables the
+        cooldown entirely (now - ts < -5 is never true)."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "-5")
+        with pytest.raises(SystemExit, match="COOLDOWN"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
     def test_hook_url_env_is_adopted(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:9090/hook")
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
@@ -702,3 +724,59 @@ class TestHookUrlTopology:
 
         register = next(c for c in calls if c["tool"] == "register_webhook")
         assert register["arguments"]["url"] == "http://laptop.tailnet.example:8082/hook"
+
+
+class TestBindHost:
+    """The bind decision gates whether the wake-injection endpoint is
+    reachable off-box - both directions must be pinned, not just the config
+    guard that shares its predicate."""
+
+    def test_loopback_hook_binds_localhost(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        assert bridge.bind_host(config) == "127.0.0.1"
+
+    def test_reachable_hook_binds_wide(self, tmp_path):
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake", hook_url="http://box.example:8082/hook", secret="s3cret"
+        )
+        assert bridge.bind_host(config) == "0.0.0.0"
+
+    def test_bind_override_pins_interface(self, tmp_path):
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://box.example:8082/hook",
+            secret="s3cret",
+            bind="100.100.1.2",
+        )
+        assert bridge.bind_host(config) == "100.100.1.2"
+
+    def test_main_passes_bind_through_and_unregisters(self, monkeypatch, tmp_path):
+        """End-to-end main(): the default local config binds loopback, the
+        lifespan registers, and the finally unregisters the committed id."""
+        import sys
+
+        import uvicorn
+
+        monkeypatch.setattr(
+            sys, "argv", ["agent-event-bus-bridge", "--wake-dir", str(tmp_path / "wake")]
+        )
+        seen = {}
+        unregistered = []
+
+        def fake_run(app, host=None, port=None):
+            seen["host"] = host
+            seen["port"] = port
+            # Run the lifespan the way uvicorn would, so registration fires
+            with TestClient(app):
+                pass
+
+        with patch.object(uvicorn, "run", fake_run):
+            with patch.object(bridge, "register_with_bus", lambda cfg: 99):
+                with patch.object(
+                    bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+                ):
+                    bridge.main()
+
+        assert seen["host"] == "127.0.0.1"
+        assert seen["port"] == bridge.DEFAULT_BRIDGE_PORT
+        assert unregistered == [99]

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -263,6 +263,21 @@ class TestInjectorCooldown:
         assert injector.deliver("target-1", make_event()) == "spool"
         assert injector.deliver("target-1", make_event()) == "spool"
 
+    def test_expired_last_wake_entries_are_pruned(self, tmp_path):
+        """Sessions are ephemeral; entries past the cooldown can never gate
+        a wake again and must not accumulate for the daemon's lifetime."""
+        injector, _ = make_tmux_injector(tmp_path, sessions=("target-1", "target-2"), cooldown=30.0)
+
+        clock = {"now": 1000.0}
+        with patch.object(bridge.time, "monotonic", lambda: clock["now"]):
+            with patch.object(bridge.subprocess, "run", tmux_ok):
+                assert injector.deliver("target-1", make_event()) == "tmux"
+                clock["now"] += 35.0
+                assert injector.deliver("target-2", make_event()) == "tmux"
+
+        assert "target-1" not in injector._last_wake
+        assert "target-2" in injector._last_wake
+
     def test_concurrent_spool_appends_do_not_tear(self, config):
         """Concurrent webhook deliveries append under the lock; every line
         must stay valid JSON even when payloads exceed the IO buffer."""
@@ -346,6 +361,28 @@ class TestTmuxBackend:
         with patch.object(bridge.subprocess, "run", tmux_perm):
             assert injector.deliver("target-1", make_event()) == "spool"
 
+    def test_malformed_panes_json_degrades_to_spool(self, tmp_path):
+        """panes.json is maintained by an external component - every failure
+        shape must read as 'unmapped', never escape as a 500."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+
+        for content in (b'["not", "an", "object"]', b'"bare string"', b"null", b"\xff\xfe{}"):
+            panes.write_bytes(content)
+            with patch.object(bridge.subprocess, "run") as mock_run:
+                assert injector.deliver("target-1", make_event()) == "spool"
+            mock_run.assert_not_called()
+
+    def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        (config.wake_dir / "panes.json").mkdir()  # IsADirectoryError on read
+
+        with patch.object(bridge.subprocess, "run") as mock_run:
+            assert injector.deliver("target-1", make_event()) == "spool"
+        mock_run.assert_not_called()
+
 
 class TestBusRegistration:
     def test_registers_webhook_with_bridge_url_and_secret(self, tmp_path):
@@ -427,6 +464,21 @@ class TestBusRegistration:
 
         assert state["webhook_id"] == 42
         assert len(attempts) == 3
+
+    def test_registration_without_id_is_retryable(self, tmp_path):
+        """A bus that answers but returns no webhook_id must be a retryable
+        failure - not a silent success that leaves the bridge receiving
+        nothing for the daemon's lifetime."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            if tool_name == "list_webhooks":
+                return []
+            return {}  # answered, but no webhook_id
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            with pytest.raises(SystemExit, match="no webhook_id"):
+                bridge.register_with_bus(config)
 
     def test_registration_retry_honors_shutdown(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -197,6 +197,19 @@ class TestHookFiltering:
         )
         assert _get_signal_level(dm) == "actionable"
 
+    def test_trailing_slash_hook_is_404_not_redirect(self, client):
+        """redirect_slashes must stay off: the bus's httpx client doesn't
+        follow redirects and counts any status under 400 as delivered, so a
+        307 for /hook/ would make a trailing-slash hook URL read as a
+        healthy webhook while the bridge processes nothing. A 404 is
+        retried and logged bus-side - loud instead of silently 'delivered'."""
+        resp = client.post(
+            "/hook/",
+            content=json.dumps(make_event()).encode(),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 404
+
     def test_below_actionable_ignored(self, client, config):
         for level in ("lifecycle", "info"):
             resp = client.post("/hook", content=json.dumps(make_event(signal_level=level)).encode())
@@ -580,6 +593,37 @@ class TestBusRegistration:
         assert register["arguments"]["channel"] == "session:"
         assert register["url"] == "http://bus/mcp"
 
+    def test_failed_stale_removal_is_retryable(self, tmp_path):
+        """unregister_webhook reports logical failure in-band (success-False
+        dict; call_tool raises only on transport errors) - a sweep that
+        didn't actually delete the row must not proceed to register and
+        stack the duplicate deliveries it exists to prevent. Already-gone
+        ("Webhook not found") stays benign: the row being absent is the goal."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", port=9999)
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            if tool_name == "list_webhooks":
+                return [{"webhook_id": 7, "url": "http://127.0.0.1:9999/hook"}]
+            if tool_name == "unregister_webhook":
+                return {}  # a JSON-RPC error response falls through to this
+            return {"webhook_id": 43}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            with pytest.raises(SystemExit, match="unexpected result"):
+                bridge.register_with_bus(config)
+
+    def test_already_gone_stale_row_is_benign(self, tmp_path):
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            if tool_name == "list_webhooks":
+                return [{"webhook_id": 7, "url": "http://127.0.0.1:9999/hook"}]
+            if tool_name == "unregister_webhook":
+                return {"success": False, "error": "Webhook not found", "webhook_id": 7}
+            return {"webhook_id": 43}
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", port=9999)
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            assert bridge.register_with_bus(config) == 43
+
     def test_unregister_calls_unregister_webhook_with_id_and_url(self, tmp_path):
         """Pin the wire call unregister_from_bus makes (tool name, id, bus
         URL) - a wrong argument here only ever surfaces as a stale row that
@@ -612,6 +656,8 @@ class TestBusRegistration:
                     {"webhook_id": 7, "url": "http://127.0.0.1:9999/hook"},
                     {"webhook_id": 8, "url": "http://elsewhere/hook"},
                 ]
+            if tool_name == "unregister_webhook":
+                return {"success": True, "webhook_id": arguments["webhook_id"]}
             return {"webhook_id": 43}
 
         with patch.object(bridge, "call_tool", fake_call_tool):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -683,6 +683,30 @@ class TestTmuxBackend:
             injector.deliver("target-1", make_event())
         assert len(warnings()) == 4
 
+    def test_bad_pane_value_warns_and_degrades_to_spool(self, tmp_path, caplog):
+        """A present-but-wrong-typed pane value (0 instead of "%0", "",
+        null) is a misconfiguration whose repair is nothing like "the
+        mapping is absent" - it must warn (once, via the reason-keyed
+        bound) instead of folding into the unmapped debug line, and still
+        degrade to spool."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            for bad in (0, "", None):
+                panes.write_text(json.dumps({"target-1": bad}))
+                with patch.object(bridge.subprocess, "run") as mock_run:
+                    assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+                mock_run.assert_not_called()
+        assert len(warnings()) == 1  # same reason across values - repeats debug
+        assert "not a pane id" in warnings()[0].message
+
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
         injector = Injector(config)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -17,7 +17,7 @@ from agent_event_bus.bridge import (
     resolve_target_session,
     verify_signature,
 )
-from agent_event_bus.server import _compute_signature
+from agent_event_bus.server import SIGNATURE_HEADER, _compute_signature
 
 
 def sign(body: bytes, secret: str) -> str:
@@ -121,7 +121,7 @@ class TestSignature:
         assert client.post("/hook", content=body).status_code == 401
 
         signed = client.post(
-            "/hook", content=body, headers={"X-Event-Bus-Signature": sign(body, "s3cret")}
+            "/hook", content=body, headers={SIGNATURE_HEADER: sign(body, "s3cret")}
         )
         assert signed.status_code == 200
         assert signed.json()["status"] == "delivered"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -97,9 +97,16 @@ def config(tmp_path):
     return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
 
 
+# The bus's httpx dispatch always sends this (server.py _dispatch_webhook);
+# the endpoint requires it so browser fetch() cannot reach the handler
+# preflight-free - a client-level default keeps every test speaking the
+# bus's wire shape without per-call noise
+JSON_CT = {"Content-Type": "application/json"}
+
+
 @pytest.fixture
 def client(config):
-    return TestClient(create_bridge_app(config))
+    return TestClient(create_bridge_app(config), headers=JSON_CT)
 
 
 class TestSignature:
@@ -121,7 +128,7 @@ class TestSignature:
 
     def test_hook_rejects_unsigned_when_secret_configured(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", secret="s3cret")
-        client = TestClient(create_bridge_app(config))
+        client = TestClient(create_bridge_app(config), headers=JSON_CT)
         body = json.dumps(make_event()).encode()
 
         assert client.post("/hook", content=body).status_code == 401
@@ -368,6 +375,37 @@ class TestHookFiltering:
         # UnicodeDecodeError (a ValueError, not JSONDecodeError) and must
         # be a 400 too, not a 500 with bus retries behind it
         assert client.post("/hook", content=b"\x80abc").status_code == 400
+        # Deep nesting blows the interpreter recursion limit inside
+        # json.loads - RecursionError, which is NOT a ValueError - at a
+        # size far under MAX_BODY_BYTES. Same named 400, not a 500 with
+        # bus retries behind it.
+        assert client.post("/hook", content=b"[" * 300_000).status_code == 400
+
+    def test_browser_shaped_post_is_rejected(self, config):
+        """The loopback-needs-no-secret posture holds only if a browser
+        cannot reach the handler: fetch(mode:"no-cors") from any web page
+        can POST to 127.0.0.1 preflight-free as long as the Content-Type
+        is CORS-safelisted (a string body defaults to text/plain) - the
+        response is opaque but the spool write would already have
+        happened. Requiring application/json (what the bus's httpx
+        dispatch actually sends) forces a preflight the bridge never
+        answers, so the browser never sends the POST at all."""
+        client = TestClient(create_bridge_app(config))  # no default headers
+        body = json.dumps(make_event()).encode()
+        # The exact shape a page can emit without a preflight: fetch()
+        # string-body default, form enctype, and no header at all
+        for content_type in ("text/plain;charset=UTF-8", "application/x-www-form-urlencoded", None):
+            headers = {"Content-Type": content_type} if content_type else {}
+            resp = client.post("/hook", content=body, headers=headers)
+            assert resp.status_code == 415, content_type
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+        # Media-type parameters must not defeat the guard - the check is
+        # about what a browser can send preflight-free, not strictness
+        ok = client.post(
+            "/hook", content=body, headers={"Content-Type": "application/json; charset=utf-8"}
+        )
+        assert ok.status_code == 200
+        assert ok.json()["status"] == "delivered"
 
     def test_non_object_json_rejected(self, client):
         """Valid JSON that isn't an object must be a 400, not an
@@ -1592,6 +1630,11 @@ class TestDaemonLifecycle:
         bad = BridgeConfig(wake_dir=tmp_path / "wake", port="eighty")
         with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
             create_bridge_app(bad)
+        # Path() was the one normalization that could still raise a bare
+        # TypeError - the exact shape this block exists to prevent
+        non_path = BridgeConfig(wake_dir=123)
+        with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_WAKE_DIR"):
+            create_bridge_app(non_path)
 
     def test_half_wired_registration_pair_is_rejected(self, config):
         """Passing only one of registration_state/registration_stop would
@@ -1746,6 +1789,22 @@ class TestHookUrlTopology:
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.example:99999/hook")
         with pytest.raises(SystemExit, match="bad port"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_malformed_hook_port_refused_for_hand_built_configs(self, tmp_path):
+        """SplitResult.port parses lazily, so a malformed port sails past
+        the scheme/hostname refusals - and the bus stores the registered
+        URL verbatim, so on the embedding path it would register cleanly
+        and then fail every dispatch bus-side (httpx.InvalidURL) with
+        /health green: the silent-inertness shape the scheme refusal
+        closed in round 7. The refusal must live in validate_config so
+        embedders get the same named error as the CLI."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://bridge.example:80o82/hook",
+            secret="s3cret",
+        )
+        with pytest.raises(bridge.BridgeConfigError, match="bad port"):
+            create_bridge_app(config)
 
     def test_out_of_range_port_is_refused(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "99999")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -730,6 +730,20 @@ class TestHookFiltering:
         for host in ("[fd7a:115c:a1e0::1]:8082", "[fd7a:115c:a1e0::1]"):
             assert client.get("/health", headers={"Host": host}).status_code == 200, host
 
+    def test_ipv6_hook_host_normalized_in_allowlist(self, tmp_path):
+        """Same normalization on the hook side: an EXPANDED IPv6 hook-URL
+        literal must still match the compressed Host a probe (or curl to the
+        hook hostname) sends - urlsplit lowercases but does not compress."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://[FD7A:115C:A1E0:0:0:0:0:1]:8082/hook",  # expanded
+            secret="s3cret",
+        )
+        client = TestClient(create_bridge_app(config))
+        assert (
+            client.get("/health", headers={"Host": "[fd7a:115c:a1e0::1]:8082"}).status_code == 200
+        )
+
     def test_oversized_body_rejected(self, client):
         """The body must be read before the HMAC can be checked, so bound
         what an unauthenticated peer can make the bridge buffer."""
@@ -1156,7 +1170,7 @@ class TestTmuxBackend:
         assert len(warnings()) == 3
 
     def test_wake_failure_bound_is_per_session(self, tmp_path, caplog):
-        """The round-38 panes lesson applies here too: the bound must key
+        """The panes-guard lesson applies here too: the bound must key
         per (session, exception type). A second broken session must WARN
         rather than be demoted behind the first's key, and a healthy
         session's success must not re-arm a broken one into warn-per-DM."""
@@ -1412,7 +1426,7 @@ class TestTmuxBackend:
         assert len(warnings()) == 1  # neither absent nor healthy reads re-armed it
 
     def test_warn_key_caps_bound_both_sets(self, tmp_path, caplog, monkeypatch):
-        """The round-47 retention caps are load-bearing: without a pin a
+        """The warn-key retention caps are load-bearing: without a pin a
         refactor could delete the clear, flip the comparison, or clear the
         WRONG set (the two sit a screen apart under different locking).
         Cap at 2, drive three distinct conditions per set, assert the bound
@@ -2217,7 +2231,7 @@ class TestHookUrlTopology:
         URL verbatim, so on the embedding path it would register cleanly
         and then fail every dispatch bus-side (httpx.InvalidURL) with
         /health green: the silent-inertness shape the scheme refusal
-        closed in round 7. The refusal must live in validate_config so
+        already closes. The refusal must live in validate_config so
         embedders get the same named error as the CLI."""
         config = BridgeConfig(
             wake_dir=tmp_path / "wake",
@@ -2426,7 +2440,7 @@ class TestBindHost:
     def test_non_loopback_bind_without_secret_is_refused(self, monkeypatch):
         """--bind decides exposure before the hook URL does: a wide bind
         with the default local bus must not open an unsigned /hook off-box
-        (the round-6 refusal, reachable through the round-7 flag)."""
+        (the exposure refusal, reachable through the --bind flag)."""
         for bind in ("0.0.0.0", "100.100.1.2"):
             args = bridge.build_parser().parse_args(["--bind", bind])
             with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
@@ -2724,6 +2738,29 @@ class TestBindHost:
         monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", loose)
         with pytest.raises(SystemExit, match="group/world-accessible"):
             bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "wake"))
+
+    def test_uncreatable_lock_dir_is_a_named_exit(self, tmp_path, monkeypatch):
+        """The create arm of _ensure_private_lock_dir: an os.mkdir that
+        cannot succeed (here a parent that is a regular file -> NotADirectory)
+        must surface as the named 'set XDG_RUNTIME_DIR' message, not a bare
+        traceback at the operator's first contact with the daemon."""
+        (tmp_path / "afile").write_text("x")
+        monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", tmp_path / "afile" / "locks")
+        with pytest.raises(SystemExit, match="Cannot create bridge lock dir"):
+            bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "wake"))
+
+    def test_symlinked_singleton_lock_is_a_named_exit(self, tmp_path):
+        """The os.open arm of _flock_or_exit: a symlinked singleton lock FILE
+        must fail O_NOFOLLOW (ELOOP) into the named 'Cannot open bridge lock'
+        message, and the link target must never be created through it. Driven
+        on the wake-dir lock, reachable without touching DEFAULT_LOCK_DIR."""
+        wake = tmp_path / "wake"
+        wake.mkdir()
+        victim = tmp_path / "victim"
+        (wake / "bridge.singleton.lock").symlink_to(victim)
+        with pytest.raises(SystemExit, match="Cannot open bridge lock"):
+            bridge._acquire_singleton_locks(BridgeConfig(wake_dir=wake))
+        assert not victim.exists()  # O_NOFOLLOW: never created through the link
 
     def test_main_refuses_and_never_sweeps_when_singleton_held(self, monkeypatch, tmp_path):
         """Pins the acquisition AND its ordering: with the lock already held,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -772,15 +772,19 @@ class TestTmuxBackend:
                     assert injector.deliver("target-1", make_event()) == "spool-unmapped"
                 mock_run.assert_not_called()
             assert len(warnings()) == 1  # same reason across values - repeats debug
+            # The repr names the entry to fix - null warned first
+            assert "(None)" in warnings()[0].message
             # Per-shape, not aggregate: the two repeats were DEMOTED (seen,
-            # logged at debug), not skipped - an aggregate count can't tell
-            # those apart
+            # logged at debug, carrying their own reprs), not skipped - an
+            # aggregate count can't tell those apart
             demoted = [
                 r
                 for r in caplog.records
                 if r.levelno == logging.DEBUG and "not a pane id" in r.message
             ]
             assert len(demoted) == 2
+            assert any("(0)" in r.message for r in demoted)
+            assert any("('')" in r.message for r in demoted)
             # A genuinely ABSENT key is the healthy shape and re-arms; a bad
             # value must not - so bad -> absent -> bad warns twice
             panes.write_text(json.dumps({"other-session": "%1"}))
@@ -789,6 +793,32 @@ class TestTmuxBackend:
             injector.deliver("target-1", make_event())
         assert len(warnings()) == 2
         assert "not a pane id" in warnings()[0].message
+
+    def test_bad_pane_value_bound_survives_interleaved_sessions(self, tmp_path, caplog):
+        """The guard must be keyed per CONDITION, not per last delivery: on
+        a multi-machine bus the unmapped arm is the documented NORMAL
+        outcome, so a bad entry interleaved with absent (or healthy)
+        sessions is the steady state - a single re-arm slot would oscillate
+        into one WARNING per DM."""
+        import logging
+
+        # cooldown 0 so every target-2 delivery attempts (and succeeds at)
+        # a real wake - the healthy-entry read is the arm under test
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux", cooldown_seconds=0.0)
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+        panes.write_text(json.dumps({"target-1": 0, "target-2": "%5"}))
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.subprocess, "run", tmux_ok):
+                for _ in range(3):
+                    injector.deliver("target-1", make_event())  # bad entry
+                    injector.deliver("other-session", make_event())  # absent - normal
+                    assert injector.deliver("target-2", make_event()) == "tmux"  # healthy
+        assert len(warnings()) == 1  # neither absent nor healthy reads re-armed it
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -481,6 +481,49 @@ class TestHookFiltering:
         assert start["status"] == 200  # fell through the precheck, delivered
         assert (config.wake_dir / "target-1.jsonl").exists()
 
+    def test_unserializable_payload_is_a_named_400_not_500(self, config):
+        """json.dumps in _spool has the same recursion sibling the
+        json.loads arm catches, one screen up - and it runs a few frames
+        deeper, so a payload nested just under the parse limit is admitted
+        and then fails to encode. Deterministic (all three bus retries
+        raise identically), so process() maps it to the same named 400
+        every other wire-input path gives, not three tracebacks. Driven by
+        forcing the encoder failure rather than tuning a fragile
+        cross-version depth band."""
+        client = TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE, headers=JSON_CT)
+        with patch.object(bridge.Injector, "deliver", side_effect=RecursionError):
+            resp = client.post("/hook", content=json.dumps(make_event()).encode())
+        assert resp.status_code == 400
+        assert resp.json() == {"error": "invalid JSON"}
+
+    def test_spool_serialization_failure_creates_no_file_or_lock(self, config):
+        """_spool serializes BEFORE it opens the file or takes the flock,
+        so a RecursionError out of json.dumps leaves nothing behind - the
+        spool line and lock file must not exist, and no lock is held."""
+        injector = Injector(config)
+        with patch.object(bridge.json, "dumps", side_effect=RecursionError):
+            with pytest.raises(RecursionError):
+                injector.deliver("target-1", make_event())
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+        assert not (config.wake_dir / "target-1.lock").exists()
+
+    def test_symlinked_lock_file_does_not_write_through(self, config, tmp_path):
+        """--wake-dir may have been group/world-writable before the daemon
+        first ran; the startup chmod narrows the dir but does not remove a
+        pre-planted <sid>.lock symlink already inside it. O_NOFOLLOW makes
+        the open fail (ELOOP -> OSError, the retryable arm) instead of
+        following the link and taking an flock on a foreign inode - which
+        would silently protect the wrong file. The link target must stay
+        untouched (never created)."""
+        injector = Injector(config)  # creates + chmods the wake dir
+        outside = tmp_path / "outside-target"
+        (config.wake_dir / "target-1.lock").symlink_to(outside)
+        # The open of the symlinked lock raises ELOOP; deliver does not
+        # swallow it (only the /hook path maps spool failures to a status)
+        with pytest.raises(OSError):
+            injector.deliver("target-1", make_event())
+        assert not outside.exists()  # never followed through the link
+
     def test_browser_shaped_post_is_rejected(self, config):
         """The loopback-needs-no-secret posture holds only if a browser
         cannot reach the handler: fetch(mode:"no-cors") from any web page
@@ -548,6 +591,16 @@ class TestHookFiltering:
         resp = client.post("/hook", content=body, headers=signed)
         assert resp.status_code == 200
         assert resp.json()["status"] == "delivered"
+
+    def test_health_carries_the_same_host_guard(self, config):
+        """The DNS-rebinding guard covers /health too: a rebound tab must
+        not even be able to CONFIRM a bridge runs here (the signal that the
+        /hook probe is worth the round trip). A supervisor's loopback probe
+        still passes."""
+        client = TestClient(create_bridge_app(config))  # no default Host override
+        assert client.get("/health", headers={"Host": "evil.example:8082"}).status_code == 421
+        assert client.get("/health", headers={"Host": "127.0.0.1:8082"}).status_code == 200
+        assert client.get("/health", headers={"Host": "[::1]"}).status_code == 200
 
     def test_non_object_json_rejected(self, client):
         """Valid JSON that isn't an object must be a 400, not an
@@ -1619,7 +1672,7 @@ class TestDaemonLifecycle:
                 bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
             ):
                 app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-                with TestClient(app) as client:
+                with TestClient(app, base_url=LOOPBACK_BASE) as client:
                     assert registered.wait(timeout=5), "startup never fired registration"
                     # /health surfaces the registration outcome - the one signal
                     # that separates "working" from "listening but never registered"
@@ -1723,7 +1776,7 @@ class TestDaemonLifecycle:
                 bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
             ):
                 app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-                with TestClient(app) as client:
+                with TestClient(app, base_url=LOOPBACK_BASE) as client:
                     # Registration is in flight, deterministically not yet
                     # committed (blocked on `release`)
                     assert client.get("/health").json()["registered"] is False
@@ -1816,7 +1869,7 @@ class TestDaemonLifecycle:
             create_bridge_app(config, registration_stop=threading.Event())
 
     def test_app_without_registration_has_inert_lifespan(self, config):
-        with TestClient(create_bridge_app(config)) as client:
+        with TestClient(create_bridge_app(config), base_url=LOOPBACK_BASE) as client:
             payload = client.get("/health").json()
         assert payload["status"] == "ok"
         # No registration state -> no claim either way
@@ -2138,6 +2191,23 @@ class TestBindHost:
     def test_loopback_hook_binds_localhost(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         assert bridge.bind_host(config) == "127.0.0.1"
+
+    def test_loopback_literal_hook_binds_that_literal(self, tmp_path):
+        """The derived bind must be the loopback address the hook URL
+        NAMES, not a hardcoded 127.0.0.1: loopback is all of 127.0.0.0/8
+        plus ::1, so a hook on 127.0.1.1 (Debian's own-hostname address),
+        a 127.0.0.2 alias, or [::1] would otherwise bind an interface the
+        bus can never reach - ECONNREFUSED on every dispatch, with both
+        sides still reading as loopback so every exposure/quadrant/family
+        guard stays silent and /health reports registered:true."""
+        for host, expected in (
+            ("127.0.1.1", "127.0.1.1"),
+            ("127.0.0.2", "127.0.0.2"),
+            ("[::1]", "::1"),
+            ("localhost", "127.0.0.1"),  # no single literal - keep the v4 default
+        ):
+            config = BridgeConfig(wake_dir=tmp_path / "wake", hook_url=f"http://{host}:8082/hook")
+            assert bridge.bind_host(config) == expected, host
 
     def test_reachable_hook_binds_wide(self, tmp_path):
         config = BridgeConfig(

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -92,6 +92,16 @@ def restore_bridge_logger_level():
     bridge.logger.setLevel(level)
 
 
+@pytest.fixture(autouse=True)
+def isolate_lock_dir(monkeypatch, tmp_path):
+    """The hook-URL singleton lock lives in a FIXED dir (DEFAULT_LOCK_DIR)
+    independent of --wake-dir, so tests driving _acquire_singleton_locks or
+    main() would otherwise write into the developer's real
+    ~/.claude/.../bridge-locks and collide on the shared default-hook-URL
+    lock. Point it at a per-test tmp dir."""
+    monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", tmp_path / "bridge-locks")
+
+
 @pytest.fixture
 def config(tmp_path):
     return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
@@ -688,6 +698,22 @@ class TestHookFiltering:
         # A legitimate loopback Host reaches the router's real 405/404
         assert client.get("/hook", headers={"Host": "127.0.0.1"}).status_code == 405
         assert client.get("/nope", headers={"Host": "127.0.0.1"}).status_code == 404
+
+    def test_bind_address_is_an_allowed_host(self, tmp_path):
+        """A monitoring probe addressing the bound interface by IP is
+        ordinary in the pinned non-loopback topology the guide recommends,
+        so the effective bind address is allowlisted - else the probe 421s.
+        A foreign Host is still rejected (the rebound-page Host carries the
+        attacker hostname, never the bound literal)."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            bind="100.100.1.2",
+            hook_url="http://host.tailnet.example:8082/hook",
+            secret="s3cret",
+        )
+        client = TestClient(create_bridge_app(config))
+        assert client.get("/health", headers={"Host": "100.100.1.2"}).status_code == 200
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
 
     def test_oversized_body_rejected(self, client):
         """The body must be read before the HMAC can be checked, so bound
@@ -2596,15 +2622,72 @@ class TestBindHost:
         """The startup sweep can't tell a stale row from a live peer's, so a
         second bridge on the same wake dir must refuse BEFORE it touches the
         bus - otherwise a double-start unregisters the running bridge's
-        webhook and leaves it deaf. The flock'd singleton gives the
-        'already running' error; the holder keeps it until its fd closes."""
+        webhook and leaves it deaf. The flock'd singletons give the
+        'already running' error; the holder keeps them until the fds close."""
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         config.wake_dir.mkdir(parents=True)
-        fd = bridge._acquire_singleton_lock(config)
+        fds = bridge._acquire_singleton_locks(config)
         try:
-            with pytest.raises(SystemExit, match="already running"):
-                bridge._acquire_singleton_lock(config)
+            with pytest.raises(SystemExit, match="already"):
+                bridge._acquire_singleton_locks(config)
         finally:
-            os.close(fd)
+            for fd in fds:
+                os.close(fd)
         # Released - a fresh instance acquires cleanly
-        os.close(bridge._acquire_singleton_lock(config))
+        for fd in bridge._acquire_singleton_locks(config):
+            os.close(fd)
+
+    def test_singleton_hook_url_lock_blocks_across_wake_dirs(self, tmp_path):
+        """The destructive sweep contends on the HOOK URL, not the wake dir:
+        a second instance with a DIFFERENT --wake-dir but the same port must
+        still refuse (else it unregisters the running bridge's row and fails
+        EADDRINUSE, deafening it). The hook-URL lock closes that."""
+        a = BridgeConfig(wake_dir=tmp_path / "a")  # both default hook URL
+        b = BridgeConfig(wake_dir=tmp_path / "b")
+        a.wake_dir.mkdir(parents=True)
+        b.wake_dir.mkdir(parents=True)
+        fds = bridge._acquire_singleton_locks(a)
+        try:
+            # Different wake dir, same hook URL -> the hook-URL lock refuses
+            with pytest.raises(SystemExit, match="hook URL"):
+                bridge._acquire_singleton_locks(b)
+        finally:
+            for fd in fds:
+                os.close(fd)
+        # A genuinely distinct hook URL coexists
+        c = BridgeConfig(wake_dir=tmp_path / "c", hook_url="http://127.0.0.1:9099/hook", secret="s")
+        c.wake_dir.mkdir(parents=True)
+        fds_a = bridge._acquire_singleton_locks(a)
+        fds_c = bridge._acquire_singleton_locks(c)
+        for fd in (*fds_a, *fds_c):
+            os.close(fd)
+
+    def test_main_refuses_and_never_sweeps_when_singleton_held(self, monkeypatch, tmp_path):
+        """Pins the acquisition AND its ordering: with the lock already held,
+        main() must SystemExit before uvicorn.run runs the lifespan (the
+        destructive sweep). So neither uvicorn.run nor register_with_bus may
+        be called. Deleting the _acquire call, or moving it after
+        uvicorn.run, fails this."""
+        import sys
+
+        import uvicorn
+
+        wake = tmp_path / "wake"
+        config = BridgeConfig(wake_dir=wake)
+        # Injector creates the wake dir; do it up front so the held lock and
+        # main()'s lock target the same file
+        Injector(config)
+        held = bridge._acquire_singleton_locks(config)
+        ran = []
+        try:
+            monkeypatch.setattr(sys, "argv", ["agent-event-bus-bridge", "--wake-dir", str(wake)])
+            with patch.object(uvicorn, "run", lambda *a, **k: ran.append("uvicorn")):
+                with patch.object(
+                    bridge, "register_with_bus", lambda cfg: ran.append("register") or 1
+                ):
+                    with pytest.raises(SystemExit, match="already"):
+                        bridge.main()
+        finally:
+            for fd in held:
+                os.close(fd)
+        assert ran == []  # neither the bind nor the sweep ran

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -383,6 +383,36 @@ class TestInjectorCooldown:
         # Nothing was written while the lock was contended
         assert not (config.wake_dir / "t.jsonl").exists()
 
+    def test_stuck_drainer_does_not_stall_other_sessions(self, config, monkeypatch):
+        """Pins the invariant that _spool runs OUTSIDE the global injector
+        lock: one session's stuck drainer (holding its flock) must not block
+        deliveries for other sessions. Under the pre-fix ordering, session
+        b's delivery would block behind a's full lock deadline."""
+        monkeypatch.setattr(bridge, "SPOOL_LOCK_ATTEMPTS", 100)
+        monkeypatch.setattr(bridge, "SPOOL_LOCK_RETRY_SECONDS", 0.05)  # 5s deadline
+        injector = Injector(config)
+        a_lock = config.wake_dir / "a.lock"
+        a_result: list = []
+
+        with a_lock.open("a") as held:
+            fcntl.flock(held, fcntl.LOCK_EX)  # a's drainer is stuck
+            blocked = threading.Thread(
+                target=lambda: a_result.append(injector.deliver("a", make_event()))
+            )
+            try:
+                blocked.start()
+                start = time.monotonic()
+                assert injector.deliver("b", make_event()) == "spool"
+                elapsed = time.monotonic() - start
+                # b must complete while a is still parked on its flock -
+                # well under a's 5s deadline
+                assert elapsed < 1.0
+            finally:
+                fcntl.flock(held, fcntl.LOCK_UN)
+        blocked.join(timeout=10.0)
+        assert not blocked.is_alive()
+        assert a_result == ["spool"]  # a completes once its lock frees
+
     def test_wake_dir_is_private(self, config):
         Injector(config).deliver("target-1", make_event())
         assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
@@ -581,6 +611,21 @@ class TestBusRegistration:
 
         with patch.object(bridge, "call_tool", fake_call_tool):
             assert bridge.register_with_bus(config) == 5
+
+    def test_non_list_webhook_listing_is_retryable(self, tmp_path):
+        """A bus that answers but can't list webhooks must not skip the
+        stale-URL dedupe and register anyway - that stacks the duplicate
+        deliveries the sweep exists to prevent. Retry instead."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            if tool_name == "list_webhooks":
+                return {}  # answered, but not a list
+            return {"webhook_id": 5}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            with pytest.raises(SystemExit, match="list_webhooks"):
+                bridge.register_with_bus(config)
 
     def test_registration_retries_on_unexpected_errors(self, tmp_path):
         """Any surprise inside register_with_bus must degrade to

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -2,6 +2,7 @@
 
 import fcntl
 import json
+import os
 import threading
 import time
 from unittest.mock import patch
@@ -378,6 +379,21 @@ class TestHookFiltering:
         # backend's terminal must show more than the registration line, so
         # pin the INFO line carrying the event id like the warnings around it
         assert any("Spooled event 1" in r.message for r in caplog.records)
+
+    def test_spool_and_lock_files_created_0o600(self, config):
+        """Spool lines carry full publisher-authored payloads, and the wake
+        dir's 0o700 is the only other guard - one --wake-dir at a shared
+        pre-existing path, or one later manual chmod (the documented prune
+        and drain workflows invite it), and umask-mode files are world-
+        readable. The create mode must be explicit, not inherited."""
+        old_umask = os.umask(0o000)  # widest case: a plain open would land 0o666
+        try:
+            Injector(config).deliver("target-1", make_event())
+        finally:
+            os.umask(old_umask)
+        for name in ("target-1.jsonl", "target-1.lock"):
+            mode = (config.wake_dir / name).stat().st_mode & 0o777
+            assert mode == 0o600, (name, oct(mode))
 
     def test_health(self, client):
         assert client.get("/health").json()["status"] == "ok"
@@ -1504,6 +1520,20 @@ class TestDaemonLifecycle:
         # around app assembly must be able to catch it
         with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
             create_bridge_app(config)
+
+    def test_assume_exposed_requires_secret(self, tmp_path):
+        """The exposure check derives from config.bind, and on the embedding
+        paths this module documents (uvicorn --factory --host, an ASGI
+        mount) the HOSTING server owns the real bind - the config's None
+        reads as loopback, so a wide-open unauthenticated listener would
+        validate clean. assume_exposed is the embedder's opt-in to the same
+        hard refusal the CLI gives a wide --bind, and its error must name
+        that lever, not claim a loopback bind is reachable off-box."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", assume_exposed=True)
+        with pytest.raises(bridge.BridgeConfigError, match="assume_exposed"):
+            create_bridge_app(config)
+        config.secret = "s3cret"
+        create_bridge_app(config)  # the secret satisfies the requirement
 
     def test_hand_built_config_types_are_coerced_or_named(self, tmp_path):
         """An embedder passing raw env strings must get the named config

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -51,6 +51,11 @@ BRIDGE_ENV = (
     "AGENT_EVENT_BUS_BRIDGE_HOOK_URL",
     "AGENT_EVENT_BUS_BRIDGE_BIND",
     "AGENT_EVENT_BUS_WAKE_DIR",
+    # Not AGENT_EVENT_BUS_*-prefixed, but main() honours it as THE debug
+    # switch and CLAUDE.md tells developers to export it - exactly the
+    # people who run this suite. An inherited DEBUG level would flip any
+    # test asserting a debug line is absent (or make caplog noisier).
+    "DEV_MODE",
 )
 
 
@@ -880,6 +885,29 @@ class TestTmuxBackend:
         assert len(warnings()) == 3
         assert "not a pane id" in warnings()[0].message
 
+    def test_nul_pane_value_degrades_to_spool_not_valueerror(self, tmp_path, caplog):
+        """A pane value carrying an embedded NUL (JSON encodes it as
+        \\u0000) is a non-empty str, so a type-and-truthiness guard alone
+        admits it to the send-keys argv - where subprocess.run raises
+        ValueError BEFORE check or timeout, a class _tmux_wake's post-spool
+        arms don't catch. The escape would 500 the webhook with the cooldown
+        reservation already taken and the rollback skipped: the bus retries
+        an already-spooled event while the session sits in a cooldown for a
+        wake that never happened. The isprintable() guard must instead route
+        it into the bad-pane-value arm - warning names the entry to repair -
+        and the value must never reach argv."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        (config.wake_dir / "panes.json").write_text(json.dumps({"target-1": "%0\x00"}))
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.subprocess, "run") as mock_run:
+                assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+        mock_run.assert_not_called()
+        assert any("not a pane id" in r.message for r in caplog.records)
+
     def test_bad_pane_value_bound_survives_interleaved_sessions(self, tmp_path, caplog):
         """The guard must be keyed per CONDITION, not per last delivery: on
         a multi-machine bus the unmapped arm is the documented NORMAL
@@ -905,6 +933,57 @@ class TestTmuxBackend:
                     injector.deliver("other-session", make_event())  # absent - normal
                     assert injector.deliver("target-2", make_event()) == "tmux"  # healthy
         assert len(warnings()) == 1  # neither absent nor healthy reads re-armed it
+
+    def test_warn_key_caps_bound_both_sets(self, tmp_path, caplog, monkeypatch):
+        """The round-47 retention caps are load-bearing: without a pin a
+        refactor could delete the clear, flip the comparison, or clear the
+        WRONG set (the two sit a screen apart under different locking).
+        Cap at 2, drive three distinct conditions per set, assert the bound
+        holds and the first condition warns again after the clear."""
+        import logging
+
+        monkeypatch.setattr(bridge, "_WARN_KEYS_CAP", 2)
+
+        def warnings(text):
+            return [r for r in caplog.records if r.levelno == logging.WARNING and text in r.message]
+
+        # Panes set: three sessions with bad values, then the first again
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            panes.write_text(json.dumps({"s1": 0, "s2": 0, "s3": 0}))
+            for sid in ("s1", "s2", "s3"):
+                injector.deliver(sid, make_event())
+            assert len(injector._warned_panes_keys) <= 2  # cap held
+            injector.deliver("s1", make_event())  # cleared at cap - warns again
+        assert len(warnings("not a pane id")) == 4
+
+        # Wake-fail set: three exception types for one session, then the first
+        caplog.clear()
+        injector2, _ = make_tmux_injector(tmp_path / "w2", sessions=("t1",), cooldown=0.0)
+
+        def raiser(exc):
+            def run(cmd, **kwargs):
+                raise exc
+
+            return run
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.subprocess, "run", raiser(PermissionError("a"))):
+                injector2.deliver("t1", make_event())
+            with patch.object(
+                bridge.subprocess, "run", raiser(bridge.subprocess.TimeoutExpired("x", 1))
+            ):
+                injector2.deliver("t1", make_event())
+            with patch.object(
+                bridge.subprocess, "run", raiser(bridge.subprocess.CalledProcessError(1, ["x"]))
+            ):
+                injector2.deliver("t1", make_event())  # third type - cap clears
+            assert len(injector2._warned_wake_fail_keys) <= 2  # cap held
+            with patch.object(bridge.subprocess, "run", raiser(PermissionError("a"))):
+                injector2.deliver("t1", make_event())  # re-warns after clear
+        assert len(warnings("tmux wake failed")) == 4
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
@@ -1907,8 +1986,8 @@ class TestBindHost:
             return None
 
         # The autouse restore_bridge_logger_level fixture undoes the level
-        # main() pins here, for this and every other main()-driving test
-        monkeypatch.delenv("DEV_MODE", raising=False)
+        # main() pins here, for this and every other main()-driving test;
+        # clean_bridge_env guarantees DEV_MODE starts unset for the off half.
         with patch.object(uvicorn, "run", run_quiet):
             bridge.main()
         assert not bridge.logger.isEnabledFor(logging.DEBUG)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -227,6 +227,27 @@ class TestBusTimingContract:
         assert spool_deadline + bridge.TMUX_TIMEOUT < WEBHOOK_TIMEOUT
 
 
+class TestImportHygiene:
+    def test_bridge_import_does_not_pull_in_the_bus_server(self):
+        """server.py is not side-effect-free at module scope: it opens,
+        creates, and MIGRATES the bus database (SQLiteStorage()), attaches
+        the bus's file log handler, and builds the FastMCP app. The bridge
+        is a pure HTTP client of the bus and must never import it - on a
+        client-mode machine that would fabricate a phantom bus DB, and on
+        the bus host it would run migrations against the irreplaceable live
+        DB from a second process. conftest neutralizes all of that under
+        pytest, so this is checked in a clean subprocess."""
+        import subprocess as sp
+        import sys
+
+        code = (
+            "import sys; import agent_event_bus.bridge; "
+            "sys.exit(1 if 'agent_event_bus.server' in sys.modules else 0)"
+        )
+        result = sp.run([sys.executable, "-c", code], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
 class TestHookFiltering:
     def test_session_dm_signal_level_contract(self):
         """The bridge filters on the literal 'actionable' - pin that the bus
@@ -276,10 +297,24 @@ class TestHookFiltering:
         the spool breadcrumb."""
         import logging
 
-        with caplog.at_level(logging.INFO, logger="agent-event-bus-bridge"):
+        def infos():
+            return [
+                r
+                for r in caplog.records
+                if r.levelno == logging.INFO and "no signal_level" in r.message
+            ]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
             resp = client.post("/hook", content=json.dumps(make_event(signal_level=None)).encode())
-        assert resp.json() == {"status": "ignored", "reason": "below actionable"}
-        assert any("no signal_level" in r.message for r in caplog.records)
+            assert resp.json() == {"status": "ignored", "reason": "below actionable"}
+            # Persistent condition, DM-rate volume: repeats demote to debug
+            client.post("/hook", content=json.dumps(make_event(signal_level=None)).encode())
+            assert len(infos()) == 1
+            # A delivery that DOES carry a level (an upgraded bus) re-arms,
+            # so a later downgrade surfaces again instead of staying dark
+            client.post("/hook", content=json.dumps(make_event(signal_level="info")).encode())
+            client.post("/hook", content=json.dumps(make_event(signal_level=None)).encode())
+        assert len(infos()) == 2
         assert not (config.wake_dir / "target-1.jsonl").exists()
 
     def test_untargeted_actionable_ignored(self, client):
@@ -1375,8 +1410,22 @@ class TestDaemonLifecycle:
         an off-box /hook with no authentication is refused at app
         construction, not just at the CLI."""
         config = BridgeConfig(wake_dir=tmp_path / "wake", hook_url="http://box.example:8082/hook")
-        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
+        # BridgeConfigError, not SystemExit: an embedder's `except Exception`
+        # around app assembly must be able to catch it
+        with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
             create_bridge_app(config)
+
+    def test_hand_built_config_types_are_coerced_or_named(self, tmp_path):
+        """An embedder passing raw env strings must get the named config
+        error, not a bare TypeError out of a comparison - validate_config
+        normalizes before checking, so string numbers simply work."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", port="8082", cooldown_seconds="30")
+        create_bridge_app(config)  # coerced, valid
+        assert config.port == 8082
+        assert config.cooldown_seconds == 30.0
+        bad = BridgeConfig(wake_dir=tmp_path / "wake", port="eighty")
+        with pytest.raises(bridge.BridgeConfigError, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
+            create_bridge_app(bad)
 
     def test_half_wired_registration_pair_is_rejected(self, config):
         """Passing only one of registration_state/registration_stop would

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -63,6 +63,17 @@ def clean_bridge_env(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def restore_bridge_logger_level():
+    """main() pins a level on the module logger (the DEV_MODE switch), so
+    any test driving main() end to end would otherwise leak that level into
+    later tests' caplog expectations - records silently dropped with no
+    hint why. Snapshot and restore around every test."""
+    level = bridge.logger.level
+    yield
+    bridge.logger.setLevel(level)
+
+
 @pytest.fixture
 def config(tmp_path):
     return BridgeConfig(wake_dir=tmp_path / "wake", cooldown_seconds=30.0)
@@ -1457,19 +1468,16 @@ class TestBindHost:
         def run_quiet(app, host=None, port=None):
             return None
 
-        try:
-            monkeypatch.delenv("DEV_MODE", raising=False)
-            with patch.object(uvicorn, "run", run_quiet):
-                bridge.main()
-            assert not bridge.logger.isEnabledFor(logging.DEBUG)
-            monkeypatch.setenv("DEV_MODE", "1")
-            with patch.object(uvicorn, "run", run_quiet):
-                bridge.main()
-            assert bridge.logger.isEnabledFor(logging.DEBUG)
-        finally:
-            # main() sets a level on the module logger; don't leak it into
-            # tests that rely on the default NOTSET-inherits-root behavior
-            bridge.logger.setLevel(logging.NOTSET)
+        # The autouse restore_bridge_logger_level fixture undoes the level
+        # main() pins here, for this and every other main()-driving test
+        monkeypatch.delenv("DEV_MODE", raising=False)
+        with patch.object(uvicorn, "run", run_quiet):
+            bridge.main()
+        assert not bridge.logger.isEnabledFor(logging.DEBUG)
+        monkeypatch.setenv("DEV_MODE", "1")
+        with patch.object(uvicorn, "run", run_quiet):
+            bridge.main()
+        assert bridge.logger.isEnabledFor(logging.DEBUG)
 
     def test_main_passes_bind_through_and_unregisters(self, monkeypatch, tmp_path):
         """End-to-end main(): the default local config binds loopback, the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,5 +1,6 @@
 """Tests for the webhook-to-injection bridge (RFC #122 prototype)."""
 
+import fcntl
 import hashlib
 import hmac
 import json
@@ -362,6 +363,26 @@ class TestInjectorCooldown:
         # The cross-process drain lock exists alongside the spool
         assert (config.wake_dir / "t.lock").exists()
 
+    def test_spool_lock_contention_raises_after_deadline(self, config, monkeypatch):
+        """The flock acquire is bounded: a stuck drainer holding the lock
+        must produce an error (nothing is spooled yet, so the bus retry is
+        meaningful) - not park a threadpool worker forever."""
+        monkeypatch.setattr(bridge, "SPOOL_LOCK_ATTEMPTS", 3)
+        monkeypatch.setattr(bridge, "SPOOL_LOCK_RETRY_SECONDS", 0.01)
+        injector = Injector(config)
+        lock_file = config.wake_dir / "t.lock"
+
+        with lock_file.open("a") as held:
+            fcntl.flock(held, fcntl.LOCK_EX)  # a stuck drainer
+            try:
+                with pytest.raises(OSError, match="Could not lock spool"):
+                    injector.deliver("t", make_event())
+            finally:
+                fcntl.flock(held, fcntl.LOCK_UN)
+
+        # Nothing was written while the lock was contended
+        assert not (config.wake_dir / "t.jsonl").exists()
+
     def test_wake_dir_is_private(self, config):
         Injector(config).deliver("target-1", make_event())
         assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
@@ -547,6 +568,39 @@ class TestBusRegistration:
             with pytest.raises(SystemExit, match="no webhook_id"):
                 bridge.register_with_bus(config)
 
+    def test_non_dict_webhook_rows_are_skipped(self, tmp_path):
+        """A malformed list_webhooks element must not AttributeError out of
+        the dedupe loop - that would kill the registration thread with no
+        retry, unlike every other registration failure."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            if tool_name == "list_webhooks":
+                return ["garbage", None, 42]
+            return {"webhook_id": 5}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            assert bridge.register_with_bus(config) == 5
+
+    def test_registration_retries_on_unexpected_errors(self, tmp_path):
+        """Any surprise inside register_with_bus must degrade to
+        backoff-and-retry, not a dead thread and a deaf daemon."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        attempts = []
+
+        def flaky_register(cfg):
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise ValueError("unexpected shape")
+            return 42
+
+        state: dict = {}
+        with patch.object(bridge, "register_with_bus", flaky_register):
+            bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
+
+        assert state["webhook_id"] == 42
+        assert len(attempts) == 2
+
     def test_registration_retry_honors_shutdown(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         stop = threading.Event()
@@ -702,6 +756,14 @@ class TestHookUrlTopology:
         loopback, silently skipping the topology guard."""
         monkeypatch.setenv("AGENT_EVENT_BUS_URL", "bus.example:8080/mcp")
         with pytest.raises(SystemExit, match="http"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_hostless_bus_url_is_refused(self, monkeypatch):
+        """http:///mcp has a valid scheme but hostname None, which would
+        read as a *local* bus, skip the topology guard, and leave the
+        registration thread retrying an unroutable URL forever."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_URL", "http:///mcp")
+        with pytest.raises(SystemExit, match="bus URL"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
 
     def test_schemeless_hook_url_is_refused(self, monkeypatch):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -666,6 +666,29 @@ class TestHookFiltering:
         for body in (b"123", b'["x"]', b'"bare"', b"null"):
             assert client.post("/hook", content=body).status_code == 400
 
+    def test_nan_infinity_literals_rejected(self, client):
+        """json.loads accepts NaN/Infinity/-Infinity by default and
+        json.dumps writes them straight back, producing a spool line no
+        other parser (jq, JSON.parse, Go) accepts - a silently-lost wake. A
+        parse_constant rejector folds them into the named 400."""
+        for body in (b'{"payload": NaN}', b'{"payload": Infinity}', b'{"x": -Infinity}'):
+            assert client.post("/hook", content=body).status_code == 400, body
+
+    def test_host_guard_precedes_routing(self, config):
+        """The Host allowlist runs in middleware, ahead of the router, so a
+        method or path mismatch cannot confirm a bridge is here: a foreign
+        Host gets 421 even on GET /hook (else 405) and an unknown path
+        (else 404). A loopback Host still sees the router's real codes."""
+        client = TestClient(create_bridge_app(config))  # Host: testserver
+        assert client.get("/hook", headers={"Host": "evil.example"}).status_code == 421
+        assert client.get("/nope", headers={"Host": "evil.example"}).status_code == 421
+        assert (
+            client.request("HEAD", "/health", headers={"Host": "evil.example"}).status_code == 421
+        )
+        # A legitimate loopback Host reaches the router's real 405/404
+        assert client.get("/hook", headers={"Host": "127.0.0.1"}).status_code == 405
+        assert client.get("/nope", headers={"Host": "127.0.0.1"}).status_code == 404
+
     def test_oversized_body_rejected(self, client):
         """The body must be read before the HMAC can be checked, so bound
         what an unauthenticated peer can make the bridge buffer."""
@@ -1880,11 +1903,10 @@ class TestDaemonLifecycle:
         assert unregistered == [77]
 
     def test_lifespan_is_reentrant(self, tmp_path):
-        """A second lifespan cycle on the same app must register again: the
-        first shutdown set() the stop event, and without clearing it on
-        startup the second cycle binds, serves /health, and never registers
-        - the silent shape the pair check exists to prevent, reached
-        through the embedding surface the docstring advertises."""
+        """A second lifespan cycle on the same app must register again.
+        Each cycle gets its own fresh stop event (see
+        test_each_cycle_gets_its_own_stop_event), so re-entry naturally
+        starts a new registration rather than resuming a stopped one."""
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         registrations = []
         unregistered: list = []
@@ -1906,6 +1928,35 @@ class TestDaemonLifecycle:
                     pass
         assert len(registrations) == 2
         assert unregistered == [41, 42]
+
+    def test_each_cycle_gets_its_own_stop_event(self, tmp_path):
+        """Regression for the resurrect-a-stale-thread bug: each cycle must
+        hand register_with_retry a FRESH stop event, never the shared caller
+        event. The old design cleared ONE shared event on re-entry, which
+        could un-set the event a prior cycle's thread (parked past the join
+        timeout) still waited on - resurrecting it into a second
+        registration that races state['webhook_id']."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        stops_seen: list = []
+
+        def fake_retry(cfg, state, stop):
+            stops_seen.append(stop)
+            state["webhook_id"] = 41 + len(stops_seen)
+
+        caller_stop = threading.Event()
+        state: dict = {}
+        with patch.object(bridge, "register_with_retry", fake_retry):
+            with patch.object(bridge, "unregister_from_bus", lambda cfg, wid: None):
+                app = create_bridge_app(
+                    config, registration_state=state, registration_stop=caller_stop
+                )
+                with TestClient(app):
+                    pass
+                with TestClient(app):
+                    pass
+        assert len(stops_seen) == 2
+        assert stops_seen[0] is not stops_seen[1]  # a fresh event per cycle
+        assert caller_stop not in stops_seen  # never the shared caller event
 
     def test_create_bridge_app_validates_hand_built_configs(self, tmp_path):
         """Embedders skip argparse, so the invariants - including the
@@ -1956,6 +2007,10 @@ class TestDaemonLifecycle:
             ({"bus_url": 123}, "AGENT_EVENT_BUS_URL"),
             ({"hook_url": tmp_path}, "AGENT_EVENT_BUS_BRIDGE_HOOK_URL"),
             ({"bind": 123, "secret": "s"}, "AGENT_EVENT_BUS_BRIDGE_BIND"),
+            # a bytes secret is truthy (satisfies the exposure requirement)
+            # and then fails at RUNTIME - register_with_bus' json= raises
+            # TypeError, verify_signature's .encode() AttributeErrors
+            ({"secret": b"s3cret"}, "AGENT_EVENT_BUS_BRIDGE_SECRET"),
         ):
             bad_str = BridgeConfig(wake_dir=tmp_path / "wake", **kwargs)
             with pytest.raises(bridge.BridgeConfigError, match=env):
@@ -2536,3 +2591,20 @@ class TestBindHost:
         assert seen["host"] == "127.0.0.1"
         assert seen["port"] == bridge.DEFAULT_BRIDGE_PORT
         assert unregistered == [99]
+
+    def test_singleton_lock_blocks_a_second_instance(self, tmp_path):
+        """The startup sweep can't tell a stale row from a live peer's, so a
+        second bridge on the same wake dir must refuse BEFORE it touches the
+        bus - otherwise a double-start unregisters the running bridge's
+        webhook and leaves it deaf. The flock'd singleton gives the
+        'already running' error; the holder keeps it until its fd closes."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        config.wake_dir.mkdir(parents=True)
+        fd = bridge._acquire_singleton_lock(config)
+        try:
+            with pytest.raises(SystemExit, match="already running"):
+                bridge._acquire_singleton_lock(config)
+        finally:
+            os.close(fd)
+        # Released - a fresh instance acquires cleanly
+        os.close(bridge._acquire_singleton_lock(config))

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -433,6 +433,54 @@ class TestHookFiltering:
         # bus retries behind it.
         assert client.post("/hook", content=b"[" * 300_000).status_code == 400
 
+    def test_isdigit_but_not_int_content_length_does_not_500(self, config):
+        """The precheck guards int() with a digit test - and it must be
+        isdecimal(), not isdigit(): U+00B2 (superscript two) is isdigit()
+        True but int() ValueError, and it is exactly latin-1 byte 0xB2,
+        the encoding Starlette decodes headers in. h11 rejects it for the
+        CLI, so this drives the ASGI app directly the way a mounting app
+        (the advertised embedding surface) that passed the header through
+        would - it must fall to the streamed count, not 500."""
+        import asyncio
+
+        app = create_bridge_app(config)
+        body = json.dumps(make_event()).encode()
+        # Raw ASGI headers are bytes; Starlette decodes them latin-1, so
+        # b"\xb2" surfaces as "\xb2" - isdigit() True, int() ValueError
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "path": "/hook",
+            "raw_path": b"/hook",
+            "query_string": b"",
+            "headers": [
+                (b"host", b"127.0.0.1:8082"),
+                (b"content-type", b"application/json"),
+                (b"content-length", b"\xb2"),
+            ],
+        }
+
+        async def drive():
+            sent = []
+            chunks = [
+                {"type": "http.request", "body": body, "more_body": False},
+            ]
+
+            async def receive():
+                return chunks.pop(0)
+
+            async def send(message):
+                sent.append(message)
+
+            await app(scope, receive, send)
+            return sent
+
+        sent = asyncio.run(drive())
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 200  # fell through the precheck, delivered
+        assert (config.wake_dir / "target-1.jsonl").exists()
+
     def test_browser_shaped_post_is_rejected(self, config):
         """The loopback-needs-no-secret posture holds only if a browser
         cannot reach the handler: fetch(mode:"no-cors") from any web page
@@ -976,6 +1024,33 @@ class TestTmuxBackend:
             with patch.object(bridge.subprocess, "run") as mock_run:
                 assert injector.deliver("target-1", make_event()) == "spool-unmapped"
             mock_run.assert_not_called()
+
+    def test_panes_json_is_read_as_utf8_not_locale_codec(self, tmp_path, monkeypatch):
+        """read_text() with no encoding uses the locale codec, which a
+        supervisor-launched daemon (launchd/systemd hand no LANG) resolves
+        to ASCII - a HEALTHY panes.json with any byte >0x7f would then
+        UnicodeDecodeError and wrongly route into the 'unparseable' arm,
+        leaving every session on the box permanently spool-unmapped. The
+        C-locale failure can't be reproduced under this suite's UTF-8
+        locale, so pin the contract directly: the read must ask for utf-8.
+        A non-ASCII decoy value round-trips to prove the parse is real."""
+        injector, config = make_tmux_injector(tmp_path)
+        (config.wake_dir / "panes.json").write_text(
+            json.dumps({"target-1": "%0", "_note": "café"}), encoding="utf-8"
+        )
+        seen = {}
+        real_read_text = bridge.Path.read_text
+
+        def capture(self, *args, **kwargs):
+            if self.name == "panes.json":
+                seen["encoding"] = kwargs.get("encoding")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(bridge.Path, "read_text", capture)
+        with patch.object(bridge.subprocess, "run", tmux_ok):
+            # The non-ASCII decoy parses and the real pane id is used
+            assert injector.deliver("target-1", make_event()) == "tmux"
+        assert seen["encoding"] == "utf-8"
 
     def test_persistent_panes_failure_warns_once(self, tmp_path, caplog):
         """A stuck-broken panes.json must not emit one WARNING per DM - and

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -460,6 +460,17 @@ class TestInjectorCooldown:
         Injector(config).deliver("target-1", make_event())
         assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
 
+    def test_unpreparable_wake_dir_is_a_named_config_error(self, tmp_path):
+        """mkdir/chmod are the one startup filesystem precondition - they
+        must surface as a named SystemExit like every other config input,
+        not a bare traceback. (Parent is a FILE, not an unwritable dir:
+        NotADirectoryError fires for root too, unlike PermissionError.)"""
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("")
+        config = BridgeConfig(wake_dir=blocker / "wake")
+        with pytest.raises(SystemExit, match="--wake-dir / AGENT_EVENT_BUS_WAKE_DIR"):
+            Injector(config)
+
 
 class TestTmuxBackend:
     def test_mapped_pane_gets_send_keys(self, tmp_path):
@@ -963,6 +974,17 @@ class TestHookUrlTopology:
         with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert any("9090" in r.message and "8082" in r.message for r in caplog.records)
+
+    def test_hook_path_mismatch_warns(self, monkeypatch, caplog):
+        """POST /hook is the only route served - any other advertised path
+        404s every dispatch, so it must be named like the port mismatch."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.local:8082/webhook")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert any("/webhook" in r.message and "/hook" in r.message for r in caplog.records)
 
     def test_registration_advertises_hook_url_override(self, tmp_path):
         config = BridgeConfig(

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -554,6 +554,20 @@ class TestInjectorCooldown:
         assert not blocked.is_alive()
         assert a_result == ["spool"]  # a completes once its lock frees
 
+    def test_wake_dir_removed_at_runtime_self_heals(self, config):
+        """Hand-clearing the wake dir is the documented interim workflow
+        while pruning is a follow-up - a delivery after an rm -rf must
+        recreate it (privately) and spool, not 500 on every event until
+        someone restarts the bridge."""
+        import shutil
+
+        injector = Injector(config)
+        injector.deliver("target-1", make_event())
+        shutil.rmtree(config.wake_dir)
+        assert injector.deliver("target-1", make_event()) == "spool"
+        assert (config.wake_dir / "target-1.jsonl").exists()
+        assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
+
     def test_wake_dir_is_private(self, config):
         Injector(config).deliver("target-1", make_event())
         assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
@@ -639,6 +653,39 @@ class TestTmuxBackend:
 
         with patch.object(bridge.subprocess, "run", tmux_perm):
             assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
+
+    def test_persistent_tmux_failure_warns_once(self, tmp_path, caplog):
+        """A missing or broken tmux binary fails every wake with the same
+        exception type forever - the last unbounded per-DM WARNING for a
+        stuck local condition. First sighting warns, same-type repeats are
+        debug, a different failure type warns fresh, and a successful wake
+        re-arms the guard."""
+        import logging
+
+        injector, _ = make_tmux_injector(tmp_path, cooldown=0.0)
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(
+                bridge.subprocess, "run", side_effect=PermissionError("tmux not executable")
+            ):
+                injector.deliver("target-1", make_event())
+                injector.deliver("target-1", make_event())
+            assert len(warnings()) == 1  # same-type repeat was debug
+            with patch.object(
+                bridge.subprocess,
+                "run",
+                side_effect=bridge.subprocess.CalledProcessError(1, ["tmux"]),
+            ):
+                injector.deliver("target-1", make_event())  # new type - warns
+            assert len(warnings()) == 2
+            with patch.object(bridge.subprocess, "run", tmux_ok):
+                assert injector.deliver("target-1", make_event()) == "tmux"  # re-arms
+            with patch.object(bridge.subprocess, "run", side_effect=PermissionError("again")):
+                injector.deliver("target-1", make_event())
+        assert len(warnings()) == 3
 
     def test_malformed_panes_json_degrades_to_spool(self, tmp_path):
         """panes.json is maintained by an external component - every failure
@@ -1254,8 +1301,20 @@ class TestEnvValidation:
 
     def test_env_backend_tmux_is_accepted(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_BACKEND", "tmux")
+        # The preflight consults the real PATH; this test is about env
+        # parsing, not about tmux being installed on the test box
+        monkeypatch.setattr(bridge.shutil, "which", lambda _: "/usr/bin/tmux")
         config = bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert config.backend == "tmux"
+
+    def test_tmux_backend_without_binary_is_refused(self, monkeypatch):
+        """A tmux backend on a box without tmux would degrade every wake to
+        spool-tmux-failed for the daemon's lifetime - one named startup
+        error beats discovering it per-DM."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_BACKEND", "tmux")
+        monkeypatch.setattr(bridge.shutil, "which", lambda _: None)
+        with pytest.raises(SystemExit, match="tmux binary"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
 
     def test_empty_backend_and_bus_url_env_fall_back_to_defaults(self, monkeypatch):
         """The last two env vars without the `or DEFAULT` normalization: an

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -224,16 +224,22 @@ class TestInjectorCooldown:
         with patch.object(bridge.subprocess, "run", slow_tmux):
             for t in threads:
                 t.start()
-            # Wait until one thread is parked inside tmux and the other has
-            # already returned (proving they overlapped), then release
+            # Wait until one thread is parked inside tmux AND the other has
+            # already returned - release is still unset, so this is asserted
+            # overlap, not a lucky serialization (under the pre-fix code both
+            # threads would be parked in tmux here and results stays empty)
             for _ in range(500):
                 if wakes and results:
                     break
                 time.sleep(0.01)
+            overlapped = bool(wakes) and bool(results) and not release.is_set()
+            snapshot = list(results)
             release.set()
             for t in threads:
                 t.join()
 
+        assert overlapped, f"deliveries never overlapped (wakes={len(wakes)}, results={results})"
+        assert snapshot == ["spool-cooldown"]
         assert sorted(results) == ["spool-cooldown", "tmux"]
         assert len(wakes) == 1
 
@@ -441,3 +447,78 @@ class TestBusRegistration:
 
         with patch.object(bridge, "call_tool", fake_call_tool):
             bridge.unregister_from_bus(config, 42)  # must not raise
+
+
+class TestDaemonLifecycle:
+    """The lifespan owns registration: startup must actually fire the thread
+    (a wiring failure is silent - the daemon binds, serves /health, and never
+    registers), and shutdown must join it before the caller reads the id."""
+
+    def test_lifespan_starts_registration_and_joins_on_shutdown(self, tmp_path):
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        registered = threading.Event()
+
+        def fake_register(cfg):
+            registered.set()
+            return 42
+
+        state: dict = {}
+        stop = threading.Event()
+        with patch.object(bridge, "register_with_bus", fake_register):
+            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+            with TestClient(app):
+                assert registered.wait(timeout=5), "startup never fired registration"
+        # Shutdown stopped and joined the thread, so the result is visible
+        assert state["webhook_id"] == 42
+        assert stop.is_set()
+
+    def test_shutdown_waits_for_inflight_registration(self, tmp_path):
+        """stop can't interrupt a register call already inside its HTTP POST;
+        shutdown must join so the committed webhook_id isn't lost (and can be
+        unregistered) on a clean exit."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        entered = threading.Event()
+
+        def slow_register(cfg):
+            entered.set()
+            time.sleep(0.2)
+            return 43
+
+        state: dict = {}
+        stop = threading.Event()
+        with patch.object(bridge, "register_with_bus", slow_register):
+            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+            with TestClient(app):
+                assert entered.wait(timeout=5)  # registration is in flight
+            # Context exit runs lifespan shutdown while slow_register sleeps
+        assert state["webhook_id"] == 43
+
+    def test_app_without_registration_has_inert_lifespan(self, config):
+        with TestClient(create_bridge_app(config)) as client:
+            assert client.get("/health").status_code == 200
+
+
+class TestEnvValidation:
+    """argparse `choices` and `type` only run for command-line values, so
+    env-supplied defaults need their own validation - a typo must be a named
+    config error, not a silent spool-only bridge or a bare traceback."""
+
+    def test_env_backend_typo_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_BACKEND", "tmuxx")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_BACKEND"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_env_backend_tmux_is_accepted(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_BACKEND", "tmux")
+        config = bridge.config_from_args(bridge.build_parser().parse_args([]))
+        assert config.backend == "tmux"
+
+    def test_env_port_typo_is_a_config_error(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "eight")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
+            bridge.build_parser()
+
+    def test_env_cooldown_typo_is_a_config_error(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "30s")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_COOLDOWN"):
+            bridge.build_parser()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -715,6 +715,21 @@ class TestHookFiltering:
         assert client.get("/health", headers={"Host": "100.100.1.2"}).status_code == 200
         assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
 
+    def test_ipv6_bind_address_normalized_in_allowlist(self, tmp_path):
+        """The bind address is stored NORMALIZED (str(ip_address)), so an
+        uppercase or expanded IPv6 --bind still matches the lowercase,
+        compressed Host a probe sends - the tailnet case the bind-address
+        allowlisting exists for (a raw-string compare would 421 it)."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            bind="FD7A:115C:A1E0::1",  # uppercase; a probe sends lowercase
+            hook_url="http://host.tailnet.example:8082/hook",
+            secret="s3cret",
+        )
+        client = TestClient(create_bridge_app(config))
+        for host in ("[fd7a:115c:a1e0::1]:8082", "[fd7a:115c:a1e0::1]"):
+            assert client.get("/health", headers={"Host": host}).status_code == 200, host
+
     def test_oversized_body_rejected(self, client):
         """The body must be read before the HMAC can be checked, so bound
         what an unauthenticated peer can make the bridge buffer."""
@@ -2684,6 +2699,31 @@ class TestBindHost:
         fresh = BridgeConfig(wake_dir=tmp_path / "w2", hook_url=clash_url, secret="s")
         for fd in bridge._acquire_singleton_locks(fresh):
             os.close(fd)
+
+    def test_lock_dir_symlink_is_refused(self, tmp_path, monkeypatch):
+        """The hook-lock dir sits at a guessable path under a possibly-shared
+        temp dir, so it is create-and-verified, not adopted: a symlink
+        planted there fails closed with a named SystemExit (lstat, not stat),
+        never chmod'd or written through."""
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        link = tmp_path / "planted-lockdir"
+        link.symlink_to(victim)
+        monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", link)
+        with pytest.raises(SystemExit, match="not a directory"):
+            bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "wake"))
+        assert not list(victim.iterdir())  # nothing written through the link
+
+    def test_lock_dir_group_accessible_is_refused(self, tmp_path, monkeypatch):
+        """A pre-planted lock dir we own but that is group/world-accessible
+        must be refused, not silently used - the same posture as the wake
+        dir's 0o700."""
+        loose = tmp_path / "loose"
+        loose.mkdir()
+        os.chmod(loose, 0o777)  # mkdir mode is umask-masked; force it wide
+        monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", loose)
+        with pytest.raises(SystemExit, match="group/world-accessible"):
+            bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "wake"))
 
     def test_main_refuses_and_never_sweeps_when_singleton_held(self, monkeypatch, tmp_path):
         """Pins the acquisition AND its ordering: with the lock already held,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -170,6 +170,18 @@ class TestHookFiltering:
         big = b'{"payload": "' + b"x" * (2 * 1024 * 1024) + b'"}'
         assert client.post("/hook", content=big).status_code == 413
 
+    def test_oversized_chunked_body_rejected(self, client):
+        """The post-read check is the half an attacker actually hits: a
+        chunked body carries no content-length to precheck. (The body is
+        still buffered once before the 413 - acknowledged residual.)"""
+
+        def chunks():
+            yield b'{"payload": "'
+            yield b"x" * (2 * 1024 * 1024)
+            yield b'"}'
+
+        assert client.post("/hook", content=chunks()).status_code == 413
+
     def test_actionable_dm_delivered_to_spool(self, client, config):
         resp = client.post("/hook", content=json.dumps(make_event()).encode())
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -593,6 +593,30 @@ class TestTmuxBackend:
                 assert injector.deliver("target-1", make_event()) == "spool-unmapped"
             mock_run.assert_not_called()
 
+    def test_persistent_panes_failure_warns_once(self, tmp_path, caplog):
+        """A stuck-broken panes.json must not emit one WARNING per DM (same
+        unbounded-volume shape as the unsafe-channel warning): first
+        sighting warns, repeats are debug, and a healthy read re-arms."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
+        injector = Injector(config)
+        panes = config.wake_dir / "panes.json"
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            panes.write_text("[]")  # not an object
+            injector.deliver("target-1", make_event())
+            injector.deliver("target-1", make_event())
+            assert len(warnings()) == 1  # the repeat was debug
+            panes.write_text("{}")  # healthy read re-arms the guard
+            injector.deliver("target-1", make_event())
+            panes.write_text("[]")  # breaks again - warns again
+            injector.deliver("target-1", make_event())
+        assert len(warnings()) == 2
+
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
         injector = Injector(config)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -159,6 +159,22 @@ class TestPathSafety:
         assert not (config.wake_dir.parent / "escape.jsonl").exists()
 
 
+class TestBusTimingContract:
+    def test_internal_deadlines_leave_headroom_under_bus_webhook_timeout(self):
+        """The bus's per-attempt clock (WEBHOOK_TIMEOUT) starts before the
+        bridge's, so a bridge-side bound at or above it guarantees the bus
+        times out and retries instead of ever seeing the bounded response
+        (500 for a stuck spool lock, 200 for a failed tmux wake). Pin the
+        headroom - including the sum, since one request can hit lock
+        contention AND a slow tmux."""
+        from agent_event_bus.server import WEBHOOK_TIMEOUT
+
+        spool_deadline = bridge.SPOOL_LOCK_ATTEMPTS * bridge.SPOOL_LOCK_RETRY_SECONDS
+        assert spool_deadline < WEBHOOK_TIMEOUT
+        assert bridge.TMUX_TIMEOUT < WEBHOOK_TIMEOUT
+        assert spool_deadline + bridge.TMUX_TIMEOUT < WEBHOOK_TIMEOUT
+
+
 class TestHookFiltering:
     def test_session_dm_signal_level_contract(self):
         """The bridge filters on the literal 'actionable' - pin that the bus
@@ -552,6 +568,25 @@ class TestBusRegistration:
         # v1 only acts on DMs, so the bus drops broadcast traffic server-side
         assert register["arguments"]["channel"] == "session:"
         assert register["url"] == "http://bus/mcp"
+
+    def test_unregister_calls_unregister_webhook_with_id_and_url(self, tmp_path):
+        """Pin the wire call unregister_from_bus makes (tool name, id, bus
+        URL) - a wrong argument here only ever surfaces as a stale row that
+        the next startup sweep silently reclaims, so no other test would
+        catch it."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
+        calls = []
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
+            return {"success": True}
+
+        with patch.object(bridge, "call_tool", fake_call_tool):
+            bridge.unregister_from_bus(config, 42)
+
+        assert calls == [
+            {"tool": "unregister_webhook", "arguments": {"webhook_id": 42}, "url": "http://bus/mcp"}
+        ]
 
     def test_startup_removes_stale_webhooks_at_same_url(self, tmp_path):
         """Unclean exits leave active webhooks behind; each would duplicate

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -2662,6 +2662,29 @@ class TestBindHost:
         for fd in (*fds_a, *fds_c):
             os.close(fd)
 
+    def test_partial_acquisition_does_not_leak_the_first_lock(self, tmp_path):
+        """Sequential acquisition must close an already-held lock when a
+        later one refuses: an instance sharing a wake dir but with a
+        DISTINCT hook URL takes the hook lock, then refuses on the wake lock
+        - the hook fd must be released, or in-process a later legitimate
+        start on that URL 421s against a bridge that is not running."""
+        clash_url = "http://127.0.0.1:9191/hook"
+        held = bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "w1"))
+        try:
+            # Same wake dir as the holder, distinct hook URL: the hook lock
+            # acquires, then the wake lock refuses -> the hook fd must not leak
+            clash = BridgeConfig(wake_dir=tmp_path / "w1", hook_url=clash_url, secret="s")
+            with pytest.raises(SystemExit, match="wake dir"):
+                bridge._acquire_singleton_locks(clash)
+        finally:
+            for fd in held:
+                os.close(fd)
+        # If the hook fd leaked, this same-URL start (free wake dir) would
+        # spuriously refuse; it must acquire cleanly
+        fresh = BridgeConfig(wake_dir=tmp_path / "w2", hook_url=clash_url, secret="s")
+        for fd in bridge._acquire_singleton_locks(fresh):
+            os.close(fd)
+
     def test_main_refuses_and_never_sweeps_when_singleton_held(self, monkeypatch, tmp_path):
         """Pins the acquisition AND its ordering: with the lock already held,
         main() must SystemExit before uvicorn.run runs the lifespan (the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,8 +1,6 @@
 """Tests for the webhook-to-injection bridge (RFC #122 prototype)."""
 
 import fcntl
-import hashlib
-import hmac
 import json
 import threading
 import time
@@ -19,10 +17,14 @@ from agent_event_bus.bridge import (
     resolve_target_session,
     verify_signature,
 )
+from agent_event_bus.server import _compute_signature
 
 
 def sign(body: bytes, secret: str) -> str:
-    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    # Built from the BUS's signing function, not a local copy: these are
+    # contract tests, and a bus-side change to the canonical form must
+    # fail them rather than leave real deliveries 401ing silently
+    return "sha256=" + _compute_signature(body, secret)
 
 
 def make_event(**overrides) -> dict:
@@ -827,6 +829,16 @@ class TestHookUrlTopology:
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_HOOK_URL"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
 
+    def test_malformed_hook_port_is_refused(self, monkeypatch):
+        """A hook URL port outside 0-65535 raises ValueError out of
+        SplitResult.port - it must surface as a named config error, not a
+        bare traceback. Secret set so the exposure refusal doesn't fire
+        first (box.example is a non-loopback hook host)."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http://box.example:99999/hook")
+        with pytest.raises(SystemExit, match="bad port"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
     def test_out_of_range_port_is_refused(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "99999")
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
@@ -924,10 +936,19 @@ class TestBindHost:
             with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
                 bridge.config_from_args(args)
 
-    def test_non_loopback_bind_with_secret_is_accepted(self, monkeypatch):
+    def test_non_loopback_bind_with_secret_is_accepted(self, monkeypatch, caplog):
+        """Accepted - but this is also the fourth quadrant (wide bind,
+        loopback hook URL): the bus POSTs to 127.0.0.1 where nothing
+        listens, so the warning must actually fire."""
+        import logging
+
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
-        config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "0.0.0.0"]))
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            config = bridge.config_from_args(
+                bridge.build_parser().parse_args(["--bind", "0.0.0.0"])
+            )
         assert bridge.bind_host(config) == "0.0.0.0"
+        assert any("0.0.0.0" in r.message and "127.0.0.1" in r.message for r in caplog.records)
 
     def test_loopback_bind_is_accepted_without_secret(self):
         config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "127.0.0.1"]))

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1164,6 +1164,16 @@ class TestDaemonLifecycle:
                     assert client.get("/health").json()["registered"] is True
         assert unregistered == [77]
 
+    def test_half_wired_registration_pair_is_rejected(self, config):
+        """Passing only one of registration_state/registration_stop would
+        bind and serve /health but never register - silently, with
+        registered:false forever. A partial pair is unambiguously a
+        programming error in an embedding, so it raises."""
+        with pytest.raises(ValueError, match="pair"):
+            create_bridge_app(config, registration_state={})
+        with pytest.raises(ValueError, match="pair"):
+            create_bridge_app(config, registration_stop=threading.Event())
+
     def test_app_without_registration_has_inert_lifespan(self, config):
         with TestClient(create_bridge_app(config)) as client:
             payload = client.get("/health").json()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -198,6 +198,10 @@ class TestHookFiltering:
 
     def test_invalid_json_rejected(self, client):
         assert client.post("/hook", content=b"not-json{").status_code == 400
+        # json.loads(bytes) DECODES before parsing: invalid UTF-8 raises
+        # UnicodeDecodeError (a ValueError, not JSONDecodeError) and must
+        # be a 400 too, not a 500 with bus retries behind it
+        assert client.post("/hook", content=b"\x80abc").status_code == 400
 
     def test_non_object_json_rejected(self, client):
         """Valid JSON that isn't an object must be a 400, not an
@@ -885,6 +889,14 @@ class TestHookUrlTopology:
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "-5")
         with pytest.raises(SystemExit, match="COOLDOWN"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_non_finite_cooldown_is_refused(self, monkeypatch):
+        """nan never prunes-compares True (cooldown never engages); inf
+        never prunes at all (one wake ever, then silence)."""
+        for value in ("nan", "inf"):
+            monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", value)
+            with pytest.raises(SystemExit, match="COOLDOWN"):
+                bridge.config_from_args(bridge.build_parser().parse_args([]))
 
     def test_empty_wake_dir_env_falls_back_to_default(self, monkeypatch):
         """An empty env var would make Path('') == cwd - the bridge would

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -337,13 +337,20 @@ class TestInjectorCooldown:
     """The cooldown bounds successful injections only - spool writes are
     durable bookkeeping, and failed wakes must not burn the window."""
 
-    def test_second_wake_within_cooldown_spools_only(self, tmp_path):
+    def test_second_wake_within_cooldown_spools_only(self, tmp_path, caplog):
+        import logging
+
         injector, config = make_tmux_injector(tmp_path)
 
-        with patch.object(bridge.subprocess, "run", tmux_ok):
-            assert injector.deliver("target-1", make_event()) == "tmux"
-            assert injector.deliver("target-1", make_event()) == "spool-cooldown"
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.subprocess, "run", tmux_ok):
+                assert injector.deliver("target-1", make_event()) == "tmux"
+                assert injector.deliver("target-1", make_event()) == "spool-cooldown"
 
+        # The one deliberately-suppressed arm still names itself under
+        # DEV_MODE - the only case where the bridge chose not to wake a
+        # session it could have
+        assert any("Cooldown active" in r.message for r in caplog.records)
         # Both events were spooled - cooldown bounds wakes, not durability
         lines = (config.wake_dir / "target-1.jsonl").read_text().splitlines()
         assert len(lines) == 2
@@ -616,9 +623,12 @@ class TestTmuxBackend:
             mock_run.assert_not_called()
 
     def test_persistent_panes_failure_warns_once(self, tmp_path, caplog):
-        """A stuck-broken panes.json must not emit one WARNING per DM (same
-        unbounded-volume shape as the unsafe-channel warning): first
-        sighting warns, repeats are debug, and a healthy read re-arms."""
+        """A stuck-broken panes.json must not emit one WARNING per DM - and
+        the guard must key on the REASON, not the message: a torn
+        non-atomic write yields a different parse position on every read,
+        so message-keyed dedupe would warn per delivery (the value-keyed
+        defect in local-file form). First sighting warns, repeats are
+        debug, a healthy read re-arms."""
         import logging
 
         config = BridgeConfig(wake_dir=tmp_path / "wake", backend="tmux")
@@ -629,13 +639,16 @@ class TestTmuxBackend:
             return [r for r in caplog.records if r.levelno == logging.WARNING]
 
         with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
-            panes.write_text("[]")  # not an object
+            # Same reason, VARYING exception text (the torn-writer shape:
+            # a different parse position per read) - still one warning
+            panes.write_bytes(b"{broken")
             injector.deliver("target-1", make_event())
+            panes.write_bytes(b"[1, 2,")
             injector.deliver("target-1", make_event())
-            assert len(warnings()) == 1  # the repeat was debug
+            assert len(warnings()) == 1  # the varying repeat was debug
             panes.write_text("{}")  # healthy read re-arms the guard
             injector.deliver("target-1", make_event())
-            panes.write_text("[]")  # breaks again - warns again
+            panes.write_text("[]")  # breaks again (new reason) - warns
             injector.deliver("target-1", make_event())
         assert len(warnings()) == 2
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -160,6 +160,27 @@ class TestPathSafety:
 
 
 class TestHookFiltering:
+    def test_session_dm_signal_level_contract(self):
+        """The bridge filters on the literal 'actionable' - pin that the bus
+        really derives that level for session: DMs, the same way sign()
+        builds on the bus's _compute_signature. If the bus stopped making
+        DMs actionable, every bridge filter test would otherwise stay green
+        while the bridge woke nobody."""
+        from datetime import datetime
+
+        from agent_event_bus.server import _get_signal_level
+        from agent_event_bus.storage import Event as BusEvent
+
+        dm = BusEvent(
+            id=1,
+            event_type="note",
+            payload="hi",
+            session_id="sender-1",
+            timestamp=datetime(2026, 8, 8),
+            channel="session:target-1",
+        )
+        assert _get_signal_level(dm) == "actionable"
+
     def test_below_actionable_ignored(self, client, config):
         for level in ("lifecycle", "info"):
             resp = client.post("/hook", content=json.dumps(make_event(signal_level=level)).encode())
@@ -744,14 +765,16 @@ class TestEnvValidation:
         assert config.backend == "tmux"
 
     def test_env_port_typo_is_a_config_error(self, monkeypatch):
+        """Named error at CONFIG time - parser-build must stay clean so
+        --help keeps working under a typo'd env var."""
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "eight")
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
-            bridge.build_parser()
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
 
     def test_env_cooldown_typo_is_a_config_error(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_COOLDOWN", "30s")
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_COOLDOWN"):
-            bridge.build_parser()
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
 
 
 class TestHookUrlTopology:
@@ -841,6 +864,18 @@ class TestHookUrlTopology:
 
     def test_out_of_range_port_is_refused(self, monkeypatch):
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "99999")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_bad_numeric_env_does_not_break_help(self, monkeypatch, capsys):
+        """A typo'd numeric env var must fail at CONFIG time with a named
+        error - not at parser-build time, which would break --help, the
+        first thing an operator reaches for when the daemon won't start."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_PORT", "eighty")
+        with pytest.raises(SystemExit) as exc:
+            bridge.build_parser().parse_args(["--help"])
+        assert exc.value.code == 0  # help printed cleanly
+        assert "--port" in capsys.readouterr().out
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_PORT"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -94,11 +94,12 @@ def restore_bridge_logger_level():
 
 @pytest.fixture(autouse=True)
 def isolate_lock_dir(monkeypatch, tmp_path):
-    """The hook-URL singleton lock lives in a FIXED dir (DEFAULT_LOCK_DIR)
-    independent of --wake-dir, so tests driving _acquire_singleton_locks or
-    main() would otherwise write into the developer's real
-    ~/.claude/.../bridge-locks and collide on the shared default-hook-URL
-    lock. Point it at a per-test tmp dir."""
+    """The hook-URL singleton lock lives in a FIXED dir (DEFAULT_LOCK_DIR:
+    $XDG_RUNTIME_DIR, else tempfile.gettempdir(), plus /agent-event-bus-
+    bridge-<uid>) independent of --wake-dir, so tests driving
+    _acquire_singleton_locks or main() would otherwise write into the
+    developer's real runtime/temp lock dir and collide on the shared
+    default-hook-URL lock. Point it at a per-test tmp dir."""
     monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", tmp_path / "bridge-locks")
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -64,6 +64,18 @@ def clean_bridge_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def reset_unsafe_warn_state():
+    """The unsafe-id rate limit is deliberately process-wide module state
+    (resolve_target_session runs before any Injector exists), so any test
+    driving that arm leaves a real monotonic reading behind - a later test
+    asserting the WARNING would then pass or fail on 60s of wall clock and
+    run ordering, with no hint why. Reset it around every test."""
+    bridge._unsafe_warn_state["last"] = -float("inf")
+    yield
+    bridge._unsafe_warn_state["last"] = -float("inf")
+
+
+@pytest.fixture(autouse=True)
 def restore_bridge_logger_level():
     """main() pins a level on the module logger (the DEV_MODE switch), so
     any test driving main() end to end would otherwise leak that level into
@@ -398,7 +410,11 @@ class TestInjectorCooldown:
 
         def slow_tmux(cmd, **kwargs):
             wakes.append(cmd)
-            release.wait(timeout=5)
+            # Unbounded on purpose: the poll loop below is the failure
+            # detector, and a timeout here would let a slow second thread
+            # turn the snapshot assertions into a confusing wrong-thread
+            # failure. release.set() runs unconditionally before the joins.
+            release.wait()
 
             class Result:
                 returncode = 0
@@ -699,12 +715,32 @@ class TestTmuxBackend:
             return [r for r in caplog.records if r.levelno == logging.WARNING]
 
         with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
-            for bad in (0, "", None):
+            # null FIRST: .get() can't tell null from absent, so ordering
+            # null last would let a .get()-based implementation pass on the
+            # other two values' warnings. null is also the likeliest real
+            # misconfiguration (TMUX_PANE unset -> panes[sid] = null).
+            for bad in (None, 0, ""):
                 panes.write_text(json.dumps({"target-1": bad}))
                 with patch.object(bridge.subprocess, "run") as mock_run:
                     assert injector.deliver("target-1", make_event()) == "spool-unmapped"
                 mock_run.assert_not_called()
-        assert len(warnings()) == 1  # same reason across values - repeats debug
+            assert len(warnings()) == 1  # same reason across values - repeats debug
+            # Per-shape, not aggregate: the two repeats were DEMOTED (seen,
+            # logged at debug), not skipped - an aggregate count can't tell
+            # those apart
+            demoted = [
+                r
+                for r in caplog.records
+                if r.levelno == logging.DEBUG and "not a pane id" in r.message
+            ]
+            assert len(demoted) == 2
+            # A genuinely ABSENT key is the healthy shape and re-arms; a bad
+            # value must not - so bad -> absent -> bad warns twice
+            panes.write_text(json.dumps({"other-session": "%1"}))
+            injector.deliver("target-1", make_event())
+            panes.write_text(json.dumps({"target-1": None}))
+            injector.deliver("target-1", make_event())
+        assert len(warnings()) == 2
         assert "not a pane id" in warnings()[0].message
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -164,6 +164,12 @@ class TestHookFiltering:
         for body in (b"123", b'["x"]', b'"bare"', b"null"):
             assert client.post("/hook", content=body).status_code == 400
 
+    def test_oversized_body_rejected(self, client):
+        """The body must be read before the HMAC can be checked, so bound
+        what an unauthenticated peer can make the bridge buffer."""
+        big = b'{"payload": "' + b"x" * (2 * 1024 * 1024) + b'"}'
+        assert client.post("/hook", content=big).status_code == 413
+
     def test_actionable_dm_delivered_to_spool(self, client, config):
         resp = client.post("/hook", content=json.dumps(make_event()).encode())
 
@@ -749,6 +755,46 @@ class TestBindHost:
             bind="100.100.1.2",
         )
         assert bridge.bind_host(config) == "100.100.1.2"
+
+    def test_non_loopback_bind_without_secret_is_refused(self, monkeypatch):
+        """--bind decides exposure before the hook URL does: a wide bind
+        with the default local bus must not open an unsigned /hook off-box
+        (the round-6 refusal, reachable through the round-7 flag)."""
+        for bind in ("0.0.0.0", "100.100.1.2"):
+            args = bridge.build_parser().parse_args(["--bind", bind])
+            with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
+                bridge.config_from_args(args)
+
+    def test_non_loopback_bind_with_secret_is_accepted(self, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "0.0.0.0"]))
+        assert bridge.bind_host(config) == "0.0.0.0"
+
+    def test_loopback_bind_is_accepted_without_secret(self):
+        config = bridge.config_from_args(bridge.build_parser().parse_args(["--bind", "127.0.0.1"]))
+        assert bridge.bind_host(config) == "127.0.0.1"
+
+    def test_invalid_bind_is_refused(self):
+        args = bridge.build_parser().parse_args(["--bind", "localhost:8082"])
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_BIND"):
+            bridge.config_from_args(args)
+
+    def test_loopback_bind_under_reachable_hook_warns(self, monkeypatch, caplog):
+        """The inverse mismatch is silent inertness (the bus's POSTs are
+        refused at the TCP level) - legitimate behind a same-box TLS
+        terminator, so a named warning, not a refusal."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        args = bridge.build_parser().parse_args(
+            ["--bind", "127.0.0.1", "--hook-url", "http://laptop.tailnet.example:8082/hook"]
+        )
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(args)
+        assert any(
+            "laptop.tailnet.example" in r.message and "127.0.0.1" in r.message
+            for r in caplog.records
+        )
 
     def test_main_passes_bind_through_and_unregisters(self, monkeypatch, tmp_path):
         """End-to-end main(): the default local config binds loopback, the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1272,14 +1272,43 @@ class TestTmuxBackend:
         mock_run.assert_not_called()
 
     def test_fifo_panes_json_does_not_hang(self, tmp_path):
-        """A planted FIFO must not park the delivery worker forever (this
-        path has no TMUX_TIMEOUT). O_NONBLOCK makes the read return promptly;
-        the delivery degrades to spool instead of hanging."""
+        """A planted FIFO with NO writer must not park the delivery worker
+        forever (this path has no TMUX_TIMEOUT). O_NONBLOCK makes the read
+        return EOF promptly; the delivery degrades to spool, not a hang."""
         injector, config = make_tmux_injector(tmp_path)
         (config.wake_dir / "panes.json").unlink()
         os.mkfifo(config.wake_dir / "panes.json")  # no writer -> would block
         with patch.object(bridge.subprocess, "run") as mock_run:
-            # Returns (does not hang); the empty/blocking read degrades
+            assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+        mock_run.assert_not_called()
+
+    def test_fifo_panes_json_with_writer_degrades_not_500(self, tmp_path):
+        """A FIFO with a writer attached and nothing buffered makes the text
+        read return None -> TypeError, which is NOT an OSError. It must still
+        degrade to spool (the never-500 contract), not escape _tmux_pane -
+        an escape would 500 an already-spooled delivery and the bus would
+        retry it, duplicating lines."""
+        injector, config = make_tmux_injector(tmp_path)
+        fifo = config.wake_dir / "panes.json"
+        fifo.unlink()
+        os.mkfifo(fifo)
+        writer = os.open(fifo, os.O_RDWR | os.O_NONBLOCK)  # hold a writer, write nothing
+        try:
+            with patch.object(bridge.subprocess, "run") as mock_run:
+                assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+            mock_run.assert_not_called()
+        finally:
+            os.close(writer)
+
+    def test_oversized_panes_json_degrades_to_spool(self, tmp_path, monkeypatch):
+        """The read is bounded (MAX_PANES_BYTES), so a runaway file can't pull
+        unbounded bytes into memory per DM; the truncated read is invalid
+        JSON and degrades to spool."""
+        monkeypatch.setattr(bridge, "MAX_PANES_BYTES", 64)
+        injector, config = make_tmux_injector(tmp_path)
+        big = {"target-1": "%0", "_pad": "x" * 500}  # valid, but past the cap
+        (config.wake_dir / "panes.json").write_text(json.dumps(big), encoding="utf-8")
+        with patch.object(bridge.subprocess, "run") as mock_run:
             assert injector.deliver("target-1", make_event()) == "spool-unmapped"
         mock_run.assert_not_called()
 
@@ -2769,6 +2798,24 @@ class TestBindHost:
         with pytest.raises(SystemExit, match="not a directory"):
             bridge._acquire_singleton_locks(BridgeConfig(wake_dir=tmp_path / "wake"))
         assert not list(victim.iterdir())  # nothing written through the link
+
+    def test_flock_recreates_vanished_lock_dir_privately(self, tmp_path, monkeypatch):
+        """If the hook-lock dir vanishes between _ensure_private_lock_dir and
+        _flock_or_exit's mkdir, the re-create must be 0o700 - else the NEXT
+        start's verify would refuse our OWN dir as group/world-accessible.
+        Drive that exact sequence and assert the re-created dir still passes
+        the verify (fails if mode=0o700 is dropped, under any umask)."""
+        import shutil
+
+        d = tmp_path / "lockdir"
+        monkeypatch.setattr(bridge, "DEFAULT_LOCK_DIR", d)
+        bridge._ensure_private_lock_dir(d)
+        shutil.rmtree(d)  # simulate the vanish between verify and mkdir
+        fd = bridge._flock_or_exit(d / "hook.x.lock", "conflict")
+        try:
+            bridge._ensure_private_lock_dir(d)  # must NOT raise on our re-created dir
+        finally:
+            os.close(fd)
 
     def test_lock_dir_group_accessible_is_refused(self, tmp_path, monkeypatch):
         """A pre-planted lock dir we own but that is group/world-accessible

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -547,10 +547,11 @@ class TestTmuxBackend:
         with patch.object(bridge.subprocess, "run") as mock_run:
             action = injector.deliver("target-1", make_event())
 
-        # Distinct from plain "spool": the unmapped-pane arm logs only at
-        # debug, so the action field is the one in-band signal separating a
-        # broken tmux setup from the spool backend's normal path
-        assert action == "spool-tmux-failed"
+        # Distinct from "spool" AND from "spool-tmux-failed": unmapped is
+        # the normal outcome for a foreign-machine session (webhooks have no
+        # machine scoping), so it must not read as a broken tmux setup - and
+        # it logs only at debug, so the action field is the in-band signal
+        assert action == "spool-unmapped"
         mock_run.assert_not_called()
 
     def test_tmux_failure_falls_back_to_spool(self, tmp_path):
@@ -589,7 +590,7 @@ class TestTmuxBackend:
         for content in (b'["not", "an", "object"]', b'"bare string"', b"null", b"\xff\xfe{}"):
             panes.write_bytes(content)
             with patch.object(bridge.subprocess, "run") as mock_run:
-                assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
+                assert injector.deliver("target-1", make_event()) == "spool-unmapped"
             mock_run.assert_not_called()
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
@@ -598,7 +599,7 @@ class TestTmuxBackend:
         (config.wake_dir / "panes.json").mkdir()  # IsADirectoryError on read
 
         with patch.object(bridge.subprocess, "run") as mock_run:
-            assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
+            assert injector.deliver("target-1", make_event()) == "spool-unmapped"
         mock_run.assert_not_called()
 
 
@@ -1126,6 +1127,37 @@ class TestHookUrlTopology:
         with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
         assert any("9090" in r.message and "8082" in r.message for r in caplog.records)
+
+    def test_hook_url_without_port_warns_on_scheme_default_mismatch(self, monkeypatch, caplog):
+        """A missing port is not 'no opinion' - the bus POSTs to the scheme
+        default (80/443), so a forgotten :8082 is exactly the mismatch the
+        warning names, and skipping it left the likeliest typo silent."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        for url, default in (
+            ("http://box.local/hook", "80"),
+            ("https://box.local/hook", "443"),
+        ):
+            caplog.clear()
+            monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", url)
+            with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+                bridge.config_from_args(bridge.build_parser().parse_args([]))
+            assert any(
+                f"advertises port {default} " in r.message and "8082" in r.message
+                for r in caplog.records
+            )
+
+    def test_hook_url_scheme_default_matching_port_is_quiet(self, monkeypatch, caplog):
+        """https behind a TLS terminator with --port 443 is the legitimate
+        shape - the substituted default must not warn when it matches."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "https://box.local/hook")
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(bridge.build_parser().parse_args(["--port", "443"]))
+        assert not any("advertises port" in r.message for r in caplog.records)
 
     def test_hook_path_mismatch_warns(self, monkeypatch, caplog):
         """POST /hook is the only route served - any other advertised path

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -143,6 +143,31 @@ class TestPathSafety:
         ):
             assert resolve_target_session(make_event(channel=channel)) is None
 
+    def test_unsafe_id_warning_is_bounded_per_channel(self, caplog, monkeypatch):
+        """The rejection arm is publisher-drivable, so a repeated garbage
+        channel must not write one WARNING per event: first sighting warns,
+        repeats are debug, and the dedup set clears at its cap so warnings
+        resume instead of the set growing without bound."""
+        import logging
+
+        monkeypatch.setattr(bridge, "_warned_unsafe_channels", set())
+        monkeypatch.setattr(bridge, "_WARNED_UNSAFE_CHANNELS_CAP", 2)
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            assert resolve_target_session(make_event(channel="session:a/b")) is None
+            assert resolve_target_session(make_event(channel="session:a/b")) is None
+            assert len(warnings()) == 1  # the repeat was debug, not warning
+            assert "session:a/b" in warnings()[0].message
+            # Two more distinct channels reach the cap and clear the set...
+            assert resolve_target_session(make_event(channel="session:c/d")) is None
+            assert resolve_target_session(make_event(channel="session:e/f")) is None
+            # ...so the first channel warns again instead of staying dark
+            assert resolve_target_session(make_event(channel="session:a/b")) is None
+        assert len(warnings()) == 4
+
     def test_traversal_channel_is_ignored_and_writes_nothing(self, client, config, tmp_path):
         evil = make_event(channel="session:../../escape")
         resp = client.post("/hook", content=json.dumps(evil).encode())
@@ -245,9 +270,10 @@ class TestHookFiltering:
         assert client.post("/hook", content=big).status_code == 413
 
     def test_oversized_chunked_body_rejected(self, client):
-        """The post-read check is the half an attacker actually hits: a
-        chunked body carries no content-length to precheck. (The body is
-        still buffered once before the 413 - acknowledged residual.)"""
+        """The streamed count is the half an attacker actually hits: a
+        chunked body carries no content-length to precheck, and the bound
+        must hold WHILE reading - the 413 fires mid-stream, not after an
+        unbounded buffer."""
 
         def chunks():
             yield b'{"payload": "'
@@ -374,7 +400,7 @@ class TestInjectorCooldown:
             raise bridge.subprocess.CalledProcessError(1, cmd)
 
         with patch.object(bridge.subprocess, "run", tmux_fail):
-            assert injector.deliver("target-1", make_event()) == "spool"
+            assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
 
         with patch.object(bridge.subprocess, "run", tmux_ok):
             assert injector.deliver("target-1", make_event()) == "tmux"
@@ -506,7 +532,11 @@ class TestTmuxBackend:
             action = injector.deliver("target-1", make_event())
 
         assert action == "tmux"
-        assert commands[0][:4] == ["tmux", "send-keys", "-t", "%7"]
+        # Full argv, not a prefix: WAKE_PROMPT as ONE argument without -l,
+        # then Enter - dropping the Enter (or switching to -l without a
+        # separate Enter send) would type the prompt and never submit it,
+        # a wake that wakes nobody while everything else stays green
+        assert commands[0] == ["tmux", "send-keys", "-t", "%7", bridge.WAKE_PROMPT, "Enter"]
         # The event is also spooled (durable path is unconditional)
         assert (config.wake_dir / "target-1.jsonl").exists()
 
@@ -517,7 +547,10 @@ class TestTmuxBackend:
         with patch.object(bridge.subprocess, "run") as mock_run:
             action = injector.deliver("target-1", make_event())
 
-        assert action == "spool"
+        # Distinct from plain "spool": the unmapped-pane arm logs only at
+        # debug, so the action field is the one in-band signal separating a
+        # broken tmux setup from the spool backend's normal path
+        assert action == "spool-tmux-failed"
         mock_run.assert_not_called()
 
     def test_tmux_failure_falls_back_to_spool(self, tmp_path):
@@ -532,7 +565,7 @@ class TestTmuxBackend:
         with patch.object(bridge.subprocess, "run", fake_run):
             action = injector.deliver("target-1", make_event())
 
-        assert action == "spool"
+        assert action == "spool-tmux-failed"
 
     def test_tmux_oserror_falls_back_to_spool(self, tmp_path):
         """A non-executable tmux binary (PermissionError) must degrade to
@@ -544,7 +577,7 @@ class TestTmuxBackend:
             raise PermissionError("tmux not executable")
 
         with patch.object(bridge.subprocess, "run", tmux_perm):
-            assert injector.deliver("target-1", make_event()) == "spool"
+            assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
 
     def test_malformed_panes_json_degrades_to_spool(self, tmp_path):
         """panes.json is maintained by an external component - every failure
@@ -556,7 +589,7 @@ class TestTmuxBackend:
         for content in (b'["not", "an", "object"]', b'"bare string"', b"null", b"\xff\xfe{}"):
             panes.write_bytes(content)
             with patch.object(bridge.subprocess, "run") as mock_run:
-                assert injector.deliver("target-1", make_event()) == "spool"
+                assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
             mock_run.assert_not_called()
 
     def test_unreadable_panes_json_degrades_to_spool(self, tmp_path):
@@ -565,7 +598,7 @@ class TestTmuxBackend:
         (config.wake_dir / "panes.json").mkdir()  # IsADirectoryError on read
 
         with patch.object(bridge.subprocess, "run") as mock_run:
-            assert injector.deliver("target-1", make_event()) == "spool"
+            assert injector.deliver("target-1", make_event()) == "spool-tmux-failed"
         mock_run.assert_not_called()
 
 
@@ -804,13 +837,16 @@ class TestBusRegistration:
 
 
 class TestDaemonLifecycle:
-    """The lifespan owns registration: startup must actually fire the thread
-    (a wiring failure is silent - the daemon binds, serves /health, and never
-    registers), and shutdown must join it before the caller reads the id."""
+    """The lifespan owns registration end to end: startup must actually fire
+    the thread (a wiring failure is silent - the daemon binds, serves /health,
+    and never registers), and shutdown must join it, then unregister the
+    committed id itself and pop it - main()'s finally is belt-and-braces
+    only, for exits that skip the lifespan."""
 
     def test_lifespan_starts_registration_and_joins_on_shutdown(self, tmp_path):
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         registered = threading.Event()
+        unregistered: list = []
 
         def fake_register(cfg):
             registered.set()
@@ -819,18 +855,24 @@ class TestDaemonLifecycle:
         state: dict = {}
         stop = threading.Event()
         with patch.object(bridge, "register_with_bus", fake_register):
-            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-            with TestClient(app) as client:
-                assert registered.wait(timeout=5), "startup never fired registration"
-                # /health surfaces the registration outcome - the one signal
-                # that separates "working" from "listening but never registered"
-                for _ in range(500):
-                    if client.get("/health").json().get("registered"):
-                        break
-                    time.sleep(0.01)
-                assert client.get("/health").json()["registered"] is True
-        # Shutdown stopped and joined the thread, so the result is visible
-        assert state["webhook_id"] == 42
+            with patch.object(
+                bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+            ):
+                app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+                with TestClient(app) as client:
+                    assert registered.wait(timeout=5), "startup never fired registration"
+                    # /health surfaces the registration outcome - the one signal
+                    # that separates "working" from "listening but never registered"
+                    for _ in range(500):
+                        if client.get("/health").json().get("registered"):
+                            break
+                        time.sleep(0.01)
+                    assert client.get("/health").json()["registered"] is True
+        # Shutdown stopped and joined the thread, then unregistered the
+        # committed id and popped it - the app owns the row end to end, and
+        # a main()-style belt-and-braces finally finds nothing to repeat
+        assert unregistered == [42]
+        assert state.get("webhook_id") is None
         assert stop.is_set()
 
     def test_cancelled_shutdown_still_stops_and_joins(self, tmp_path):
@@ -852,20 +894,28 @@ class TestDaemonLifecycle:
 
         state: dict = {}
         stop = threading.Event()
+        unregistered: list = []
         with patch.object(bridge, "register_with_bus", slow_register):
-            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+            with patch.object(
+                bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+            ):
+                app = create_bridge_app(config, registration_state=state, registration_stop=stop)
 
-            async def scenario():
-                with anyio.CancelScope() as scope:
-                    async with app.router.lifespan_context(app):
-                        scope.cancel()
-                    # exiting the lifespan now tears down under an active
-                    # cancellation - the path uvicorn's forced shutdown takes
+                async def scenario():
+                    with anyio.CancelScope() as scope:
+                        async with app.router.lifespan_context(app):
+                            scope.cancel()
+                        # exiting the lifespan now tears down under an active
+                        # cancellation - the path uvicorn's forced shutdown takes
 
-            anyio.run(scenario)
+                anyio.run(scenario)
 
         assert stop.is_set()
-        assert state["webhook_id"] == 44
+        # The unregister call observing 44 is the proof the join really ran
+        # under cancellation - the id is committed only after slow_register's
+        # sleep, and the lifespan pops it after handing it off
+        assert unregistered == [44]
+        assert state.get("webhook_id") is None
 
     def test_shutdown_waits_for_inflight_registration(self, tmp_path):
         """stop can't interrupt a register call already inside its HTTP POST;
@@ -881,12 +931,17 @@ class TestDaemonLifecycle:
 
         state: dict = {}
         stop = threading.Event()
+        unregistered: list = []
         with patch.object(bridge, "register_with_bus", slow_register):
-            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
-            with TestClient(app):
-                assert entered.wait(timeout=5)  # registration is in flight
-            # Context exit runs lifespan shutdown while slow_register sleeps
-        assert state["webhook_id"] == 43
+            with patch.object(
+                bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+            ):
+                app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+                with TestClient(app):
+                    assert entered.wait(timeout=5)  # registration is in flight
+                # Context exit runs lifespan shutdown while slow_register sleeps
+        # The join observed the in-flight commit, so the unregister got it
+        assert unregistered == [43]
 
     def test_app_without_registration_has_inert_lifespan(self, config):
         with TestClient(create_bridge_app(config)) as client:
@@ -1176,6 +1231,33 @@ class TestBindHost:
             "laptop.tailnet.example" in r.message and "127.0.0.1" in r.message
             for r in caplog.records
         )
+
+    def test_ipv6_hook_with_ipv4_bind_warns(self, monkeypatch, caplog):
+        """0.0.0.0 binds IPv4 only: an IPv6 hook literal with the derived
+        wide bind is refused at TCP while every quadrant warning stays
+        quiet (both sides non-loopback, port and path agreeing), so the
+        address-family mismatch needs its own name."""
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        args = bridge.build_parser().parse_args(
+            ["--hook-url", "http://[fd7a:115c:a1e0::1]:8082/hook"]
+        )
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            config = bridge.config_from_args(args)
+        assert bridge.bind_host(config) == "0.0.0.0"
+        assert any("IPv6" in r.message and "0.0.0.0" in r.message for r in caplog.records)
+
+    def test_ipv6_hook_with_ipv6_bind_is_quiet(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_SECRET", "s3cret")
+        args = bridge.build_parser().parse_args(
+            ["--hook-url", "http://[fd7a:115c:a1e0::1]:8082/hook", "--bind", "::"]
+        )
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            bridge.config_from_args(args)
+        assert not any("IPv6" in r.message for r in caplog.records)
 
     def test_main_passes_bind_through_and_unregisters(self, monkeypatch, tmp_path):
         """End-to-end main(): the default local config binds loopback, the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -593,6 +593,23 @@ class TestBusRegistration:
         assert register["arguments"]["channel"] == "session:"
         assert register["url"] == "http://bus/mcp"
 
+    def test_unregister_unexpected_result_warns_not_asserts(self, tmp_path, caplog):
+        """Shutdown-side twin of the sweep's result check: best-effort, so a
+        bus that answers but doesn't delete is a warning (the next startup
+        sweep reclaims the row) - but the log must not claim 'Unregistered'
+        for a removal that never happened."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            return {}  # a JSON-RPC error response falls through to this
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "call_tool", fake_call_tool):
+                bridge.unregister_from_bus(config, 42)
+        assert any("unexpected result" in r.message for r in caplog.records)
+
     def test_failed_stale_removal_is_retryable(self, tmp_path):
         """unregister_webhook reports logical failure in-band (success-False
         dict; call_tool raises only on transport errors) - a sweep that
@@ -815,6 +832,40 @@ class TestDaemonLifecycle:
         # Shutdown stopped and joined the thread, so the result is visible
         assert state["webhook_id"] == 42
         assert stop.is_set()
+
+    def test_cancelled_shutdown_still_stops_and_joins(self, tmp_path):
+        """TestClient's context exit is always a CLEAN shutdown, so the two
+        subtlest lifespan lines - the try/finally around the yield and the
+        shielded join - are invisible to the tests above. Drive the lifespan
+        directly and tear it down under an active cancellation: without the
+        try/finally the cleanup never runs at all; without the shield,
+        anyio.to_thread.run_sync raises at its own cancellation checkpoint
+        and the join is skipped, so the post-stop commit below is never
+        observed and the webhook row leaks."""
+        import anyio
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+
+        def slow_register(cfg):
+            time.sleep(0.2)  # the commit lands only if shutdown really joins
+            return 44
+
+        state: dict = {}
+        stop = threading.Event()
+        with patch.object(bridge, "register_with_bus", slow_register):
+            app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+
+            async def scenario():
+                with anyio.CancelScope() as scope:
+                    async with app.router.lifespan_context(app):
+                        scope.cancel()
+                    # exiting the lifespan now tears down under an active
+                    # cancellation - the path uvicorn's forced shutdown takes
+
+            anyio.run(scenario)
+
+        assert stop.is_set()
+        assert state["webhook_id"] == 44
 
     def test_shutdown_waits_for_inflight_registration(self, tmp_path):
         """stop can't interrupt a register call already inside its HTTP POST;

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -115,6 +115,12 @@ class TestTargetResolution:
         assert resolve_target_session(make_event(channel=f"session:{uuid}")) == uuid
         assert resolve_target_session(make_event(channel="session:brave_trex-2")) == "brave_trex-2"
 
+    def test_non_string_channel_has_no_target(self):
+        """A non-string channel inside an otherwise valid event must resolve
+        to no target, not raise .startswith into a 500."""
+        for channel in (123, True, ["session:x"], {"c": 1}, None):
+            assert resolve_target_session(make_event(channel=channel)) is None
+
 
 class TestPathSafety:
     """The session id comes verbatim off the wire (the event's channel string,
@@ -159,6 +165,11 @@ class TestHookFiltering:
 
     def test_untargeted_actionable_ignored(self, client):
         resp = client.post("/hook", content=json.dumps(make_event(channel="repo:myrepo")).encode())
+        assert resp.json() == {"status": "ignored", "reason": "no target session"}
+
+    def test_non_string_channel_ignored_not_500(self, client):
+        resp = client.post("/hook", content=json.dumps(make_event(channel=123)).encode())
+        assert resp.status_code == 200
         assert resp.json() == {"status": "ignored", "reason": "no target session"}
 
     def test_invalid_json_rejected(self, client):
@@ -699,6 +710,13 @@ class TestHookUrlTopology:
         and registers a URL the bus can never POST to (silently inert with
         /health reporting registered)."""
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "laptop.example:8082/hook")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_HOOK_URL"):
+            bridge.config_from_args(bridge.build_parser().parse_args([]))
+
+    def test_hostless_hook_url_is_refused(self, monkeypatch):
+        """A scheme with no host (http:///hook) also parses to hostname
+        None - same silent-inertness escape, different malformation."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_HOOK_URL", "http:///hook")
         with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_HOOK_URL"):
             bridge.config_from_args(bridge.build_parser().parse_args([]))
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -607,7 +607,7 @@ class TestInjectorCooldown:
         Injector(config).deliver("target-1", make_event())
         assert (config.wake_dir.stat().st_mode & 0o777) == 0o700
 
-    def test_unpreparable_wake_dir_is_a_named_config_error(self, tmp_path):
+    def test_unpreparable_wake_dir_is_a_named_config_error(self, tmp_path, monkeypatch):
         """mkdir/chmod are the one startup filesystem precondition - they
         must surface as a named SystemExit like every other config input,
         not a bare traceback. (Parent is a FILE, not an unwritable dir:
@@ -615,8 +615,19 @@ class TestInjectorCooldown:
         blocker = tmp_path / "not-a-dir"
         blocker.write_text("")
         config = BridgeConfig(wake_dir=blocker / "wake")
-        with pytest.raises(SystemExit, match="--wake-dir / AGENT_EVENT_BUS_WAKE_DIR"):
+        # BridgeConfigError on the construction path, so an embedder's
+        # `except Exception` around app assembly can catch it
+        with pytest.raises(bridge.BridgeConfigError, match="--wake-dir / AGENT_EVENT_BUS_WAKE_DIR"):
             Injector(config)
+        # The CLI path still gets a clean message-and-exit via main()'s
+        # translation, not a traceback
+        import sys
+
+        monkeypatch.setattr(
+            sys, "argv", ["agent-event-bus-bridge", "--wake-dir", str(blocker / "wake")]
+        )
+        with pytest.raises(SystemExit, match="--wake-dir"):
+            bridge.main()
 
 
 class TestTmuxBackend:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -823,7 +823,15 @@ class TestTmuxBackend:
             injector.deliver("target-1", make_event())
             panes.write_text(json.dumps({"target-1": None}))
             injector.deliver("target-1", make_event())
-        assert len(warnings()) == 2
+            assert len(warnings()) == 2
+            # A missing FILE is this session's absent read too: a full
+            # clean-state cycle (delete, recreate with a bad entry) must
+            # re-arm the warning - the repair-didn't-take signal
+            panes.unlink()
+            injector.deliver("target-1", make_event())
+            panes.write_text(json.dumps({"target-1": 0}))
+            injector.deliver("target-1", make_event())
+        assert len(warnings()) == 3
         assert "not a pane id" in warnings()[0].message
 
     def test_bad_pane_value_bound_survives_interleaved_sessions(self, tmp_path, caplog):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -330,11 +330,11 @@ class TestHookFiltering:
         assert bridge.resolve_target_session(payload) == "target-1"
 
     def test_bus_dispatch_sends_the_media_type_the_hook_requires(self):
-        """Round 54 made Content-Type a hard delivery precondition, which
-        promotes it to a cross-module wire contract - and the client
-        fixture supplies the header itself, so without this pin the bus
-        could drop or change it and every bridge test would stay green
-        while every real delivery 415d with /health still registered:true.
+        """Content-Type is a hard delivery precondition, which promotes it
+        to a cross-module wire contract - and the client fixture supplies
+        the header itself, so without this pin the bus could drop or change
+        it and every bridge test would stay green while every real delivery
+        415d with /health still registered:true.
         Captured off the REAL dispatch path, not asserted from a local
         literal (the constant is single-sourced in helpers.py, but
         single-sourcing can't catch the header being dropped entirely)."""
@@ -677,12 +677,31 @@ class TestHookFiltering:
             assert client.post("/hook", content=body).status_code == 400
 
     def test_nan_infinity_literals_rejected(self, client):
-        """json.loads accepts NaN/Infinity/-Infinity by default and
-        json.dumps writes them straight back, producing a spool line no
-        other parser (jq, JSON.parse, Go) accepts - a silently-lost wake. A
-        parse_constant rejector folds them into the named 400."""
+        """A spooled line must be STANDARD JSON - no NaN/Infinity, which
+        jq/JSON.parse/Go all reject (a drainer skips the line and the wake is
+        silently lost). Two producers turn a body into a non-standard value:
+        the bare NaN/Infinity/-Infinity TOKENS json.loads accepts (caught by
+        parse_constant), and an OVERFLOWING numeric literal (1e400 ->
+        float(inf), which parse_constant never sees - caught at the write
+        side by _spool's allow_nan=False). Both must be a named 400."""
         for body in (b'{"payload": NaN}', b'{"payload": Infinity}', b'{"x": -Infinity}'):
             assert client.post("/hook", content=body).status_code == 400, body
+        # The overflow route needs an ACTIONABLE event so it reaches _spool
+        for value in ("1e400", "-1e400"):
+            body = json.dumps(make_event()).replace('"need a review"', value).encode()
+            assert client.post("/hook", content=body).status_code == 400, value
+
+    def test_spooled_line_round_trips_through_a_strict_parser(self, client, config):
+        """Pin the guarantee on what gets WRITTEN, not only on what's
+        rejected at the door: a delivered event's spool line must parse
+        under a strict parser that rejects the non-standard constants."""
+        assert client.post("/hook", content=json.dumps(make_event()).encode()).status_code == 200
+        line = (config.wake_dir / "target-1.jsonl").read_text().splitlines()[0]
+
+        def strict(literal):
+            raise ValueError(f"non-standard constant {literal!r}")
+
+        assert json.loads(line, parse_constant=strict)["event_id"] == 1
 
     def test_host_guard_precedes_routing(self, config):
         """The Host allowlist runs in middleware, ahead of the router, so a
@@ -727,22 +746,35 @@ class TestHookFiltering:
             secret="s3cret",
         )
         client = TestClient(create_bridge_app(config))
-        for host in ("[fd7a:115c:a1e0::1]:8082", "[fd7a:115c:a1e0::1]"):
+        # BOTH wire spellings must match: normalization happens on both the
+        # stored entry and the incoming Host (in _host_from_header), so the
+        # guard never depends on which spelling the probe/bus renders.
+        for host in (
+            "[fd7a:115c:a1e0::1]:8082",  # compressed
+            "[FD7A:115C:A1E0::1]:8082",  # compressed, upper
+            "[fd7a:115c:a1e0:0:0:0:0:1]:8082",  # expanded
+            "[fd7a:115c:a1e0::1]",  # no port
+        ):
             assert client.get("/health", headers={"Host": host}).status_code == 200, host
 
     def test_ipv6_hook_host_normalized_in_allowlist(self, tmp_path):
-        """Same normalization on the hook side: an EXPANDED IPv6 hook-URL
-        literal must still match the compressed Host a probe (or curl to the
-        hook hostname) sends - urlsplit lowercases but does not compress."""
+        """Same normalization on the hook side, and BOTH directions: an
+        EXPANDED IPv6 hook-URL literal must match a compressed probe Host AND
+        the expanded Host the bus's httpx client may render from the
+        registered URL - _host_from_header normalizes the incoming side too,
+        so the guard doesn't rest on httpx's spelling choice."""
         config = BridgeConfig(
             wake_dir=tmp_path / "wake",
             hook_url="http://[FD7A:115C:A1E0:0:0:0:0:1]:8082/hook",  # expanded
             secret="s3cret",
         )
         client = TestClient(create_bridge_app(config))
-        assert (
-            client.get("/health", headers={"Host": "[fd7a:115c:a1e0::1]:8082"}).status_code == 200
-        )
+        for host in (
+            "[fd7a:115c:a1e0::1]:8082",  # compressed
+            "[fd7a:115c:a1e0:0:0:0:0:1]:8082",  # expanded (as registered)
+            "[FD7A:115C:A1E0:0:0:0:0:1]:8082",  # expanded, upper
+        ):
+            assert client.get("/health", headers={"Host": host}).status_code == 200, host
 
     def test_oversized_body_rejected(self, client):
         """The body must be read before the HMAC can be checked, so bound
@@ -1214,32 +1246,42 @@ class TestTmuxBackend:
                 assert injector.deliver("target-1", make_event()) == "spool-unmapped"
             mock_run.assert_not_called()
 
-    def test_panes_json_is_read_as_utf8_not_locale_codec(self, tmp_path, monkeypatch):
-        """read_text() with no encoding uses the locale codec, which a
-        supervisor-launched daemon (launchd/systemd hand no LANG) resolves
-        to ASCII - a HEALTHY panes.json with any byte >0x7f would then
-        UnicodeDecodeError and wrongly route into the 'unparseable' arm,
-        leaving every session on the box permanently spool-unmapped. The
-        C-locale failure can't be reproduced under this suite's UTF-8
-        locale, so pin the contract directly: the read must ask for utf-8.
-        A non-ASCII decoy value round-trips to prove the parse is real."""
+    def test_panes_json_is_read_as_utf8_not_locale_codec(self, tmp_path):
+        """The read decodes as UTF-8, not the locale codec (a
+        supervisor-launched daemon gets no LANG, so glibc resolves C ->
+        ASCII, and a healthy file with any byte >0x7f would wrongly hit the
+        unparseable arm). A non-ASCII decoy value ('café') round-trips to
+        the tmux wake, which proves the decode is UTF-8: an ASCII codec
+        would UnicodeDecodeError on it and degrade to spool-unmapped."""
         injector, config = make_tmux_injector(tmp_path)
         (config.wake_dir / "panes.json").write_text(
             json.dumps({"target-1": "%0", "_note": "café"}), encoding="utf-8"
         )
-        seen = {}
-        real_read_text = bridge.Path.read_text
-
-        def capture(self, *args, **kwargs):
-            if self.name == "panes.json":
-                seen["encoding"] = kwargs.get("encoding")
-            return real_read_text(self, *args, **kwargs)
-
-        monkeypatch.setattr(bridge.Path, "read_text", capture)
         with patch.object(bridge.subprocess, "run", tmux_ok):
-            # The non-ASCII decoy parses and the real pane id is used
             assert injector.deliver("target-1", make_event()) == "tmux"
-        assert seen["encoding"] == "utf-8"
+
+    def test_symlinked_panes_json_degrades_to_spool(self, tmp_path):
+        """panes.json shares the wake dir's history, so a symlink planted at
+        the name must not be followed (O_NOFOLLOW -> ELOOP -> the unreadable
+        arm), degrading to spool rather than reading a foreign file."""
+        injector, config = make_tmux_injector(tmp_path)
+        (config.wake_dir / "panes.json").unlink()
+        (config.wake_dir / "panes.json").symlink_to(tmp_path / "elsewhere.json")
+        with patch.object(bridge.subprocess, "run") as mock_run:
+            assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+        mock_run.assert_not_called()
+
+    def test_fifo_panes_json_does_not_hang(self, tmp_path):
+        """A planted FIFO must not park the delivery worker forever (this
+        path has no TMUX_TIMEOUT). O_NONBLOCK makes the read return promptly;
+        the delivery degrades to spool instead of hanging."""
+        injector, config = make_tmux_injector(tmp_path)
+        (config.wake_dir / "panes.json").unlink()
+        os.mkfifo(config.wake_dir / "panes.json")  # no writer -> would block
+        with patch.object(bridge.subprocess, "run") as mock_run:
+            # Returns (does not hang); the empty/blocking read degrades
+            assert injector.deliver("target-1", make_event()) == "spool-unmapped"
+        mock_run.assert_not_called()
 
     def test_valid_nondict_read_clears_stale_read_keys(self, tmp_path, caplog):
         """A valid-JSON-but-non-dict read (a list) proves the read AND parse

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -165,7 +165,7 @@ class TestPathSafety:
 
         monkeypatch.setitem(bridge._unsafe_warn_state, "last", -float("inf"))
         clock = {"now": 1000.0}
-        monkeypatch.setattr(bridge.time, "monotonic", lambda: clock["now"])
+        monkeypatch.setattr(bridge, "_now", lambda: clock["now"])
 
         def warnings():
             return [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -254,6 +254,20 @@ class TestHookFiltering:
         for level in ("lifecycle", "info"):
             resp = client.post("/hook", content=json.dumps(make_event(signal_level=level)).encode())
             assert resp.json() == {"status": "ignored", "reason": "below actionable"}
+        assert not (config.wake_dir / "target-1.jsonl").exists()
+
+    def test_missing_signal_level_filtered_loudly(self, client, config, caplog):
+        """A bus predating derived levels (#129) sends no signal_level at
+        all - every delivery lands on this arm forever, so the version skew
+        must be visible at INFO rather than silently filtering 100% of
+        deliveries. The INFO line IS the point of the branch; pin it like
+        the spool breadcrumb."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="agent-event-bus-bridge"):
+            resp = client.post("/hook", content=json.dumps(make_event(signal_level=None)).encode())
+        assert resp.json() == {"status": "ignored", "reason": "below actionable"}
+        assert any("no signal_level" in r.message for r in caplog.records)
         assert not (config.wake_dir / "target-1.jsonl").exists()
 
     def test_untargeted_actionable_ignored(self, client):
@@ -366,7 +380,7 @@ class TestInjectorCooldown:
         injector, _ = make_tmux_injector(tmp_path, cooldown=30.0)
 
         clock = {"now": 1000.0}
-        with patch.object(bridge.time, "monotonic", lambda: clock["now"]):
+        with patch.object(bridge, "_now", lambda: clock["now"]):
             with patch.object(bridge.subprocess, "run", tmux_ok):
                 assert injector.deliver("target-1", make_event()) == "tmux"
                 clock["now"] += 10.0
@@ -446,7 +460,7 @@ class TestInjectorCooldown:
         injector, _ = make_tmux_injector(tmp_path, sessions=("target-1", "target-2"), cooldown=30.0)
 
         clock = {"now": 1000.0}
-        with patch.object(bridge.time, "monotonic", lambda: clock["now"]):
+        with patch.object(bridge, "_now", lambda: clock["now"]):
             with patch.object(bridge.subprocess, "run", tmux_ok):
                 assert injector.deliver("target-1", make_event()) == "tmux"
                 clock["now"] += 35.0

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -687,6 +687,38 @@ class TestTmuxBackend:
                 injector.deliver("target-1", make_event())
         assert len(warnings()) == 3
 
+    def test_wake_failure_bound_is_per_session(self, tmp_path, caplog):
+        """The round-38 panes lesson applies here too: the bound must key
+        per (session, exception type). A second broken session must WARN
+        rather than be demoted behind the first's key, and a healthy
+        session's success must not re-arm a broken one into warn-per-DM."""
+        import logging
+
+        injector, _ = make_tmux_injector(
+            tmp_path, sessions=("target-1", "target-2", "target-3"), cooldown=0.0
+        )
+
+        def warnings():
+            return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+        def broken_panes(cmd, **kwargs):
+            if cmd[3] in {"%0", "%1"}:  # target-1, target-2 have stale panes
+                raise bridge.subprocess.CalledProcessError(1, cmd)
+
+            class Result:
+                returncode = 0
+
+            return Result()
+
+        with caplog.at_level(logging.DEBUG, logger="agent-event-bus-bridge"):
+            with patch.object(bridge.subprocess, "run", broken_panes):
+                injector.deliver("target-1", make_event())  # warns
+                injector.deliver("target-2", make_event())  # different session - warns too
+                assert len(warnings()) == 2
+                assert injector.deliver("target-3", make_event()) == "tmux"  # healthy
+                injector.deliver("target-1", make_event())  # still bounded - debug
+        assert len(warnings()) == 2
+
     def test_malformed_panes_json_degrades_to_spool(self, tmp_path):
         """panes.json is maintained by an external component - every failure
         shape must read as 'unmapped', never escape as a 500."""
@@ -1300,6 +1332,43 @@ class TestDaemonLifecycle:
                         time.sleep(0.01)
                     assert client.get("/health").json()["registered"] is True
         assert unregistered == [77]
+
+    def test_lifespan_is_reentrant(self, tmp_path):
+        """A second lifespan cycle on the same app must register again: the
+        first shutdown set() the stop event, and without clearing it on
+        startup the second cycle binds, serves /health, and never registers
+        - the silent shape the pair check exists to prevent, reached
+        through the embedding surface the docstring advertises."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        registrations = []
+        unregistered: list = []
+
+        def fake_register(cfg):
+            registrations.append(1)
+            return 40 + len(registrations)
+
+        state: dict = {}
+        stop = threading.Event()
+        with patch.object(bridge, "register_with_bus", fake_register):
+            with patch.object(
+                bridge, "unregister_from_bus", lambda cfg, wid: unregistered.append(wid)
+            ):
+                app = create_bridge_app(config, registration_state=state, registration_stop=stop)
+                with TestClient(app):
+                    pass
+                with TestClient(app):
+                    pass
+        assert len(registrations) == 2
+        assert unregistered == [41, 42]
+
+    def test_create_bridge_app_validates_hand_built_configs(self, tmp_path):
+        """Embedders skip argparse, so the invariants - including the
+        exposed-listener secret requirement - must travel with the config:
+        an off-box /hook with no authentication is refused at app
+        construction, not just at the CLI."""
+        config = BridgeConfig(wake_dir=tmp_path / "wake", hook_url="http://box.example:8082/hook")
+        with pytest.raises(SystemExit, match="AGENT_EVENT_BUS_BRIDGE_SECRET"):
+            create_bridge_app(config)
 
     def test_half_wired_registration_pair_is_rejected(self, config):
         """Passing only one of registration_state/registration_stop would


### PR DESCRIPTION
Implements the minimal version of RFC #122: a localhost daemon (`agent-event-bus-bridge`) that finally consumes the bus's dormant push subsystem and closes the pull-only delivery gap — a DM to an idle session now produces a wake-up instead of sitting unread until the next human prompt.

## How it works

1. On startup the bridge registers its own webhook on the bus (`http://127.0.0.1:<port>/hook`), HMAC-signed when `AGENT_EVENT_BUS_BRIDGE_SECRET` is set, and unregisters it on clean shutdown.
2. Incoming events are filtered to **actionable DMs**: the payload's server-derived `signal_level` (from #129/#132) does the level check, and only `session:` channels have an unambiguous wake target. Broadcast actionable events (e.g. `help_needed` on a repo channel) deliberately stay pull-only in v1.
3. Delivery has two backends:
   - **spool** (default): appends the event to `wake/<session_id>.jsonl` for a Stop/UserPromptSubmit hook to drain. This durable path runs unconditionally in every backend — nothing is ever dropped.
   - **tmux**: additionally types a wake prompt into the session's pane via `tmux send-keys`, using the `wake/panes.json` mapping (`{session_id: pane_id}`) that something session-side must maintain; unmapped sessions or tmux failures fall back to spool.
4. A per-session cooldown (default 30s, `--cooldown`) bounds injections for loop prevention; events during cooldown spool instead of waking.

## Design notes

- Answers RFC #122's open questions empirically: loop prevention = cooldown + actionable-DM-only scope; idle detection is deferred (the spool + hook-drain path is idle-safe by construction, and the tmux prompt is harmless mid-turn); the bridge lives in this repo as the natural consumer of the bus.
- Webhook processing runs in worker threads per the request-path invariant from #112; the tmux subprocess is bounded like the notifier subprocesses.
- Loopback bind by default; the topology guards refuse or warn on every silently-inert or exposed misconfiguration the reviews surfaced; HMAC authenticates the bus→bridge hop and is required whenever the listener is reachable off-box.

## Testing

`make check` green: 518 tests. Bridge coverage: HMAC accept/reject, signal-level and target filtering (including version-skew), spool delivery and durability under cooldown, per-session cooldown with TOCTOU reservation, tmux argv shape, unmapped/failed-tmux fallbacks and their per-condition warning bounds, panes.json failure shapes, bus registration/unregistration and the lifespan lifecycle (clean, cancelled, in-flight, re-entrant), config validation on both the CLI and embedding paths, the cross-module contracts (`sign()`, `SIGNATURE_HEADER`, `_get_signal_level`, `get_matching_webhooks`, `call_tool`'s debug seam, `WEBHOOK_TIMEOUT` headroom), and import hygiene (the bridge never imports the bus server module).

## Observed end-to-end run

Beyond the unit suite, the full daemon path was run as real processes in a Linux container (bus and bridge separately, isolated `AGENT_EVENT_BUS_DB` and wake dir, real tmux):

1. `uv run agent-event-bus` (bus on :8080, auth disabled), `tmux new-session -d`, `panes.json` mapping a target id to the live pane, `uv run agent-event-bus-bridge --backend tmux`.
2. `GET /health` on :8082 → `{"status": "ok", "service": "agent-event-bus-bridge", "registered": true}`; bridge log: `Registered bridge webhook #1`.
3. `agent-event-bus-cli publish --type help_needed --channel session:e2e-target-0001 …` produced, within ~100ms:
   - **spool**: `wake/e2e-target-0001.jsonl` gained the event line carrying the server-derived `"signal_level": "actionable"`;
   - **bridge log**: `Woke e2e-targ... via tmux pane %0`;
   - **pane capture**: `Check the event bus - a directed event arrived for this session.` typed **and submitted** — the pane's bash executed it (`Check: command not found`), confirming tmux treated `WAKE_PROMPT` as typed text with the trailing `Enter` (the exact no-`-l` claims the module comment makes) and incidentally demonstrating the documented stale-pane hazard.
4. `SIGTERM` → bridge log `Unregistered bridge webhook #1`; `agent-event-bus-cli webhook list` → `No webhooks registered`.

This covers the two surfaces the suite necessarily mocks: a real uvicorn bind receiving a real bus webhook POST, and real tmux parsing of the send-keys argv.

Companion changes elsewhere: evansenter/dotfiles#328 wires the hooks to #128/#129; agent-event-bus#134 tracks the cursor-ack primitive the dotfiles drain still needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R