### PR TITLE
Fall back to CLAUDE_CODE_SESSION_ID for CLI session attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,12 @@ AGENT_EVENT_BUS_ICON=/path/to/icon.png agent-event-bus
 # Disable Tailscale auth (for testing/local dev)
 AGENT_EVENT_BUS_AUTH_DISABLED=1 agent-event-bus
 
-# CLI session attribution (used by hooks)
+# CLI session attribution (used by hooks). When --session-id is omitted, the
+# CLI reads AGENT_EVENT_BUS_SESSION_ID, then falls back to
+# CLAUDE_CODE_SESSION_ID (which Claude Code injects into every subprocess it
+# spawns). The fallback matters because shell-profile mappings of one to the
+# other typically live in an rc file that only INTERACTIVE shells read, so a
+# tool-spawned subprocess never runs them and publishes land as "anonymous".
 AGENT_EVENT_BUS_SESSION_ID=abc123 agent-event-bus-cli publish ...
 ```
 

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -231,6 +231,30 @@ def cmd_channels(args):
     print()
 
 
+def _session_id_from_env() -> str | None:
+    """Session id for an omitted --session-id, in precedence order.
+
+    AGENT_EVENT_BUS_SESSION_ID is the explicit, tool-agnostic knob and wins.
+    CLAUDE_CODE_SESSION_ID is the fallback because Claude Code injects it into
+    every subprocess it spawns, so it is present exactly where the explicit one
+    tends not to be.
+
+    The fallback exists because setting the explicit var from a shell profile
+    is not reliable: the dotfiles that map one to the other live in ~/.exports,
+    which is sourced from ~/.zshrc - and zsh reads .zshrc for INTERACTIVE
+    shells only. Tool-spawned subprocesses are non-interactive, so the mapping
+    never runs there and publishes landed as "anonymous" (`zsh -i -c` sees it,
+    `zsh -c` does not). That is a property of shell startup, not of any OS -
+    it reproduces on Linux - so the fix belongs here, where it holds for every
+    shell, spawner, and machine, rather than in one shell's rc plumbing.
+
+    The two ids are the same value by construction: the SessionStart hook
+    registers on the bus with client_id = the Claude Code session id, which the
+    bus adopts as its session id.
+    """
+    return os.environ.get("AGENT_EVENT_BUS_SESSION_ID") or os.environ.get("CLAUDE_CODE_SESSION_ID")
+
+
 def cmd_publish(args):
     """Publish an event."""
     arguments = {
@@ -240,7 +264,7 @@ def cmd_publish(args):
     if args.channel:
         arguments["channel"] = args.channel
     # Use explicit --session-id, fall back to env var
-    session_id = args.session_id or os.environ.get("AGENT_EVENT_BUS_SESSION_ID")
+    session_id = args.session_id or _session_id_from_env()
     if session_id:
         arguments["session_id"] = session_id
     # Optional structured payload fields (RFC #121)
@@ -260,7 +284,7 @@ def cmd_publish(args):
 def cmd_events(args):
     """Get recent events."""
     # Use explicit --session-id, fall back to env var (matches cmd_publish)
-    session_id = args.session_id or os.environ.get("AGENT_EVENT_BUS_SESSION_ID")
+    session_id = args.session_id or _session_id_from_env()
 
     # Validate --resume requires a session id (flag or env var)
     if args.resume and not session_id:
@@ -467,7 +491,8 @@ def main():
     p_publish.add_argument("--payload", required=True, help="Event payload")
     p_publish.add_argument("--channel", default="all", help="Target channel")
     p_publish.add_argument(
-        "--session-id", help="Your session ID (default: $AGENT_EVENT_BUS_SESSION_ID)"
+        "--session-id",
+        help="Your session ID (default: $AGENT_EVENT_BUS_SESSION_ID, else $CLAUDE_CODE_SESSION_ID)",
     )
     p_publish.add_argument("--title", help="Optional short headline for the payload")
     p_publish.add_argument("--tags", help="Comma-separated tags for downstream filtering")
@@ -484,7 +509,8 @@ def main():
     p_events.add_argument("--cursor", help="Cursor from previous call (for pagination)")
     p_events.add_argument(
         "--session-id",
-        help="Your session ID for cursor tracking (default: $AGENT_EVENT_BUS_SESSION_ID)",
+        help="Your session ID for cursor tracking (default: "
+        "$AGENT_EVENT_BUS_SESSION_ID, else $CLAUDE_CODE_SESSION_ID)",
     )
     p_events.add_argument("--limit", type=int, help="Maximum number of events to return")
     p_events.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,19 @@ import pytest
 from agent_event_bus import cli
 from conftest import make_events_args, make_publish_args
 
+# Both names the CLI consults when --session-id is omitted. CLAUDE_CODE_SESSION_ID
+# is injected by Claude Code into every subprocess it spawns - including the one
+# running this suite - so without the scrub below an ambient value would silently
+# satisfy assertions that expect NO attribution, and the suite would pass on a
+# developer's machine while failing in CI (or the reverse).
+SESSION_ID_ENV = ("AGENT_EVENT_BUS_SESSION_ID", "CLAUDE_CODE_SESSION_ID")
+
+
+@pytest.fixture(autouse=True)
+def clean_session_id_env(monkeypatch):
+    for name in SESSION_ID_ENV:
+        monkeypatch.delenv(name, raising=False)
+
 
 class TestCallTool:
     """Tests for call_tool function."""
@@ -286,6 +299,37 @@ class TestCmdPublish:
 
         call_args = mock_call.call_args[0][1]
         assert call_args["session_id"] == "explicit-123"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_publish_falls_back_to_claude_code_session_id(self, mock_call, monkeypatch):
+        """publish shares the events precedence chain - it is the surface that
+        was actually landing as "anonymous" from tool-spawned subprocesses."""
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+        mock_call.return_value = {"event_id": 1}
+
+        cli.cmd_publish(make_publish_args())
+
+        assert mock_call.call_args[0][1]["session_id"] == "cc-session-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_publish_explicit_env_beats_claude_code_fallback(self, mock_call, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-123")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+        mock_call.return_value = {"event_id": 1}
+
+        cli.cmd_publish(make_publish_args())
+
+        assert mock_call.call_args[0][1]["session_id"] == "env-session-123"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_publish_omits_session_id_when_neither_is_set(self, mock_call):
+        """The autouse scrub removes both, so this pins that an unattributed
+        publish stays unattributed rather than picking up an ambient id."""
+        mock_call.return_value = {"event_id": 1}
+
+        cli.cmd_publish(make_publish_args())
+
+        assert "session_id" not in mock_call.call_args[0][1]
 
 
 class TestCmdEvents:
@@ -979,6 +1023,54 @@ class TestCmdEventsEnvAttribution:
 
         call_args = mock_call.call_args[0][1]
         assert "session_id" not in call_args
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_claude_code_session_id_is_the_fallback(self, mock_call, monkeypatch):
+        """THE reason this fallback exists. The dotfiles that map
+        CLAUDE_CODE_SESSION_ID -> AGENT_EVENT_BUS_SESSION_ID live in ~/.exports,
+        sourced from ~/.zshrc - and zsh reads .zshrc for INTERACTIVE shells
+        only, so a tool-spawned (non-interactive) subprocess never runs the
+        mapping and publishes landed as "anonymous". Claude Code injects
+        CLAUDE_CODE_SESSION_ID into that subprocess regardless, so reading it
+        here fixes the attribution for every shell and machine at once."""
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+
+        cli.cmd_events(make_events_args())
+
+        assert mock_call.call_args[0][1]["session_id"] == "cc-session-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_explicit_env_var_beats_the_claude_code_fallback(self, mock_call, monkeypatch):
+        """AGENT_EVENT_BUS_SESSION_ID is the tool-agnostic knob, so it wins -
+        an operator who sets it deliberately is not overridden by the ambient
+        one Claude Code happens to inject."""
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-id")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+
+        cli.cmd_events(make_events_args())
+
+        assert mock_call.call_args[0][1]["session_id"] == "env-session-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_flag_beats_both_env_vars(self, mock_call, monkeypatch):
+        monkeypatch.setenv("AGENT_EVENT_BUS_SESSION_ID", "env-session-id")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+
+        cli.cmd_events(make_events_args(session_id="explicit-id"))
+
+        assert mock_call.call_args[0][1]["session_id"] == "explicit-id"
+
+    @patch("agent_event_bus.cli.call_tool")
+    def test_resume_satisfied_by_claude_code_session_id(self, mock_call, monkeypatch):
+        """--resume needs a session id from somewhere; the fallback supplies
+        one, so a drain hook running in a non-interactive shell no longer
+        exits 1 with 'requires --session-id'."""
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session-id")
+        mock_call.return_value = {"events": [], "next_cursor": None}
+
+        cli.cmd_events(make_events_args(resume=True))
+
+        assert mock_call.call_args[0][1]["session_id"] == "cc-session-id"
 
     @patch("agent_event_bus.cli.call_tool")
     def test_resume_satisfied_by_env_session_id(self, mock_call, monkeypatch):


### PR DESCRIPTION
Closes the last gap in #128. Verified on the Mac mini after evansenter/dotfiles#328 merged — the mapping that PR added never fires where it matters.

## What's actually broken

#128 made the CLI read `AGENT_EVENT_BUS_SESSION_ID` when `--session-id` is omitted, and dotfiles#328 mapped `CLAUDE_CODE_SESSION_ID` onto it from `~/.exports`. But `~/.exports` is sourced from `~/.zshrc`, and **zsh reads `.zshrc` for interactive shells only**. Tool-spawned subprocesses are non-interactive, so the mapping never runs and every publish from one lands as `anonymous` — precisely the bug #128 exists to fix.

Measured on the host:

```
printenv AGENT_EVENT_BUS_SESSION_ID  ->  (unset)
printenv CLAUDE_CODE_SESSION_ID      ->  000a712d-…   (= the SessionStart registered id)
zsh -i -c '…'                        ->  fires correctly
zsh    -c '…'                        ->  empty
```

## Correcting the record

dotfiles#328's PR body scoped the residual risk to *"the macOS login-shell chain"*, and I repeated that in the merge commit. **That misattributed it.** This is shell startup semantics, not an OS difference — it reproduces identically on Linux under `zsh -c`. The original container verification passed only because container checks either source `.exports` directly or run an interactive/login shell, so the `.zshrc` gating never applied.

## Why fix it here rather than in the dotfiles

- The CLI fallback holds for **every shell, spawner, and machine**. The failure we hit was "we assumed a file gets sourced and it isn't"; an rc-file fix trades that assumption for a different one about zsh startup ordering.
- The dotfiles alternative — move the mapping to `~/.zshenv`, which non-interactive zsh *does* read — is not the one-line move it appears to be: `home/.zshenv` **is not tracked** in that repo (only `.exports`, `.zshrc`, `.zsh_prompt` are), so it needs a new repo file, a bootstrap symlink, and reconciliation with the existing unmanaged `~/.zshenv`.
- The `.exports` mapping stays valid and harmless for interactive shells, and keeps working if this fallback is ever removed.

## Precedence

Pinned by tests on **both** call sites (`publish` and `events`):

```
--session-id  >  $AGENT_EVENT_BUS_SESSION_ID  >  $CLAUDE_CODE_SESSION_ID
```

`AGENT_EVENT_BUS_SESSION_ID` stays ahead of the fallback because it's the tool-agnostic knob — an operator who sets it deliberately shouldn't be overridden by the ambient one Claude Code happens to inject.

## Test-environment fix worth calling out

Added an autouse scrub of both names to `test_cli.py`. `CLAUDE_CODE_SESSION_ID` is injected into the subprocess running the suite, so without the scrub an ambient value silently satisfies the assertions that expect **no** attribution — the suite would pass on a developer's machine and fail in CI, or the reverse. The pre-existing `test_no_env_no_flag_omits_session_id` would have started failing for exactly this reason.

## Testing

`make check` green: **576 passed** (569 + 7).

Empirically confirmed in the broken shape (explicit var unset, non-interactive):

```
AGENT_EVENT_BUS_SESSION_ID: None
CLAUDE_CODE_SESSION_ID    : 067fd316-…
resolved attribution      : 067fd316-…
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R)_