### PR TITLE
Allowlist a reverse proxy's Host + log bridge rejections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |
 | Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/`, else the system temp dir (`$TMPDIR`, or `/tmp` when unset; macOS: per-user `/var/folders/.../T`) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Create-and-verified private (not adopted). Safe to remove when no bridge is running |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_WAKE_DIR`)
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_BRIDGE_ALLOWED_HOSTS`, `_WAKE_DIR`)
 
 ---
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -177,6 +177,13 @@ class BridgeConfig:
     # the CLI gives a wide --bind. The CLI path never needs it: there the
     # bridge owns the bind, so the derived check is already real.
     assume_exposed: bool = False
+    # Extra Host values the /hook and /health allowlist accepts, beyond the
+    # loopback literals, the hook URL hostname, and a pinned --bind. A
+    # forwarding proxy commonly rewrites Host to its upstream address (the
+    # nginx default `proxy_set_header Host $proxy_host`) or a name, which
+    # nothing else adds under the derived wildcard bind - so a reverse-proxy
+    # deployment must list that value here or every dispatch is 421'd.
+    allowed_hosts: tuple[str, ...] = ()
 
 
 class BridgeConfigError(ValueError):
@@ -262,6 +269,27 @@ SESSION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 # therefore share the window - acceptable for v1.)
 _UNSAFE_WARN_INTERVAL_SECONDS = 60.0
 _unsafe_warn_state = {"last": -math.inf}
+
+# Every ACCEPTED event has its disposition logged somewhere (the skew line,
+# the filter arms, the cooldown/unmapped debug lines, the spool breadcrumb),
+# but a REJECTED request (bad signature, wrong media type, oversized,
+# unparseable, unserializable, foreign Host) returned only a status the bus
+# discards - so a secret mismatch, a media-type change, or a Host-rewriting
+# proxy behind a 421 was diagnosable only by reproducing it with curl.
+# _log_rejection closes that asymmetry. Rate-limited PER REASON by wall
+# clock: the values (Host, signature) are attacker/proxy-controlled and
+# would otherwise spam. Process-wide like _unsafe_warn_state, same v1
+# caveat about mounted apps sharing the window.
+_reject_warn_state: dict[str, float] = {}
+
+
+def _log_rejection(reason: str, detail: str) -> None:
+    now = _now()
+    if now - _reject_warn_state.get(reason, -math.inf) >= _UNSAFE_WARN_INTERVAL_SECONDS:
+        _reject_warn_state[reason] = now
+        logger.warning(f"Rejected request ({reason}): {detail}")
+    else:
+        logger.debug(f"Rejected request ({reason}): {detail}")
 
 
 def resolve_target_session(event: dict) -> str | None:
@@ -899,6 +927,13 @@ def create_bridge_app(
             allowed_hook_hosts.add(str(bind_ip))
     except ValueError:
         pass  # "localhost" - already present; the resolver decides its family
+    # Operator-configured extras (--allowed-host): the ONLY way to accept a
+    # reverse proxy's rewritten Host, which the derived wildcard bind above
+    # never adds (and a name-rewriting proxy can't be covered by --bind at
+    # all). Canonicalized through _host_from_header so a "10.0.0.5:8082" or
+    # bracketed-IPv6 entry matches the incoming Host the same way.
+    for extra in config.allowed_hosts:
+        allowed_hook_hosts.add(_host_from_header(extra))
     # Version-skew line bound (a closure cell: the arm lives in process(),
     # not on the injector). The condition - a bus predating derived levels -
     # is persistent and per-deployment, so it gets the same first-sighting
@@ -995,8 +1030,11 @@ def create_bridge_app(
         # sibling case OUTSIDE ValueError: ~500k nested brackets fit well
         # under MAX_BODY_BYTES and blow the interpreter limit before any
         # JSONDecodeError can be raised. The bus retries any >=400
-        # identically, so a 400 buys a clean named error in both logs
-        # instead of a traceback per attempt - not fewer retries.
+        # identically, so a 400 is not fewer retries - it is a clean named
+        # status instead of a traceback per attempt. The named reason
+        # reaches THIS daemon's log via _log_rejection at the hook_endpoint
+        # boundary; the bus discards the response body, so its log carries
+        # only the status code.
         except (ValueError, RecursionError):
             return {"error": "invalid JSON"}, 400
         if not isinstance(event, dict):
@@ -1053,7 +1091,13 @@ def create_bridge_app(
             # this 400 structurally cannot fire after a spool line has
             # landed (which would make the bus retry and duplicate it) - a
             # RecursionError from deliver's later tmux steps stays a 500.
-            return {"error": "invalid JSON"}, 400
+            # A DISTINCT string from the parse-failure 400 above: the body
+            # parsed fine, it just cannot re-serialize to a standard-JSON
+            # spool line (deep nesting, or an inf/nan allow_nan=False
+            # rejects) - a different producer and fix than "not JSON". The
+            # response body is a direct-caller-only surface, so this is the
+            # only place the distinction can surface.
+            return {"error": "payload not serializable to a spool line"}, 400
         return {"status": "delivered", "action": action, "session_id": target}, 200
 
     async def hook_endpoint(request: Request) -> JSONResponse:
@@ -1073,6 +1117,7 @@ def create_bridge_app(
         # about strictness for its own sake.
         content_type = request.headers.get("content-type", "")
         if content_type.split(";", 1)[0].strip().lower() != WEBHOOK_CONTENT_TYPE:
+            _log_rejection("content-type", f"Content-Type {content_type!r} (need JSON)")
             return JSONResponse(
                 {"error": f"Content-Type must be {WEBHOOK_CONTENT_TYPE}"}, status_code=415
             )
@@ -1086,6 +1131,7 @@ def create_bridge_app(
         # isdecimal() matches what int() actually accepts.
         content_length = request.headers.get("content-length")
         if content_length and content_length.isdecimal() and int(content_length) > MAX_BODY_BYTES:
+            _log_rejection("too-large", f"Content-Length {content_length} > {MAX_BODY_BYTES}")
             return JSONResponse({"error": "body too large"}, status_code=413)
         # Stream with a running count, not request.body(): body() concatenates
         # every chunk unconditionally, so a chunked POST (no content-length to
@@ -1102,15 +1148,24 @@ def create_bridge_app(
             async for chunk in request.stream():
                 received += len(chunk)
                 if received > MAX_BODY_BYTES:
+                    _log_rejection("too-large", f"streamed body exceeded {MAX_BODY_BYTES}")
                     return JSONResponse({"error": "body too large"}, status_code=413)
                 chunks.append(chunk)
         except ClientDisconnect:
+            _log_rejection("disconnect", "client aborted mid-body")
             return JSONResponse({"error": "client disconnected mid-body"}, status_code=400)
         body = b"".join(chunks)
         # Starlette header lookup is case-insensitive, so the canonical-case
         # constant works directly
         signature = request.headers.get(SIGNATURE_HEADER)
         payload, status = await run_in_threadpool(process, body, signature)
+        # The bus discards the response body, so a reject is otherwise a bare
+        # status in the uvicorn access line with no diagnosis - every ACCEPTED
+        # event's disposition is logged, so log the rejects too (rate-limited
+        # per reason). 401/400 come from process(); 415/413/disconnect above
+        # and 421 in the middleware log at their own sites.
+        if status >= 400:
+            _log_rejection(payload.get("error", "reject"), f"status {status}")
         return JSONResponse(payload, status_code=status)
 
     async def health(request: Request) -> JSONResponse:
@@ -1190,6 +1245,16 @@ class _HostAllowlistMiddleware:
                     raw_host = value.decode("latin-1")
                     break
             if _host_from_header(raw_host) not in self.allowed:
+                # A rebound tab's Host is attacker-chosen, but so is a
+                # reverse proxy's rewritten Host - which is a legitimate
+                # deployment 421'd silently under the derived wildcard bind.
+                # Name the rejected Host and the fix so it's recoverable.
+                _log_rejection(
+                    "host",
+                    f"Host {raw_host!r} not in the allowlist {sorted(self.allowed)} - if a "
+                    "reverse proxy forwards here, add its forwarded Host via --allowed-host / "
+                    "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS",
+                )
                 response = JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
                 await response(scope, receive, send)
                 return
@@ -1474,6 +1539,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Interface to bind (default: 127.0.0.1 for a loopback hook URL, "
         "0.0.0.0 otherwise; pin e.g. your tailnet address to narrow exposure)",
     )
+    parser.add_argument(
+        "--allowed-host",
+        default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS") or "",
+        help="Comma-separated extra Host values the /hook & /health allowlist "
+        "accepts, beyond the loopback literals, the hook URL host, and a pinned "
+        "--bind. Needed when a reverse proxy rewrites Host to its upstream "
+        "address or a name (else every dispatch is 421'd)",
+    )
     return parser
 
 
@@ -1696,6 +1769,9 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         wake_dir=args.wake_dir,
         hook_url=args.hook_url,
         bind=args.bind,
+        # Comma-separated -> tuple; blank entries dropped so a trailing comma
+        # or an empty env var yields ().
+        allowed_hosts=tuple(h.strip() for h in args.allowed_host.split(",") if h.strip()),
     )
     # Translate the embedder-catchable error into the CLI's exit shape -
     # main() prints the message and exits without a traceback

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -276,10 +276,12 @@ _unsafe_warn_state = {"last": -math.inf}
 # unparseable, unserializable, foreign Host) returned only a status the bus
 # discards - so a secret mismatch, a media-type change, or a Host-rewriting
 # proxy behind a 421 was diagnosable only by reproducing it with curl.
-# _log_rejection closes that asymmetry. Rate-limited PER REASON by wall
-# clock: the values (Host, signature) are attacker/proxy-controlled and
-# would otherwise spam. Process-wide like _unsafe_warn_state, same v1
-# caveat about mounted apps sharing the window.
+# _log_rejection closes that asymmetry. Rate-limited PER REASON on the
+# MONOTONIC clock (_now, like every other window in this module - so an
+# NTP step cannot stretch or collapse it): the values (Host, signature)
+# are attacker/proxy-controlled and would otherwise spam. Process-wide
+# like _unsafe_warn_state, same v1 caveat about mounted apps sharing the
+# window.
 _reject_warn_state: dict[str, float] = {}
 
 

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -930,10 +930,12 @@ def create_bridge_app(
     # Operator-configured extras (--allowed-host): the ONLY way to accept a
     # reverse proxy's rewritten Host, which the derived wildcard bind above
     # never adds (and a name-rewriting proxy can't be covered by --bind at
-    # all). Canonicalized through _host_from_header so a "10.0.0.5:8082" or
-    # bracketed-IPv6 entry matches the incoming Host the same way.
-    for extra in config.allowed_hosts:
-        allowed_hook_hosts.add(_host_from_header(extra))
+    # all). Added VERBATIM: validate_config (called above, so this holds for
+    # embedders too) already stripped, dropped blanks, and canonicalized each
+    # entry. Re-applying _host_from_header here would be actively wrong, not
+    # merely redundant - it is not idempotent on IPv6, since the unbracketed
+    # branch splits on the last colon ("fd7a::1" -> "fd7a:").
+    allowed_hook_hosts.update(config.allowed_hosts)
     # Version-skew line bound (a closure cell: the arm lives in process(),
     # not on the injector). The condition - a bus predating derived levels -
     # is persistent and per-deployment, so it gets the same first-sighting
@@ -1613,6 +1615,42 @@ def validate_config(config: BridgeConfig) -> None:
     ):
         if value is not None and not isinstance(value, str):
             raise BridgeConfigError(f"Invalid value {value!r} (check {label}): expected a string")
+
+    # allowed_hosts is the one field whose ENTRIES feed a security guard, so
+    # it is canonicalized HERE rather than in config_from_args: the allowlist
+    # is built in create_bridge_app, which every embedder reaches without
+    # passing through argparse. Three inputs a hand-built config makes easy,
+    # each of which silently breaks the guard if it survives to that loop:
+    #   ("",)      - the `os.environ.get(..., "").split(",")` idiom. Empty
+    #                string canonicalizes to itself, and the middleware
+    #                defaults raw_host to "" when the Host header is absent
+    #                or blank (h11 permits both), so the entry MATCHES those
+    #                requests and turns the rebinding guard off entirely -
+    #                for /health too, while it still reports registered.
+    #   " host"    - never stripped, so it can never match: escape hatch
+    #                silently inert, the mirror image of the above.
+    #   "host"     - a bare str is iterable, so the loop would add one entry
+    #                PER CHARACTER (including "" for the empty string).
+    # A bare IPv6 literal is accepted too: _host_from_header's unbracketed
+    # branch splits on the last colon ("fd7a::1" -> "fd7a:"), but --bind
+    # takes bare literals, so that is the spelling an operator arrives with.
+    if isinstance(config.allowed_hosts, str):
+        config.allowed_hosts = (config.allowed_hosts,)
+    canonical_hosts = []
+    for entry in config.allowed_hosts:
+        if not isinstance(entry, str):
+            raise BridgeConfigError(
+                f"Invalid allowed host {entry!r} (check --allowed-host / "
+                "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS): expected a string"
+            )
+        stripped = entry.strip()
+        if not stripped:
+            continue  # blank entry (trailing comma, empty env var) - drop it
+        try:  # bare IPv6, which the port-splitting path would mangle
+            canonical_hosts.append(str(ipaddress.ip_address(stripped)))
+        except ValueError:
+            canonical_hosts.append(_host_from_header(stripped))
+    config.allowed_hosts = tuple(canonical_hosts)
 
     # argparse `choices` only guards command-line values, and an embedder
     # skips argparse entirely - an unknown backend would silently mean

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -929,7 +929,7 @@ def create_bridge_app(
             allowed_hook_hosts.add(str(bind_ip))
     except ValueError:
         pass  # "localhost" - already present; the resolver decides its family
-    # Operator-configured extras (--allowed-host): the ONLY way to accept a
+    # Operator-configured extras (--allowed-hosts): the ONLY way to accept a
     # reverse proxy's rewritten Host, which the derived wildcard bind above
     # never adds (and a name-rewriting proxy can't be covered by --bind at
     # all). Added VERBATIM: validate_config (called above, so this holds for
@@ -1256,7 +1256,7 @@ class _HostAllowlistMiddleware:
                 _log_rejection(
                     "host",
                     f"Host {raw_host!r} not in the allowlist {sorted(self.allowed)} - if a "
-                    "reverse proxy forwards here, add its forwarded Host via --allowed-host / "
+                    "reverse proxy forwards here, add its forwarded Host via --allowed-hosts / "
                     "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS",
                 )
                 response = JSONResponse({"error": f"unexpected Host {raw_host!r}"}, status_code=421)
@@ -1544,7 +1544,7 @@ def build_parser() -> argparse.ArgumentParser:
         "0.0.0.0 otherwise; pin e.g. your tailnet address to narrow exposure)",
     )
     parser.add_argument(
-        "--allowed-host",
+        "--allowed-hosts",
         default=os.environ.get("AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS") or "",
         help="Comma-separated extra Host values the /hook & /health allowlist "
         "accepts, beyond the loopback literals, the hook URL host, and a pinned "
@@ -1642,16 +1642,34 @@ def validate_config(config: BridgeConfig) -> None:
     for entry in config.allowed_hosts:
         if not isinstance(entry, str):
             raise BridgeConfigError(
-                f"Invalid allowed host {entry!r} (check --allowed-host / "
+                f"Invalid allowed host {entry!r} (check --allowed-hosts / "
                 "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS): expected a string"
             )
         stripped = entry.strip()
         if not stripped:
             continue  # blank entry (trailing comma, empty env var) - drop it
         try:  # bare IPv6, which the port-splitting path would mangle
-            canonical_hosts.append(str(ipaddress.ip_address(stripped)))
+            canonical = str(ipaddress.ip_address(stripped))
         except ValueError:
-            canonical_hosts.append(_host_from_header(stripped))
+            canonical = _host_from_header(stripped)
+        # Emptiness is tested on the CANONICAL value, not the stripped input:
+        # _host_from_header can PRODUCE "" from an entry that is not blank -
+        # ":8082" (no bracket, so the rsplit on the last colon leaves nothing
+        # before it) and "[]" / "[]:8082" (bracketed branch, nothing between
+        # the brackets). Checking only the input would let those through to
+        # the allowlist and reopen the Host-less bypass above by another door.
+        # A named refusal rather than the silent `continue`: a trailing comma
+        # is a formatting artifact, but ":8082" is an operator reaching for
+        # "any host on this port" - a wish this flag cannot grant, and one
+        # they need told rather than dropped.
+        if not canonical:
+            raise BridgeConfigError(
+                f"Invalid allowed host {entry!r} (check --allowed-hosts / "
+                "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS): no hostname in it. "
+                "Entries are Host values (name, IP literal, or either with a "
+                "port) - a port alone matches nothing."
+            )
+        canonical_hosts.append(canonical)
     config.allowed_hosts = tuple(canonical_hosts)
 
     # argparse `choices` only guards command-line values, and an embedder
@@ -1811,7 +1829,9 @@ def config_from_args(args: argparse.Namespace) -> BridgeConfig:
         bind=args.bind,
         # Comma-separated -> tuple; blank entries dropped so a trailing comma
         # or an empty env var yields ().
-        allowed_hosts=tuple(h.strip() for h in args.allowed_host.split(",") if h.strip()),
+        # Split only; validate_config does the stripping, blank-dropping, and
+        # canonicalization, so the embedder path gets identical treatment.
+        allowed_hosts=tuple(args.allowed_hosts.split(",")),
     )
     # Translate the embedder-catchable error into the CLI's exit shape -
     # main() prints the message and exits without a traceback

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -527,6 +527,17 @@ That lands with the supervision story.)
   it. When poking the endpoint with `curl`, send the JSON content type and
   address the bridge by a loopback literal, the hook URL's hostname, or the
   bound address.
+
+  **Behind a reverse proxy**, list the `Host` it forwards with
+  `--allowed-host` (comma-separated, or `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`).
+  nginx's `proxy_pass` rewrites `Host` to the *upstream* address unless the
+  operator adds `proxy_set_header Host $host`, and that rewritten value is in
+  no derived entry: a non-loopback hook URL derives the wildcard bind
+  `0.0.0.0`, which is deliberately not allowlisted, and pinning `--bind`
+  instead would drop the wildcard (and cannot cover a proxy rewriting to a
+  *name* at all). Without it every forwarded dispatch 421s while `/health`
+  still reports `registered: true`. The bridge log names the rejected `Host`
+  and this flag on the first rejection.
 - `GET /health` reports `registered`: whether the *startup* registration
   succeeded. The row is not re-verified afterwards, so unregistering the
   webhook by hand (or restoring the bus DB from a backup) leaves

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -529,7 +529,7 @@ That lands with the supervision story.)
   bound address.
 
   **Behind a reverse proxy**, list the `Host` it forwards with
-  `--allowed-host` (comma-separated, or `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`).
+  `--allowed-hosts` (comma-separated, or `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`).
   nginx's `proxy_pass` rewrites `Host` to the *upstream* address unless the
   operator adds `proxy_set_header Host $host`, and that rewritten value is in
   no derived entry: a non-loopback hook URL derives the wildcard bind
@@ -549,8 +549,10 @@ That lands with the supervision story.)
   confirm a bridge runs here. Probe it by a loopback literal, the hook
   URL's hostname, or the bound address *when `--bind` pins a specific one* -
   under a wildcard bind (the derived default for a non-loopback hook URL)
-  the bind is not in the allowlist, so probe by the hook URL hostname or a
-  loopback literal.
+  the bind is not in the allowlist, so probe by the hook URL hostname, a
+  loopback literal, or any value listed with `--allowed-hosts` - the same
+  allowlist covers both endpoints, so a monitoring probe arriving through
+  the same reverse proxy as the deliveries passes on the proxy's Host.
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),
   `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -753,7 +753,7 @@ class TestHookFiltering:
         assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
 
     def test_allowed_host_admits_a_forwarding_proxy(self, tmp_path):
-        """The gap --allowed-host exists for: a non-loopback hook URL derives
+        """The gap --allowed-hosts exists for: a non-loopback hook URL derives
         bind 0.0.0.0, is_unspecified keeps the wildcard OUT of the allowlist,
         and nginx's proxy_pass default rewrites Host to its UPSTREAM address -
         so every forwarded dispatch 421s while /health stays green. --bind
@@ -817,6 +817,26 @@ class TestHookFiltering:
             # a per-character allowlist would admit these single letters
             assert client.get("/health", headers={"Host": "p"}).status_code == 421, allowed
 
+    def test_port_only_allowed_host_is_refused_not_silently_dropped(self, tmp_path):
+        """The same bypass by another door: these entries are NOT blank, so a
+        check on the raw input passes them through - but _host_from_header
+        PRODUCES the empty string from each (":8082" has nothing before the
+        last colon; "[]" has nothing between the brackets), which would then
+        match the middleware's raw_host default and disable the guard. The
+        emptiness test therefore runs on the CANONICAL value. Refused rather
+        than dropped: ":8082" is an operator reaching for "any host on this
+        port", which this flag cannot express."""
+        for entry in (":8082", "[]", "[]:8082"):
+            with pytest.raises(bridge.BridgeConfigError, match="no hostname"):
+                create_bridge_app(
+                    BridgeConfig(
+                        wake_dir=tmp_path / "wake",
+                        hook_url="http://bridge.example:8082/hook",
+                        secret="s3cret",
+                        allowed_hosts=(entry,),
+                    )
+                )
+
     def test_non_string_allowed_host_is_a_named_config_error(self, tmp_path):
         """Same posture as the other hand-built-config type checks: a named
         BridgeConfigError, not a bare AttributeError off .strip()."""
@@ -845,7 +865,7 @@ class TestHookFiltering:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert len(warnings) == 1, "the repeat must not re-warn inside the interval"
         assert "10.0.0.5:8082" in warnings[0].message
-        assert "--allowed-host" in warnings[0].message
+        assert "--allowed-hosts" in warnings[0].message
 
     def test_ipv6_bind_address_normalized_in_allowlist(self, tmp_path):
         """The bind address is stored NORMALIZED (str(ip_address)), so an
@@ -2739,7 +2759,9 @@ class TestBindHost:
         (in validate_config, so embedders get the same treatment): the port
         is stripped exactly as it is on the incoming Host, which is what
         makes a "10.0.0.5:8082" entry match a request under that authority."""
-        args = bridge.build_parser().parse_args(["--allowed-host", "proxy.example, 10.0.0.5:8082,"])
+        args = bridge.build_parser().parse_args(
+            ["--allowed-hosts", "proxy.example, 10.0.0.5:8082,"]
+        )
         assert bridge.config_from_args(args).allowed_hosts == ("proxy.example", "10.0.0.5")
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS", "edge.example")
         assert bridge.config_from_args(bridge.build_parser().parse_args([])).allowed_hosts == (

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -773,6 +773,63 @@ class TestHookFiltering:
         # The allowlist is still a guard, not a bypass
         assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
 
+    def test_blank_allowed_host_does_not_disable_the_guard(self, tmp_path):
+        """THE bypass this sanitation exists for. `os.environ.get(X, "")
+        .split(",")` yields ("",) - the obvious embedder idiom - and an empty
+        entry canonicalizes to itself. The middleware defaults raw_host to ""
+        when the Host header is absent or blank (h11 permits both), so that
+        entry would MATCH those requests and turn the rebinding guard off for
+        /hook and /health alike, silently, while /health still reports
+        registered. Driven through create_bridge_app (not config_from_args)
+        because the embedder path is the one that was unprotected."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://bridge.example:8082/hook",
+            secret="s3cret",
+            allowed_hosts=tuple("".split(",")),  # ("",) - verbatim idiom
+        )
+        client = TestClient(create_bridge_app(config), base_url="http://bridge.example:8082")
+        assert client.get("/health", headers={"Host": ""}).status_code == 421
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+        # and the legitimate name still passes, so this isn't a blanket deny
+        assert client.get("/health", headers={"Host": "bridge.example:8082"}).status_code == 200
+
+    def test_allowed_host_entries_are_canonicalized_for_embedders(self, tmp_path):
+        """The other two hand-built shapes, both of which leave the escape
+        hatch silently inert rather than open: an unstripped entry can never
+        match, and a BARE str is iterable, so an unsanitized loop would add
+        one entry per CHARACTER. A bare IPv6 literal is accepted too - --bind
+        takes them unbracketed, so that's the spelling operators arrive with,
+        and _host_from_header alone would mangle it to "fd7a:"."""
+        for allowed, host in (
+            ((" proxy.example ",), "proxy.example"),  # unstripped
+            ("proxy.example", "proxy.example"),  # bare str, not a tuple
+            (("fd7a::1",), "[fd7a::1]"),  # bare IPv6 -> bracketed on the wire
+        ):
+            config = BridgeConfig(
+                wake_dir=tmp_path / "wake",
+                hook_url="http://bridge.example:8082/hook",
+                secret="s3cret",
+                allowed_hosts=allowed,
+            )
+            client = TestClient(create_bridge_app(config), base_url="http://bridge.example:8082")
+            assert client.get("/health", headers={"Host": host}).status_code == 200, allowed
+            # a per-character allowlist would admit these single letters
+            assert client.get("/health", headers={"Host": "p"}).status_code == 421, allowed
+
+    def test_non_string_allowed_host_is_a_named_config_error(self, tmp_path):
+        """Same posture as the other hand-built-config type checks: a named
+        BridgeConfigError, not a bare AttributeError off .strip()."""
+        with pytest.raises(bridge.BridgeConfigError, match="allowed host"):
+            create_bridge_app(
+                BridgeConfig(
+                    wake_dir=tmp_path / "wake",
+                    hook_url="http://bridge.example:8082/hook",
+                    secret="s3cret",
+                    allowed_hosts=(123,),
+                )
+            )
+
     def test_rejected_host_names_itself_and_the_fix(self, config, caplog):
         """A 421 was the one reject with NO diagnostic anywhere on this side:
         the bus discards the response body and logs its own status on a
@@ -2678,9 +2735,12 @@ class TestBindHost:
     def test_allowed_hosts_from_flag_and_env(self, monkeypatch):
         """Comma-separated on both surfaces, blanks dropped so a trailing
         comma or an empty env var yields () rather than an "" entry that
-        would match a Host-less request."""
+        would match a Host-less request. Entries come back CANONICALIZED
+        (in validate_config, so embedders get the same treatment): the port
+        is stripped exactly as it is on the incoming Host, which is what
+        makes a "10.0.0.5:8082" entry match a request under that authority."""
         args = bridge.build_parser().parse_args(["--allowed-host", "proxy.example, 10.0.0.5:8082,"])
-        assert bridge.config_from_args(args).allowed_hosts == ("proxy.example", "10.0.0.5:8082")
+        assert bridge.config_from_args(args).allowed_hosts == ("proxy.example", "10.0.0.5")
         monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS", "edge.example")
         assert bridge.config_from_args(bridge.build_parser().parse_args([])).allowed_hosts == (
             "edge.example",

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -88,8 +88,8 @@ def reset_reject_warn_state():
     (there is no per-request object to hang it on - the middleware 421 fires
     before any endpoint runs). A test that drives one reject reason leaves a
     real monotonic reading behind, so a later test asserting that reason's
-    WARNING would pass or fail on 60s of wall clock and run ordering. Clear
-    it around every test."""
+    WARNING would pass or fail on 60s of elapsed monotonic time and run
+    ordering. Clear it around every test."""
     bridge._reject_warn_state.clear()
     yield
     bridge._reject_warn_state.clear()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -51,6 +51,7 @@ BRIDGE_ENV = (
     "AGENT_EVENT_BUS_BRIDGE_SECRET",
     "AGENT_EVENT_BUS_BRIDGE_HOOK_URL",
     "AGENT_EVENT_BUS_BRIDGE_BIND",
+    "AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS",
     "AGENT_EVENT_BUS_WAKE_DIR",
     # Not AGENT_EVENT_BUS_*-prefixed, but main() honours it as THE debug
     # switch and CLAUDE.md tells developers to export it - exactly the
@@ -79,6 +80,19 @@ def reset_unsafe_warn_state():
     bridge._unsafe_warn_state["last"] = -float("inf")
     yield
     bridge._unsafe_warn_state["last"] = -float("inf")
+
+
+@pytest.fixture(autouse=True)
+def reset_reject_warn_state():
+    """_log_rejection rate-limits per reason in process-wide module state
+    (there is no per-request object to hang it on - the middleware 421 fires
+    before any endpoint runs). A test that drives one reject reason leaves a
+    real monotonic reading behind, so a later test asserting that reason's
+    WARNING would pass or fail on 60s of wall clock and run ordering. Clear
+    it around every test."""
+    bridge._reject_warn_state.clear()
+    yield
+    bridge._reject_warn_state.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -549,7 +563,10 @@ class TestHookFiltering:
         ):
             resp = client.post("/hook", content=json.dumps(make_event()).encode())
         assert resp.status_code == 400
-        assert resp.json() == {"error": "invalid JSON"}
+        # A DISTINCT string from the parse-failure 400: the body was valid
+        # JSON, it just cannot re-serialize to a standard-JSON spool line -
+        # a different producer and fix than "not JSON".
+        assert resp.json() == {"error": "payload not serializable to a spool line"}
 
     def test_spool_serialization_failure_creates_no_file_or_lock(self, config):
         """_spool serializes BEFORE it opens the file or takes the flock, so
@@ -734,6 +751,44 @@ class TestHookFiltering:
         client = TestClient(create_bridge_app(config))
         assert client.get("/health", headers={"Host": "100.100.1.2"}).status_code == 200
         assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+
+    def test_allowed_host_admits_a_forwarding_proxy(self, tmp_path):
+        """The gap --allowed-host exists for: a non-loopback hook URL derives
+        bind 0.0.0.0, is_unspecified keeps the wildcard OUT of the allowlist,
+        and nginx's proxy_pass default rewrites Host to its UPSTREAM address -
+        so every forwarded dispatch 421s while /health stays green. --bind
+        cannot cover it (pinning drops the wildcard, and a name-rewriting
+        proxy has no address to pin). An operator-listed Host is admitted;
+        an unlisted one is still rejected."""
+        config = BridgeConfig(
+            wake_dir=tmp_path / "wake",
+            hook_url="http://bridge.example:8082/hook",  # non-loopback -> bind 0.0.0.0
+            allowed_hosts=("10.0.0.5:8082",),
+            secret="s3cret",
+        )
+        client = TestClient(create_bridge_app(config), headers=JSON_CT)
+        body = json.dumps(make_event()).encode()
+        signed = {"Host": "10.0.0.5:8082", SIGNATURE_HEADER: sign(body, "s3cret")}
+        assert client.post("/hook", content=body, headers=signed).status_code == 200
+        # The allowlist is still a guard, not a bypass
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+
+    def test_rejected_host_names_itself_and_the_fix(self, config, caplog):
+        """A 421 was the one reject with NO diagnostic anywhere on this side:
+        the bus discards the response body and logs its own status on a
+        different host in every non-loopback topology. Diagnosing it needs
+        the rejected Host, so the warning carries it plus the flag that
+        admits it. Rate-limited per reason, so the repeat drops to debug."""
+        import logging
+
+        client = TestClient(create_bridge_app(config))
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            assert client.get("/health", headers={"Host": "10.0.0.5:8082"}).status_code == 421
+            assert client.get("/health", headers={"Host": "10.0.0.6:8082"}).status_code == 421
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, "the repeat must not re-warn inside the interval"
+        assert "10.0.0.5:8082" in warnings[0].message
+        assert "--allowed-host" in warnings[0].message
 
     def test_ipv6_bind_address_normalized_in_allowlist(self, tmp_path):
         """The bind address is stored NORMALIZED (str(ip_address)), so an
@@ -2619,6 +2674,17 @@ class TestBindHost:
                     bridge.build_parser().parse_args(["--bind", bind, "--hook-url", hook])
                 )
             assert not any("different loopback" in r.message for r in caplog.records), (bind, hook)
+
+    def test_allowed_hosts_from_flag_and_env(self, monkeypatch):
+        """Comma-separated on both surfaces, blanks dropped so a trailing
+        comma or an empty env var yields () rather than an "" entry that
+        would match a Host-less request."""
+        args = bridge.build_parser().parse_args(["--allowed-host", "proxy.example, 10.0.0.5:8082,"])
+        assert bridge.config_from_args(args).allowed_hosts == ("proxy.example", "10.0.0.5:8082")
+        monkeypatch.setenv("AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS", "edge.example")
+        assert bridge.config_from_args(bridge.build_parser().parse_args([])).allowed_hosts == (
+            "edge.example",
+        )
 
     def test_invalid_bind_is_refused(self):
         args = bridge.build_parser().parse_args(["--bind", "localhost:8082"])


### PR DESCRIPTION
Follow-up to #135, which merged with these items still open. Two gaps that only surface in the off-host-terminator topology `config_from_args` explicitly blesses — its three *"correct only if something forwards between them"* warnings.

## 1. A forwarding proxy's `Host` had no allowlist entry

The DNS-rebinding guard admits loopback literals, the hook URL's hostname, and a pinned non-wildcard `--bind`. None of those can match a reverse proxy:

- A non-loopback hook URL derives bind `0.0.0.0`, and `is_unspecified` deliberately keeps the wildcard out of the allowlist.
- nginx's `proxy_pass` rewrites `Host` to the **upstream address** unless the operator adds `proxy_set_header Host $host`.

So the middleware sees e.g. `Host: 10.0.0.5:8082` and 421s **every dispatch**, while `/health` reports `registered: true` forever. `--bind` was the only lever and can't fix it: pinning it drops the wildcard (a behaviour change with no obvious connection to a `Host` rejection), and a proxy rewriting to a *name* has no address to pin at all.

Adds `--allowed-host` / `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`, comma-separated, canonicalized through `_host_from_header` so a `10.0.0.5:8082` or bracketed-IPv6 entry collapses onto the same key as the incoming `Host` — the same normalization the derived entries already get.

## 2. No reject arm in the bridge logged anything

The 421 above, plus the 415, the two 413s, the 400s, and the 401, all returned silently. `deliver`'s docstring commits to the opposite posture — *"the bus discards the response body — so operator-facing visibility is this module's log"* — and that held for **delivered** events only. For a rejected one there was nothing to see on this side, and the bus's own `returned 421` warning sits on a different host in every non-loopback topology.

`_log_rejection` gives every reject the first-sighting-warn / repeats-at-debug shape already used by `_warn_panes_once`, the skew line, and the wake-failure guard. Rate-limited **per reason**, since `Host` and signature values are peer-controlled and would otherwise spam. The 421 line carries the rejected `Host`, the current allowlist, and the flag that admits it — that value is what makes the failure diagnosable at all.

## 3. Drive-by: the unserializable-payload 400 got its own string

It reused the parse-failure arm's `"invalid JSON"`, collapsing two structurally distinct pre-durable failures. The body parsed fine — it just can't re-serialize to a standard-JSON spool line (deep nesting, or an `inf`/`nan` that `allow_nan=False` rejects). Different producer, different fix, and the response body is the only surface where the distinction can appear.

## Testing

`make check` green: **565 passed** (562 + 3).

- `test_allowed_host_admits_a_forwarding_proxy` — a listed proxy `Host` delivers under the derived wildcard bind; an unlisted one still 421s, so the escape hatch isn't a bypass.
- `test_rejected_host_names_itself_and_the_fix` — the warning carries the rejected `Host` and `--allowed-host`, and the second rejection inside the interval does *not* re-warn.
- `test_allowed_hosts_from_flag_and_env` — comma-separated on both surfaces, blanks dropped so a trailing comma or empty env var yields `()` rather than an `""` entry.

Plus an autouse fixture clearing `_reject_warn_state` between tests (the rate-limit state is process-wide, so a leaked reading would make a later assertion depend on wall clock and run order), and `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS` added to the env scrub list.

Docs: the guide's `/hook` section gains a **"Behind a reverse proxy"** paragraph naming the nginx default and the failure shape; CLAUDE.md's env var list gains `_BRIDGE_ALLOWED_HOSTS`.

## Not included

`bridge.py`'s `_spool` builds its symlink-refusal message with an `os.readlink` call *inside* the `raise` expression. If the planted link is removed between the `is_symlink()` check and that `readlink`, the deliberate named refusal becomes the unnamed 500 it exists to avoid. Real but very narrow, and unrelated to this change — worth its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R)_