### PR TITLE
Cleanup pass before feature work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ src/agent_event_bus/
 
 ## MCP Tools
 
-`register_session`, `list_sessions`, `list_channels`, `publish_event`, `get_events`, `unregister_session`, `notify`, `register_webhook`, `list_webhooks`, `unregister_webhook`
+`register_session`, `list_sessions`, `list_channels`, `publish_event`, `get_events`, `unregister_session`, `notify`, `register_webhook`, `list_webhooks`, `set_webhook_active`, `unregister_webhook`
 
 **Usage guide**: `agent-event-bus://guide` resource. Keep it updated when changing APIs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ src/agent_event_bus/
 ├── cli.py         # CLI wrapper for shell scripts
 ├── bridge.py      # Webhook→injection re-awakening bridge (RFC #122, experimental)
 └── guide.md       # Usage guide (agent-event-bus://guide resource)
+
+docs/BRIDGE.md     # Bridge operator docs - deliberately NOT in guide.md, which
+                   # is served as an MCP resource into every session that reads it
 ```
 
 ## MCP Tools
@@ -202,5 +205,6 @@ Notifications: Uses terminal-notifier if installed (`brew install terminal-notif
 ## See Also
 
 - **Usage patterns, event types, channels**: `agent-event-bus://guide` or `src/agent_event_bus/guide.md`
+- **Re-awakening bridge (operators)**: `docs/BRIDGE.md`
 - **CLI usage**: `agent-event-bus-cli --help`
 - **Installation**: `README.md`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Ensure `~/.local/bin` is in PATH: `export PATH="$HOME/.local/bin:$PATH"`
 | `notify` | System notification |
 | `register_webhook` | Register HTTP endpoint for push notifications |
 | `list_webhooks` | List registered webhooks |
+| `set_webhook_active` | Pause/resume a webhook without unregistering |
 | `unregister_webhook` | Remove a webhook |
 
 ## Channels
@@ -110,8 +111,7 @@ Push events to HTTP endpoints instead of polling. Webhooks are called asynchrono
 mechanism: a daemon that wakes idle sessions when an actionable DM arrives
 (RFC #122). Run it as `uv run agent-event-bus-bridge` from the checkout -
 unlike the CLI, nothing symlinks it onto PATH until the supervision story
-lands. See the "Re-awakening Bridge" section of the usage guide
-(`agent-event-bus://guide`).
+lands. See [`docs/BRIDGE.md`](docs/BRIDGE.md).
 
 ### MCP
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ register_webhook(url="https://...", event_types=["task_completed", "help_needed"
 register_webhook(url="https://...", secret="your-shared-secret")
 
 # List and manage
-list_webhooks()
+list_webhooks()                                  # active_only=False also shows paused
+set_webhook_active(webhook_id=1, active=False)   # pause, keeping the registration
 unregister_webhook(webhook_id=1)
 ```
 
@@ -140,10 +141,15 @@ unregister_webhook(webhook_id=1)
 agent-event-bus-cli webhook register --url https://your-server.com/events
 agent-event-bus-cli webhook register --url https://... --channel "session:" --secret "my-secret"
 
-# List
+# List (paused webhooks only show under --all)
 agent-event-bus-cli webhook list
+agent-event-bus-cli webhook list --all
 
-# Remove
+# Pause / resume - keeps the URL, filters, and secret
+agent-event-bus-cli webhook disable 1
+agent-event-bus-cli webhook enable 1
+
+# Remove (permanent)
 agent-event-bus-cli webhook unregister 1
 ```
 

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -165,6 +165,7 @@ That lands with the supervision story.)
   types the wake prompt into whatever now owns the pane (usually a shell
   after the session exits), so the maintainer of `panes.json` should prune
   entries when sessions end.
+
 ## Loop prevention and single-instance
 
 - Per-session cooldown (default 30s, `--cooldown`) bounds *successful tmux
@@ -197,6 +198,7 @@ That lands with the supervision story.)
   different uid-scoped lock dirs, so they do not contend - give each user's
   bridge a distinct `--port`/`--hook-url` there. Embedders manage their own
   single-instance story.
+
 ## Security and operation
 
 - Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
@@ -253,7 +255,8 @@ That lands with the supervision story.)
   loopback literal, or any value listed with `--allowed-hosts` - the same
   allowlist covers both endpoints, so a monitoring probe arriving through
   the same reverse proxy as the deliveries passes on the proxy's Host.
-### Delivery outcomes
+
+## Delivery outcomes
 
 - Each delivered `200` carries an `action` field naming what happened:
   `spool` (spool backend, working as designed), `tmux` (wake injected),

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -174,12 +174,15 @@ That lands with the supervision story.)
   the cooldown never engages - a spool line only becomes a wake when the
   drain hook acts on it, so loop prevention there is the consuming hook's
   job: bound how often you act on a drained spool, and dedupe on `event_id`.
-- Startup is idempotent: stale active webhooks at this bridge's URL (from
-  unclean exits) are removed before registering, so restarts never stack
-  duplicate deliveries. The sweep matches the URL being registered NOW -
-  after changing `--port` or `--hook-url`, drop the row at the old URL
-  yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
-  the bus keeps dispatching to the dead address forever. Because that sweep
+- Startup is idempotent: stale webhooks at this bridge's URL (from unclean
+  exits) are removed before registering, so restarts never stack duplicate
+  deliveries. Paused rows are swept too - a row at this URL is stale whether
+  or not someone disabled it. The sweep matches the URL being registered
+  NOW - after changing `--port` or `--hook-url`, drop the row at the old URL
+  yourself (`agent-event-bus-cli webhook list --all` / `webhook unregister`)
+  or the bus keeps dispatching to the dead address forever. Use `--all`:
+  plain `webhook list` hides paused rows, so a disabled one at the old URL
+  would look like nothing to clean up. Because that sweep
   can't tell a stale row from a *live peer's*, the CLI takes two flock'd
   singletons at startup (both released on exit): one keyed on the **hook
   URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR`, else

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -1,0 +1,326 @@
+# Re-awakening Bridge (experimental)
+
+`agent-event-bus-bridge` is the experimental consumer of the bus's webhook
+subsystem (RFC #122). It is documented here rather than in
+`agent-event-bus://guide` because that guide is loaded as an MCP resource
+into working sessions, and this is operator documentation for a component
+most sessions never run.
+
+**Status: prototype.** No install target, no supervision story, and the
+addressability and durability caveats below are real. See issue #122.
+
+---
+
+It closes the pull-only delivery gap: a small localhost daemon that
+registers a webhook on the bus, filters to **actionable** events on
+**`session:` channels** (DMs), and wakes the target session. Broadcast events stay pull-only. Address DMs by **`session_id`**
+(the UUID) - `display_id` is display-only bus-wide, so a
+`session:<display-id>` event still spools (a `session:` channel is
+actionable unless the publisher overrides `signal_level`) but into a file
+no drain hook ever reads. One more addressability caveat: a session
+registered with a `client_id` adopts it as its `session_id` verbatim, and
+the bridge can only wake ids matching `[A-Za-z0-9_-]{1,64}` (the id
+becomes a spool filename). A `client_id` carrying a `.`, `/`, space, or
+over 64 chars (a cwd- or `repo:branch`-derived key) registers fine but is
+unwakeable - its DMs resolve to no target and log only a rate-limited
+"unsafe session id" warning. Keep `client_id` within that charset until
+bus-side validation lands.
+
+## Running it
+
+```
+uv run agent-event-bus-bridge                    # spool backend (default)
+uv run agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
+```
+
+(`uv run` from the repo checkout: the console script lives in the project
+venv - unlike `agent-event-bus-cli`, nothing symlinks it onto PATH yet.
+That lands with the supervision story.)
+
+## Backends
+
+- **spool**: every wake event is appended to
+  `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
+  drain. This path is always on, in every backend, and durable against
+  bridge and session crashes - but the append is not fsync'ed, so a
+  host-level crash (kernel panic, power loss) inside the writeback window
+  can lose a wake the bus already counted delivered; fsync-on-append is an
+  accepted follow-up. Each line is the bus's webhook payload passed through
+  verbatim: `event_id`, `event_type`, `payload`, `session_id` (the
+  **sender**, not the wake target - the target is the file's name, also in
+  the `session:<id>` channel), `timestamp`, `channel`, `correlation_id`,
+  `signal_level`, plus `title`/`tags` only when the publisher set them.
+  `signal_level` is always `actionable` on a spooled line by construction
+  (the bridge filters before spooling), so a hook need not re-check it -
+  and pass-through means bus-side payload additions appear additively:
+  read the keys you know, ignore the rest. Each line is UTF-8, STANDARD
+  JSON (`json.dumps`, one object per line) - the hook rejects the
+  non-standard `NaN`/`Infinity` literals at the door, so every spooled line
+  parses in `jq`, `JSON.parse`, and Go's `encoding/json`. Read it as UTF-8,
+  not the drain hook's locale codec. Drain contract:
+  1. Take an exclusive `flock` on `<sid>.lock`, creating it if absent
+     (`O_CREAT`, mode `0o600` to match the bridge and the create-mode rule
+     above). The bridge only creates `<sid>.lock` inside the first append
+     for that session, so a hook firing for a session with no spool yet -
+     the common case - opens a lock that does not exist; a drainer that
+     treats ENOENT as "nothing to drain" would skip locking on the very run
+     a spool appears concurrently. The bridge holds the same
+     flock around every append, so the rename below can't slip between the
+     bridge's open and its flush (an fd follows the inode, not the name -
+     without the lock a just-appended line could land in a file the drainer
+     already read). The bridge's acquire is bounded (~2s - it must stay
+     under the bus's 5s webhook timeout), so keep your hold to the
+     renames below - never drain while holding the lock; even a ~2s hold
+     turns a concurrent delivery into a bus-side timeout and retry.
+  2. Under the lock, claim a batch by rename (renames only, so the hold
+     stays short). Pick a claim id `<uniq>` unique to THIS drain - pid
+     plus a timestamp, or an mktemp-style suffix. Pid alone is NOT
+     unique: pids recycle (across reboots, or between two drains of the
+     same session), and rename silently replaces an existing target, so
+     a recycled pid would destroy a dead drain's batch with its own
+     claim. Every claim targets `<sid>.jsonl.draining.<uniq>.<seq>`
+     with one counter shared across the drain's claims. First claim the
+     live spool (if it exists):
+     `mv <sid>.jsonl <sid>.jsonl.draining.<uniq>.0`. Then claim each
+     stale `<sid>.jsonl.draining.*` not carrying your own claim id onto
+     the next counter value (`.1`, `.2`, ...) - a drain that died
+     mid-protocol (hook timeout, session exit, reboot) leaves one
+     behind; judge staleness by age (e.g. mtime over a minute old), not
+     pid liveness, for the same recycling reason. `touch` each file as
+     part of claiming it: rename preserves the file's mtime (a claim
+     would otherwise carry its last-append time and read as stale
+     immediately), and the touch makes age mean time-since-claim.
+     Release the lock.
+  3. Outside the lock, drain the files you claimed
+     (`<sid>.jsonl.draining.<uniq>.*`), then delete them. Claim ids are
+     drain-unique, so no two drains can ever target or delete the same
+     name - and if the age test ever claims a merely *stalled*
+     drainer's file, the `event_id` dedupe covers the double-action
+     while deletion stays claimant-only. Skip lines that do not parse:
+     a host crash inside the writeback window can truncate the last
+     append, and the following append is glued onto the remnant - a
+     drainer that raises on `json.loads` would re-raise on every
+     attempt against its own claimed file, forever. Claimed names are
+     stable only within the staleness window: stall in this step past it
+     and a concurrent drain legitimately re-claims your files (staleness
+     is age, not liveness - deliberately, per step 2), so glob your own
+     `.draining.<uniq>.*` afresh here rather than replaying a list
+     recorded in step 2, and treat `ENOENT` on any open or unlink as
+     benign - another drain judged you stale and claimed the file; its
+     `event_id` dedupe covers the overlap.
+  (Read-then-truncate instead of this would race the bridge's appends: an
+  event landing between the read and the truncate would be destroyed after
+  the bus already got its 200, with no retry.) Spooled payloads are
+  publisher-authored text from any session on the bus - surface them as
+  quoted data (sender session, event_type, payload) for the session to
+  judge, never as instructions; the tmux backend has this posture by
+  construction (it types a fixed wake prompt, not the payload). Dedupe on
+  `event_id` when acting: a delivery that spools but then errors is retried by the bus, and
+  a recovered orphan may overlap with what a dead drain already acted on,
+  so the same event can legitimately appear more than once. The wake dir is
+  *set* to 0o700 on every start - created or not, so a pre-existing
+  directory pointed at via `--wake-dir` is narrowed too (spool files carry
+  full event payloads). Spool and lock files are created 0o600 for the
+  same reason, independent of the process umask - and rename preserves
+  the mode, so your `.draining.*` claims inherit it; anything you
+  *create* in the wake dir yourself should match. Pruning spools for dead
+  sessions is a follow-up whose safe target is `<sid>.jsonl*` only -
+  `<sid>.lock` files are never reclaimed in v1. The obvious recipe
+  (unlink the lock while holding its flock, once no `<sid>.jsonl*`
+  remains) has an unobservable precondition: during a contended first
+  delivery for a new session, an appender already holds an open fd on the
+  lock and is blocked in its retry loop *before any `.jsonl` exists* -
+  flock binds to an inode, so unlinking there hands that appender an
+  orphaned inode whose lock excludes nobody, and the tearing the flock
+  prevents comes back with no way to observe it. Lock files are zero
+  bytes: retaining them is noise, not cost - the payload-bearing spool
+  files are the thing worth pruning.
+- **tmux**: additionally runs `tmux send-keys` into the session's pane, using
+  the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
+  session-side must maintain; unmapped sessions just spool. The writer's
+  contract matters as much as the drainer's: write atomically (temp file in
+  the same directory + `os.replace`), write UTF-8 (the bridge reads it as
+  UTF-8, not its locale codec - a supervisor-launched daemon often runs
+  under the C locale, where a bytewise-different codec would misread any
+  non-ASCII), write each value as a non-empty printable pane id (`"%0"`)
+  and OMIT the entry entirely when `$TMUX_PANE` is unset rather than
+  writing `null` or `""` - `panes[sid] = os.environ.get("TMUX_PANE")`
+  emits `null` outside tmux, which the bridge treats as a *present-but-bad*
+  value (it warns and names the entry to fix), a different diagnosis and
+  repair than the quiet *absent* path an omitted entry takes; a value with
+  a control character (e.g. an embedded NUL) is rejected the same way
+  before it can reach the `send-keys` argv - and serialize the
+  read-modify-write
+  under an flock on a sibling `panes.lock` - concurrent SessionStart hooks
+  otherwise silently lose entries (the loser reads as absent, the
+  documented *normal* outcome, so nothing errors on either side), and a
+  non-atomic in-place write produces the torn read the bridge degrades on.
+  A broken writer never surfaces as an error - only as wakes that quietly
+  never happen. Requires a tmux
+  binary on the daemon's PATH at startup - the bridge REFUSES TO START
+  otherwise, and the check is PATH-sensitive: a supervisor's minimal PATH
+  (launchd defaults to `/usr/bin:/bin:/usr/sbin:/sbin`) can hide a Homebrew
+  tmux your shell sees, so put tmux on the daemon's PATH, not just yours.
+  A tmux that breaks *later* degrades per-wake to spool instead. A stale mapping
+  types the wake prompt into whatever now owns the pane (usually a shell
+  after the session exits), so the maintainer of `panes.json` should prune
+  entries when sessions end.
+## Loop prevention and single-instance
+
+- Per-session cooldown (default 30s, `--cooldown`) bounds *successful tmux
+  injections*; events during cooldown are spooled, never dropped, and a
+  failed tmux attempt doesn't burn the window. In the default spool backend
+  the cooldown never engages - a spool line only becomes a wake when the
+  drain hook acts on it, so loop prevention there is the consuming hook's
+  job: bound how often you act on a drained spool, and dedupe on `event_id`.
+- Startup is idempotent: stale active webhooks at this bridge's URL (from
+  unclean exits) are removed before registering, so restarts never stack
+  duplicate deliveries. The sweep matches the URL being registered NOW -
+  after changing `--port` or `--hook-url`, drop the row at the old URL
+  yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
+  the bus keeps dispatching to the dead address forever. Because that sweep
+  can't tell a stale row from a *live peer's*, the CLI takes two flock'd
+  singletons at startup (both released on exit): one keyed on the **hook
+  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR`, else
+  the system temp dir - `$TMPDIR`, or `/tmp` when unset; the dir is
+  create-and-verified private, not adopted - HOME-independent so a second
+  instance registering the same URL refuses *regardless of wake dir or
+  `$HOME`* - the URL is what the sweep contends on), and one on the **wake
+  dir** (`bridge.singleton.lock` there -
+  two bridges would otherwise interleave the same spool files). To run two
+  bridges at once they need BOTH a distinct hook URL (a different `--port`
+  *and* `--hook-url`) and a distinct `--wake-dir`; changing only
+  `--wake-dir` leaves the hook URL colliding, and changing only the port
+  leaves the wake dir colliding. One case is out of scope for v1: two
+  *different Unix users* on one machine sharing a bus (the loopback-trusting
+  auth lets a second account's default bus URL land on the first's bus) get
+  different uid-scoped lock dirs, so they do not contend - give each user's
+  bridge a distinct `--port`/`--hook-url` there. Embedders manage their own
+  single-instance story.
+## Security and operation
+
+- Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
+  hop (the bridge registers its webhook with the same secret).
+- The hook body is capped at 1 MiB (the HMAC can only be checked after
+  buffering the whole body, so the cap bounds what an unauthenticated peer
+  can make the bridge hold). The bus does not cap event payloads, so a DM
+  larger than that is refused (413, retried twice, then dropped) and stays
+  pull-only: it reaches the session by polling, never as a wake.
+- `POST /hook` carries two browser guards, because "loopback needs no
+  secret" is only true if a page in the operator's browser cannot reach
+  the handler. (1) It requires `Content-Type: application/json` (415
+  otherwise) - what the bus's dispatch always sends. A *cross-origin* page
+  can POST preflight-free via `fetch(mode:"no-cors")` only with a
+  CORS-safelisted content type (text/plain et al); requiring the bus's
+  media type forces a preflight the bridge never answers. (2) It requires
+  a recognized `Host` (421 otherwise): loopback literals, the hook URL's
+  hostname, and the bound interface's address when `--bind` pins a
+  non-wildcard one (so a monitoring probe can address it by IP). This closes
+  DNS rebinding, where the attacker page is *same-origin* (served from
+  `evil.example:<port>`, A record then flipped to 127.0.0.1) so CORS never
+  applies - but the browser fills `Host` from the page's URL, so a rebound
+  request necessarily carries the attacker's hostname, never a loopback
+  literal or the bound address; allowlisting the bind address weakens
+  nothing. Both guards run in middleware ahead of routing, so a 405/404
+  cannot confirm a bridge is here either. Neither authenticates the
+  *sender* - that is the secret's job, and off-box topologies still require
+  it. When poking the endpoint with `curl`, send the JSON content type and
+  address the bridge by a loopback literal, the hook URL's hostname, or the
+  bound address.
+
+  **Behind a reverse proxy**, list the `Host` it forwards with
+  `--allowed-hosts` (comma-separated, or `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`).
+  nginx's `proxy_pass` rewrites `Host` to the *upstream* address unless the
+  operator adds `proxy_set_header Host $host`, and that rewritten value is in
+  no derived entry: a non-loopback hook URL derives the wildcard bind
+  `0.0.0.0`, which is deliberately not allowlisted, and pinning `--bind`
+  instead would drop the wildcard (and cannot cover a proxy rewriting to a
+  *name* at all). Without it every forwarded dispatch 421s while `/health`
+  still reports `registered: true`. The bridge log names the rejected `Host`
+  and this flag on the first rejection.
+- `GET /health` reports `registered`: whether the *startup* registration
+  succeeded. The row is not re-verified afterwards, so unregistering the
+  webhook by hand (or restoring the bus DB from a backup) leaves
+  `registered: true` on a bridge the bus no longer dispatches to - restart
+  the bridge after manual webhook surgery. Periodic re-assertion is a
+  follow-up. `/health` carries the same `Host` allowlist as `/hook` (421
+  otherwise) - a supervisor probing `http://127.0.0.1:<port>/health` sends
+  a loopback `Host` and passes, but a rebound browser tab cannot even
+  confirm a bridge runs here. Probe it by a loopback literal, the hook
+  URL's hostname, or the bound address *when `--bind` pins a specific one* -
+  under a wildcard bind (the derived default for a non-loopback hook URL)
+  the bind is not in the allowlist, so probe by the hook URL hostname, a
+  loopback literal, or any value listed with `--allowed-hosts` - the same
+  allowlist covers both endpoints, so a monitoring probe arriving through
+  the same reverse proxy as the deliveries passes on the proxy's Host.
+### Delivery outcomes
+
+- Each delivered `200` carries an `action` field naming what happened:
+  `spool` (spool backend, working as designed), `tmux` (wake injected),
+  `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
+  backend, no usable pane mapping - *normally* because the session lives
+  on another machine, but also when `panes.json` is missing, unreadable,
+  malformed, or its entry is not a pane id; the misconfiguration shapes
+  warn, so check the log), or `spool-tmux-failed` (the `send-keys` attempt itself
+  failed). Only the last one means tmux is broken on this host. The bus
+  discards the response body (it logs just the status code, at debug), so
+  `action` is visible only to a direct caller of `/hook` - the bridge's own
+  log is the operator-facing surface: failed wakes at warning, the quiet
+  arms (`spool-unmapped`, `spool-cooldown`) at debug under `DEV_MODE=1`.
+
+## Flags and environment variables
+
+Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
+`--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,
+`--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
+`--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
+`--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
+`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_WAKE_DIR`
+deliberately lacks the `_BRIDGE_` infix its siblings carry: the wake dir is
+the one bridge setting a *non-bridge* process (the drain hook) must also
+read, so its name must not read as bridge-internal.
+`AGENT_EVENT_BUS_BRIDGE_SECRET` is
+deliberately env-only - a `--secret` flag would expose the value in `ps`
+output and shell history. `DEV_MODE=1` turns on debug logging (the
+per-event reasons a delivery did nothing) - the same switch the bus server
+honors.
+
+## Remote-bus topology
+
+The defaults assume the bus runs on the same
+machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
+loopback hook URL would make the bus POST to *itself* - silently - so the
+bridge refuses to start unless `--hook-url` advertises an address the bus
+host can reach (e.g. your Tailscale hostname). The listener then binds
+non-loopback, and the bridge refuses to start without
+`AGENT_EVENT_BUS_BRIDGE_SECRET`: the HMAC signature is the only
+authentication on that hop - and it authenticates but neither encrypts nor
+expires, so run the hop over an encrypted transport (your tailnet, or a TLS
+terminator); replay freshness is an RFC-level follow-up. `--bind` can pin
+the listener to a single interface (e.g. the tailnet address) instead of
+all interfaces - any non-loopback bind requires the secret too. `/health`
+is intentionally unauthenticated (readiness probes shouldn't need the
+secret); it exposes only `status`/`service`/`registered`, but on a
+non-loopback bind anyone who can reach the port can read it. Keep `--port` and the port in `--hook-url` in agreement
+unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
+every `session:` DM; tmux wakes only work for sessions on the bridge's own
+machine, and spool files for foreign sessions accumulate until the pruning
+follow-up lands. That accumulation is unbounded in the adversarial case:
+`deliver` spools before any existence check and the id is only
+charset-validated, never checked against `list_sessions`, so any publisher
+on the bus can create a `<id>.jsonl`+`<id>.lock` pair for every distinct
+never-registered id it invents - two inodes and up to ~1 MiB each, at its
+publish rate. On a loopback-only bus that is the operator's own trust
+boundary; on the recommended tailnet topology it is any session on the
+shared bus. Pruning must bound this, not just the benign foreign-session
+case; the real fix is the `list_sessions`-based scoping tracked for v2,
+which drops unknown ids before they reach the filesystem. Machine-scoped
+delivery is a v2 item.
+
+## Supervision
+
+Supervision is deliberately out of scope for the v1 prototype: there is no
+`make install-bridge`, launchd plist, or systemd unit yet - run the bridge in
+a terminal (or your own supervisor) while experimenting. Startup ordering is
+already safe for a future supervisor (registration retries until the bus is
+up); unit files land once the prototype proves out (RFC #122).

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -179,19 +179,18 @@ That lands with the supervision story.)
   deliveries. Paused rows are swept too - a row at this URL is stale whether
   or not someone disabled it. The sweep matches the URL being registered
   NOW - after changing `--port` or `--hook-url`, drop the row at the old URL
-  yourself (`agent-event-bus-cli webhook list --all` / `webhook unregister`)
-  or the bus keeps dispatching to the dead address forever. Use `--all`:
-  plain `webhook list` hides paused rows, so a disabled one at the old URL
-  would look like nothing to clean up. Because that sweep
-  can't tell a stale row from a *live peer's*, the CLI takes two flock'd
-  singletons at startup (both released on exit): one keyed on the **hook
-  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR`, else
-  the system temp dir - `$TMPDIR`, or `/tmp` when unset; the dir is
-  create-and-verified private, not adopted - HOME-independent so a second
-  instance registering the same URL refuses *regardless of wake dir or
-  `$HOME`* - the URL is what the sweep contends on), and one on the **wake
-  dir** (`bridge.singleton.lock` there -
-  two bridges would otherwise interleave the same spool files). To run two
+  yourself (`agent-event-bus-cli webhook list --all` / `webhook unregister`;
+  `--all` because plain `list` hides paused rows) or the bus keeps
+  dispatching to the dead address forever.
+- Because that sweep can't tell a stale row from a *live peer's*, the CLI
+  takes two flock'd singletons at startup (both released on exit): one keyed
+  on the **hook URL** (in a machine- and uid-scoped lock dir under
+  `$XDG_RUNTIME_DIR`, else the system temp dir - `$TMPDIR`, or `/tmp` when
+  unset; the dir is create-and-verified private, not adopted -
+  HOME-independent so a second instance registering the same URL refuses
+  *regardless of wake dir or `$HOME`* - the URL is what the sweep contends
+  on), and one on the **wake dir** (`bridge.singleton.lock` there - two
+  bridges would otherwise interleave the same spool files). To run two
   bridges at once they need BOTH a distinct hook URL (a different `--port`
   *and* `--hook-url`) and a distinct `--wake-dir`; changing only
   `--wake-dir` leaves the hook URL colliding, and changing only the port

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -1351,13 +1351,20 @@ def register_with_bus(config: BridgeConfig) -> int:
     register_with_retry backs off on all of them.
 
     Idempotent: an unclean exit (SIGKILL, crash, reboot) skips main()'s
-    finally, leaving a stale active webhook at this URL - and the bus neither
-    dedupes by URL nor deactivates failing hooks, so each stale row would
-    duplicate every wake. Remove matching URLs before registering.
+    finally, leaving a stale webhook at this URL - and the bus neither dedupes
+    by URL nor deactivates failing hooks, so each stale row would duplicate
+    every wake. Remove matching URLs before registering.
     """
     hook_url = bridge_hook_url(config)
 
-    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
+    # active_only=False: a row at THIS bridge's hook URL is stale whether or
+    # not someone paused it, and the removal is a delete either way. Sweeping
+    # active-only would skip a paused row and add a second row at the same
+    # URL - and re-enabling the paused one then makes the bus dispatch every
+    # DM here twice. (Harmless until set_webhook_active existed, since
+    # `active` could never be 0; pausing a noisy hook is exactly the case
+    # that feature is for, and this endpoint fits it.)
+    existing = call_tool("list_webhooks", {"active_only": False}, url=config.bus_url)
     if not isinstance(existing, list):
         # Proceeding without the dedupe would stack the duplicate deliveries
         # this sweep exists to prevent - retryable failure, like the no-id

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -1433,9 +1433,9 @@ def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
     # Same accept-shape as the startup sweep: the bus reports logical
     # failure in-band (success-False dict), and already-gone is the goal
     # state. Shutdown stays best-effort, so a surprise is a warning here
-    # rather than the sweep's retryable BridgeRegistrationError - but the
-    # log must not
-    # assert a removal it never checked; the next startup sweep reclaims.
+    # rather than the sweep's retryable BridgeRegistrationError - but the log
+    # must not assert a removal it never checked; the next startup sweep
+    # reclaims.
     ok = isinstance(result, dict) and (
         result.get("success") or result.get("error") == "Webhook not found"
     )

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -65,7 +65,7 @@ from starlette.requests import ClientDisconnect, Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
-from agent_event_bus.cli import DEFAULT_URL, call_tool
+from agent_event_bus.cli import DEFAULT_URL, BusUnreachableError, call_tool
 
 # The header name is a wire contract with the bus - import it rather than
 # re-spelling it, the same coupling discipline as the tests building their
@@ -1331,12 +1331,24 @@ def bind_host(config: BridgeConfig) -> str:
     return "0.0.0.0"  # noqa: S104 - deliberate; secret enforced at config time
 
 
+class BridgeRegistrationError(Exception):
+    """A registration step failed in a way that should be retried.
+
+    Raised for the bus answering with something this module cannot act on (a
+    non-list webhook listing, a missing webhook_id, a refused removal). Every
+    such case is retryable, so register_with_retry backs off on it exactly as
+    it does on a BusUnreachableError - but it carries its own message, so the log
+    line names which step failed.
+    """
+
+
 def register_with_bus(config: BridgeConfig) -> int:
-    """Register this bridge's webhook on the bus. Returns webhook_id;
-    raises on any failure - SystemExit for this module's own named checks
-    and for call_tool's connection-error arm, the original transport
-    exception (debug=True) for everything else. register_with_retry treats
-    both shapes as retry-with-backoff.
+    """Register this bridge's webhook on the bus. Returns webhook_id.
+
+    Raises on any failure: BusUnreachableError when the bus is not up, whatever
+    call_tool lets through for a real transport fault (401, timeout, bad
+    body), and BridgeRegistrationError for this module's own named checks.
+    register_with_retry backs off on all of them.
 
     Idempotent: an unclean exit (SIGKILL, crash, reboot) skips main()'s
     finally, leaving a stale active webhook at this URL - and the bus neither
@@ -1345,19 +1357,12 @@ def register_with_bus(config: BridgeConfig) -> int:
     """
     hook_url = bridge_hook_url(config)
 
-    # debug=True: call_tool would otherwise funnel every failure into a bare
-    # SystemExit(1) with the real cause printed to stderr - a stream a
-    # supervisor may discard - leaving the retry loop logging
-    # "SystemExit(1)" for a 401, timeout, and bad body alike. With the flag,
-    # those re-raise and their repr reaches the daemon's own log; the one
-    # failure still funneled into a bare exit is a connection error, which
-    # the retry loop renders as exactly that.
-    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url, debug=True)
+    existing = call_tool("list_webhooks", {"active_only": True}, url=config.bus_url)
     if not isinstance(existing, list):
         # Proceeding without the dedupe would stack the duplicate deliveries
         # this sweep exists to prevent - retryable failure, like the no-id
         # case below
-        raise SystemExit(f"list_webhooks returned unexpected result: {existing!r}")
+        raise BridgeRegistrationError(f"list_webhooks returned unexpected result: {existing!r}")
     for wh in existing:
         # Guard the element shape too: an AttributeError here would
         # escape register_with_retry and kill the registration thread
@@ -1368,7 +1373,6 @@ def register_with_bus(config: BridgeConfig) -> int:
                 "unregister_webhook",
                 {"webhook_id": wh["webhook_id"]},
                 url=config.bus_url,
-                debug=True,
             )
             # unregister_webhook reports logical failure in-band (a
             # success-False dict) rather than raising, and call_tool only
@@ -1379,7 +1383,7 @@ def register_with_bus(config: BridgeConfig) -> int:
                 removal.get("success") or removal.get("error") == "Webhook not found"
             )
             if not ok:
-                raise SystemExit(
+                raise BridgeRegistrationError(
                     f"unregister_webhook #{wh['webhook_id']} returned "
                     f"unexpected result: {removal!r}"
                 )
@@ -1397,13 +1401,12 @@ def register_with_bus(config: BridgeConfig) -> int:
             **({"secret": config.secret} if config.secret else {}),
         },
         url=config.bus_url,
-        debug=True,
     )
     webhook_id = result.get("webhook_id") if isinstance(result, dict) else None
     if webhook_id is None:
         # A bus that answers but returns no id must be a retryable failure,
-        # not silent success - register_with_retry treats SystemExit as retry
-        raise SystemExit(f"register_webhook returned no webhook_id: {result!r}")
+        # not silent success
+        raise BridgeRegistrationError(f"register_webhook returned no webhook_id: {result!r}")
     logger.info(f"Registered bridge webhook #{webhook_id} on {config.bus_url}")
     return webhook_id
 
@@ -1411,25 +1414,20 @@ def register_with_bus(config: BridgeConfig) -> int:
 def unregister_from_bus(config: BridgeConfig, webhook_id: int) -> None:
     """Best-effort webhook cleanup on shutdown."""
     try:
-        result = call_tool(
-            "unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url, debug=True
-        )
-    except SystemExit:
-        # With debug=True the only failure call_tool still funnels into
-        # SystemExit is its connection-error arm - so this log line now
-        # reports a diagnosis it actually observed
+        result = call_tool("unregister_webhook", {"webhook_id": webhook_id}, url=config.bus_url)
+    except BusUnreachableError:
         logger.warning(f"Could not unregister webhook #{webhook_id} (bus unreachable)")
         return
     except Exception as e:
-        # Everything else re-raises with its cause (401, timeout, bad
-        # body); shutdown stays best-effort, but the one log line an
-        # operator has when a row leaks should carry the real reason
+        # 401, timeout, bad body. Shutdown stays best-effort, but the one log
+        # line an operator has when a row leaks should carry the real reason
         logger.warning(f"Could not unregister webhook #{webhook_id} ({e!r})")
         return
     # Same accept-shape as the startup sweep: the bus reports logical
     # failure in-band (success-False dict), and already-gone is the goal
     # state. Shutdown stays best-effort, so a surprise is a warning here
-    # rather than the sweep's retryable SystemExit - but the log must not
+    # rather than the sweep's retryable BridgeRegistrationError - but the
+    # log must not
     # assert a removal it never checked; the next startup sweep reclaims.
     ok = isinstance(result, dict) and (
         result.get("success") or result.get("error") == "Webhook not found"
@@ -1450,33 +1448,23 @@ def register_with_retry(
     """Keep trying to register until the bus is reachable (or stop is set).
 
     The bridge and the bus are typically launched by the same supervisor, so
-    "bus not up yet" is the normal case at boot - call_tool's SystemExit on
-    connection errors must not kill the daemon. Runs in a background thread
-    started from the app's startup hook, so the listener binds (essentially)
-    first and webhook deliveries have a live port to hit.
+    "bus not up yet" is the normal case at boot - a BusUnreachableError must not
+    kill the daemon. Runs in a background thread started from the app's
+    startup hook, so the listener binds (essentially) first and webhook
+    deliveries have a live port to hit.
     """
     delay = initial_delay
     while not stop.is_set():
         try:
             state["webhook_id"] = register_with_bus(config)
             return
-        # SystemExit is call_tool's failure shape; Exception covers the
-        # transport errors debug=True re-raises and anything unexpected
-        # inside register_with_bus - either way the thread must back off
-        # and retry, never die silently
-        except (SystemExit, Exception) as e:
-            # With debug=True at the call sites, a BARE SystemExit(1) means
-            # exactly one thing - call_tool's connection-error arm - so name
-            # it instead of logging "SystemExit(1)" for every cause alike
-            # (the real reason went to stderr, a stream a supervisor may
-            # discard). The bridge's own SystemExits carry their message.
-            reason = (
-                "bus unreachable (connection error)"
-                if isinstance(e, SystemExit) and e.code == 1
-                else repr(e)
-            )
+        # Every failure shape - unreachable bus, transport fault, this
+        # module's own named checks - is retryable here; the thread must
+        # back off, never die silently. Each carries its own message, so
+        # the log line names the real cause without inspecting exit codes.
+        except Exception as e:
             logger.warning(
-                f"Registration on {config.bus_url} failed ({reason}); retrying in {delay:.0f}s"
+                f"Registration on {config.bus_url} failed ({e!r}); retrying in {delay:.0f}s"
             )
         if stop.wait(delay):
             return

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -16,6 +16,8 @@ Usage:
     agent-event-bus-cli notify --title TITLE --message MSG [--sound]
     agent-event-bus-cli webhook register --url URL [--channel CH] [--event-types T1,T2] [--secret S]
     agent-event-bus-cli webhook list [--all]
+    agent-event-bus-cli webhook disable WEBHOOK_ID
+    agent-event-bus-cli webhook enable WEBHOOK_ID
     agent-event-bus-cli webhook unregister WEBHOOK_ID
 
 Examples:
@@ -415,6 +417,23 @@ def cmd_webhook_list(args):
         print()
 
 
+def cmd_webhook_set_active(args):
+    """Pause or resume a webhook, keeping its registration."""
+    # One handler behind two subcommands - the verb the user typed IS the
+    # desired state, so there is no flag to get backwards.
+    active = args.webhook_command == "enable"
+    result = call_tool(
+        "set_webhook_active",
+        {"webhook_id": args.webhook_id, "active": active},
+        url=args.url,
+    )
+    if result.get("success"):
+        print(f"Webhook #{args.webhook_id} {'enabled' if active else 'disabled'}")
+    else:
+        print(f"Failed: {result.get('error', 'Unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_webhook_unregister(args):
     """Unregister a webhook."""
     result = call_tool("unregister_webhook", {"webhook_id": args.webhook_id}, url=args.url)
@@ -577,6 +596,14 @@ def main():
     p_wh_list = webhook_subparsers.add_parser("list", help="List webhooks")
     p_wh_list.add_argument("--all", action="store_true", help="Include inactive webhooks")
     p_wh_list.set_defaults(func=cmd_webhook_list)
+
+    # webhook disable / enable - pause deliveries without losing the registration
+    for verb, effect in (("disable", "Pause"), ("enable", "Resume")):
+        p_wh_active = webhook_subparsers.add_parser(
+            verb, help=f"{effect} deliveries, keeping the registration"
+        )
+        p_wh_active.add_argument("webhook_id", type=int, help=f"Webhook ID to {verb}")
+        p_wh_active.set_defaults(func=cmd_webhook_set_active)
 
     # webhook unregister
     p_wh_unregister = webhook_subparsers.add_parser("unregister", help="Remove a webhook")

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -629,14 +629,16 @@ def main():
     # (SystemExit is not an Exception) passes through untouched.
     try:
         args.func(args)
-    except BusUnreachableError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        print("Start with: agent-event-bus", file=sys.stderr)
-        sys.exit(1)
     except Exception as e:
+        # --debug is checked before the friendly arms so it means one thing
+        # everywhere: give me the traceback. Handling BusUnreachableError
+        # first instead would swallow the stack for the single failure a user
+        # is most likely to be debugging when they reach for the flag.
         if args.debug:
             raise
         print(f"Error: {e}", file=sys.stderr)
+        if isinstance(e, BusUnreachableError):
+            print("Start with: agent-event-bus", file=sys.stderr)
         sys.exit(1)
 
 

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -82,26 +82,48 @@ HEADERS = {
 }
 
 
+class BusError(Exception):
+    """A call to the event bus failed."""
+
+
+class BusUnreachableError(BusError):
+    """Nothing answered at the bus URL - wrong address, or the bus is down.
+
+    Distinguished from every other failure because it is the one that means
+    "try again later" rather than "this request was wrong": the bridge
+    retries on it at boot, while a 401 or a malformed body is a real fault.
+    """
+
+
 def call_tool(
     tool_name: str,
     arguments: dict,
     url: str = DEFAULT_URL,
     timeout_ms: int | None = None,
-    debug: bool = False,
 ) -> dict:
     """Call an MCP tool and return the result.
+
+    Raises BusUnreachableError when nothing answers at `url`, and lets every other
+    failure (HTTP status, timeout, undecodable body) propagate with its own
+    type and message.
+
+    This is a library function, not a command: it never prints and never
+    exits. Rendering a failure and picking an exit code belong to main().
+    That split matters beyond tidiness - bridge.py imports this function, and
+    it needs to tell a retryable "bus not up yet" from a genuine fault by
+    exception type rather than by inspecting a process exit code.
 
     Args:
         tool_name: Name of the MCP tool to call
         arguments: Tool arguments
         url: Event bus URL
         timeout_ms: Timeout in milliseconds (default: 10000)
-        debug: If True, show full stack traces on errors
     """
     timeout_sec = (timeout_ms / 1000) if timeout_ms else 10
+    target = url or DEFAULT_URL
     try:
         resp = requests.post(
-            url or DEFAULT_URL,
+            target,
             headers=HEADERS,
             json={
                 "jsonrpc": "2.0",
@@ -112,30 +134,23 @@ def call_tool(
             timeout=timeout_sec,
         )
         resp.raise_for_status()
+    except requests.exceptions.ConnectionError as e:
+        raise BusUnreachableError(f"Cannot connect to agent event bus at {target}") from e
 
-        # Parse SSE response
-        for line in resp.text.split("\n"):
-            if line.startswith("data: "):
-                data = json.loads(line[6:])
-                result = data.get("result", {})
-                # Try structured content first, fall back to text
-                structured = result.get("structuredContent", {}).get("result")
-                if structured is not None:
-                    return structured
-                content = result.get("content", [])
-                if content and content[0].get("text"):
-                    return json.loads(content[0]["text"])
-                return result
-        return {}
-    except requests.exceptions.ConnectionError:
-        print("Error: Cannot connect to agent event bus. Is it running?", file=sys.stderr)
-        print("Start with: agent-event-bus", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        if debug:
-            raise
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    # Parse SSE response
+    for line in resp.text.split("\n"):
+        if line.startswith("data: "):
+            data = json.loads(line[6:])
+            result = data.get("result", {})
+            # Try structured content first, fall back to text
+            structured = result.get("structuredContent", {}).get("result")
+            if structured is not None:
+                return structured
+            content = result.get("content", [])
+            if content and content[0].get("text"):
+                return json.loads(content[0]["text"])
+            return result
+    return {}
 
 
 def cmd_register(args):
@@ -150,7 +165,7 @@ def cmd_register(args):
         arguments["client_id"] = args.client_id
     arguments["cwd"] = os.getcwd()
 
-    result = call_tool("register_session", arguments, url=args.url, debug=args.debug)
+    result = call_tool("register_session", arguments, url=args.url)
     print(json.dumps(result, indent=2))
 
     # Print session info for easy capture in scripts
@@ -174,7 +189,7 @@ def cmd_unregister(args):
         print("Error: Must provide --session-id or --client-id", file=sys.stderr)
         sys.exit(1)
 
-    result = call_tool("unregister_session", arguments, url=args.url, debug=args.debug)
+    result = call_tool("unregister_session", arguments, url=args.url)
 
     if "error" in result:
         print(f"Error: {result['error']}", file=sys.stderr)
@@ -185,7 +200,7 @@ def cmd_unregister(args):
 
 def cmd_sessions(args):
     """List active sessions."""
-    result = call_tool("list_sessions", {}, url=args.url, debug=args.debug)
+    result = call_tool("list_sessions", {}, url=args.url)
     if not result:
         print("No active sessions")
         return
@@ -216,7 +231,7 @@ def cmd_sessions(args):
 
 def cmd_channels(args):
     """List active channels."""
-    result = call_tool("list_channels", {}, url=args.url, debug=args.debug)
+    result = call_tool("list_channels", {}, url=args.url)
     if not result:
         print("No active channels")
         return
@@ -253,7 +268,7 @@ def cmd_publish(args):
     if args.signal_level:
         arguments["signal_level"] = args.signal_level
 
-    result = call_tool("publish_event", arguments, url=args.url, debug=args.debug)
+    result = call_tool("publish_event", arguments, url=args.url)
     print(json.dumps(result, indent=2))
 
 
@@ -288,9 +303,7 @@ def cmd_events(args):
     if args.min_level:
         arguments["min_level"] = args.min_level
 
-    result = call_tool(
-        "get_events", arguments, url=args.url, timeout_ms=args.timeout, debug=args.debug
-    )
+    result = call_tool("get_events", arguments, url=args.url, timeout_ms=args.timeout)
 
     # Check for server-side errors (e.g., session not found)
     if "error" in result:
@@ -351,7 +364,7 @@ def cmd_notify(args):
     if args.sound:
         arguments["sound"] = True
 
-    result = call_tool("notify", arguments, url=args.url, debug=args.debug)
+    result = call_tool("notify", arguments, url=args.url)
     if result.get("success"):
         print("Notification sent")
     else:
@@ -373,7 +386,7 @@ def cmd_webhook_register(args):
     if args.secret:
         arguments["secret"] = args.secret
 
-    result = call_tool("register_webhook", arguments, url=args.url, debug=args.debug)
+    result = call_tool("register_webhook", arguments, url=args.url)
     print(json.dumps(result, indent=2))
     if "webhook_id" in result:
         print(f"\nWebhook registered: #{result['webhook_id']}", file=sys.stderr)
@@ -382,7 +395,7 @@ def cmd_webhook_register(args):
 def cmd_webhook_list(args):
     """List registered webhooks."""
     arguments = {"active_only": not args.all}
-    result = call_tool("list_webhooks", arguments, url=args.url, debug=args.debug)
+    result = call_tool("list_webhooks", arguments, url=args.url)
 
     if not result:
         print("No webhooks registered")
@@ -404,12 +417,7 @@ def cmd_webhook_list(args):
 
 def cmd_webhook_unregister(args):
     """Unregister a webhook."""
-    result = call_tool(
-        "unregister_webhook",
-        {"webhook_id": args.webhook_id},
-        url=args.url,
-        debug=args.debug,
-    )
+    result = call_tool("unregister_webhook", {"webhook_id": args.webhook_id}, url=args.url)
     if result.get("success"):
         print(f"Webhook #{args.webhook_id} removed")
     else:
@@ -588,7 +596,21 @@ def main():
             p_webhook.print_help()
             sys.exit(1)
 
-    args.func(args)
+    # The one place that turns a failure into output and an exit code.
+    # call_tool and the cmd_* handlers stay quiet about transport failures so
+    # that policy lives here; a handler's own sys.exit for a logical error
+    # (SystemExit is not an Exception) passes through untouched.
+    try:
+        args.func(args)
+    except BusUnreachableError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print("Start with: agent-event-bus", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        if args.debug:
+            raise
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -22,6 +22,7 @@ CC sessions (e.g., in separate terminals or worktrees), this MCP server lets ses
 | `notify(title, message, sound?)` | System notification |
 | `register_webhook(url, channel?, event_types?, secret?)` | Register HTTP endpoint for push notifications |
 | `list_webhooks(active_only?)` | List registered webhooks |
+| `set_webhook_active(webhook_id, active)` | Pause/resume without unregistering |
 | `unregister_webhook(webhook_id)` | Remove a webhook |
 
 *Signatures simplified for quick start. Full parameters (machine, cwd, cursor, limit, channel, etc.) available - check MCP tool docstrings.*
@@ -304,318 +305,41 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
 - `event_types=["task_completed", "ci_completed"]` - Only these types
 - Omit for all event types
 
-### List and Remove Webhooks
+### List, Pause, and Remove Webhooks
 ```
-list_webhooks(active_only=True)
-→ [{webhook_id: 1, url: "...", has_secret: true, ...}]
+list_webhooks(active_only=True)   # active_only=False also shows paused ones
+→ [{webhook_id: 1, url: "...", active: true, has_secret: true, ...}]
+
+set_webhook_active(webhook_id=1, active=False)
+→ {success: true, webhook_id: 1, active: false}
 
 unregister_webhook(webhook_id=1)
 → {success: true, webhook_id: 1}
 ```
+
+Pausing stops deliveries but keeps the registration, its filters, and its
+secret - the right move for an endpoint that is failing or noisy but that
+you intend to bring back. Unregistering is permanent; re-adding means
+re-supplying the URL, filters, and secret.
 
 ### Retry Behavior
 Webhooks retry up to 2 times with exponential backoff if the endpoint returns 4xx/5xx or times out.
 
 ## Re-awakening Bridge (experimental)
 
-`agent-event-bus-bridge` closes the pull-only delivery gap (RFC #122): a
-small localhost daemon that registers a webhook on the bus, filters to
-**actionable** events on **`session:` channels** (DMs), and wakes the target
-session. Broadcast events stay pull-only. Address DMs by **`session_id`**
-(the UUID) - `display_id` is display-only bus-wide, so a
-`session:<display-id>` event still spools (a `session:` channel is
-actionable unless the publisher overrides `signal_level`) but into a file
-no drain hook ever reads. One more addressability caveat: a session
-registered with a `client_id` adopts it as its `session_id` verbatim, and
-the bridge can only wake ids matching `[A-Za-z0-9_-]{1,64}` (the id
-becomes a spool filename). A `client_id` carrying a `.`, `/`, space, or
-over 64 chars (a cwd- or `repo:branch`-derived key) registers fine but is
-unwakeable - its DMs resolve to no target and log only a rate-limited
-"unsafe session id" warning. Keep `client_id` within that charset until
-bus-side validation lands.
+Delivery to sessions is pull-only: a DM to an idle session sits unread until
+its human prompts it. `agent-event-bus-bridge` is the experimental daemon
+that closes that gap - it registers a webhook, filters to **actionable**
+events on **`session:` channels**, and wakes the target session (RFC #122).
 
-```
-uv run agent-event-bus-bridge                    # spool backend (default)
-uv run agent-event-bus-bridge --backend tmux     # also types a wake prompt into tmux
-```
+Operator documentation - backends, addressability caveats, hook contract,
+security model, flags - lives in [`docs/BRIDGE.md`](https://github.com/evansenter/agent-event-bus/blob/main/docs/BRIDGE.md),
+not here: it is guidance for running a daemon, and this guide is loaded into
+every session that reads the resource.
 
-(`uv run` from the repo checkout: the console script lives in the project
-venv - unlike `agent-event-bus-cli`, nothing symlinks it onto PATH yet.
-That lands with the supervision story.)
-
-- **spool**: every wake event is appended to
-  `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to
-  drain. This path is always on, in every backend, and durable against
-  bridge and session crashes - but the append is not fsync'ed, so a
-  host-level crash (kernel panic, power loss) inside the writeback window
-  can lose a wake the bus already counted delivered; fsync-on-append is an
-  accepted follow-up. Each line is the bus's webhook payload passed through
-  verbatim: `event_id`, `event_type`, `payload`, `session_id` (the
-  **sender**, not the wake target - the target is the file's name, also in
-  the `session:<id>` channel), `timestamp`, `channel`, `correlation_id`,
-  `signal_level`, plus `title`/`tags` only when the publisher set them.
-  `signal_level` is always `actionable` on a spooled line by construction
-  (the bridge filters before spooling), so a hook need not re-check it -
-  and pass-through means bus-side payload additions appear additively:
-  read the keys you know, ignore the rest. Each line is UTF-8, STANDARD
-  JSON (`json.dumps`, one object per line) - the hook rejects the
-  non-standard `NaN`/`Infinity` literals at the door, so every spooled line
-  parses in `jq`, `JSON.parse`, and Go's `encoding/json`. Read it as UTF-8,
-  not the drain hook's locale codec. Drain contract:
-  1. Take an exclusive `flock` on `<sid>.lock`, creating it if absent
-     (`O_CREAT`, mode `0o600` to match the bridge and the create-mode rule
-     above). The bridge only creates `<sid>.lock` inside the first append
-     for that session, so a hook firing for a session with no spool yet -
-     the common case - opens a lock that does not exist; a drainer that
-     treats ENOENT as "nothing to drain" would skip locking on the very run
-     a spool appears concurrently. The bridge holds the same
-     flock around every append, so the rename below can't slip between the
-     bridge's open and its flush (an fd follows the inode, not the name -
-     without the lock a just-appended line could land in a file the drainer
-     already read). The bridge's acquire is bounded (~2s - it must stay
-     under the bus's 5s webhook timeout), so keep your hold to the
-     renames below - never drain while holding the lock; even a ~2s hold
-     turns a concurrent delivery into a bus-side timeout and retry.
-  2. Under the lock, claim a batch by rename (renames only, so the hold
-     stays short). Pick a claim id `<uniq>` unique to THIS drain - pid
-     plus a timestamp, or an mktemp-style suffix. Pid alone is NOT
-     unique: pids recycle (across reboots, or between two drains of the
-     same session), and rename silently replaces an existing target, so
-     a recycled pid would destroy a dead drain's batch with its own
-     claim. Every claim targets `<sid>.jsonl.draining.<uniq>.<seq>`
-     with one counter shared across the drain's claims. First claim the
-     live spool (if it exists):
-     `mv <sid>.jsonl <sid>.jsonl.draining.<uniq>.0`. Then claim each
-     stale `<sid>.jsonl.draining.*` not carrying your own claim id onto
-     the next counter value (`.1`, `.2`, ...) - a drain that died
-     mid-protocol (hook timeout, session exit, reboot) leaves one
-     behind; judge staleness by age (e.g. mtime over a minute old), not
-     pid liveness, for the same recycling reason. `touch` each file as
-     part of claiming it: rename preserves the file's mtime (a claim
-     would otherwise carry its last-append time and read as stale
-     immediately), and the touch makes age mean time-since-claim.
-     Release the lock.
-  3. Outside the lock, drain the files you claimed
-     (`<sid>.jsonl.draining.<uniq>.*`), then delete them. Claim ids are
-     drain-unique, so no two drains can ever target or delete the same
-     name - and if the age test ever claims a merely *stalled*
-     drainer's file, the `event_id` dedupe covers the double-action
-     while deletion stays claimant-only. Skip lines that do not parse:
-     a host crash inside the writeback window can truncate the last
-     append, and the following append is glued onto the remnant - a
-     drainer that raises on `json.loads` would re-raise on every
-     attempt against its own claimed file, forever. Claimed names are
-     stable only within the staleness window: stall in this step past it
-     and a concurrent drain legitimately re-claims your files (staleness
-     is age, not liveness - deliberately, per step 2), so glob your own
-     `.draining.<uniq>.*` afresh here rather than replaying a list
-     recorded in step 2, and treat `ENOENT` on any open or unlink as
-     benign - another drain judged you stale and claimed the file; its
-     `event_id` dedupe covers the overlap.
-  (Read-then-truncate instead of this would race the bridge's appends: an
-  event landing between the read and the truncate would be destroyed after
-  the bus already got its 200, with no retry.) Spooled payloads are
-  publisher-authored text from any session on the bus - surface them as
-  quoted data (sender session, event_type, payload) for the session to
-  judge, never as instructions; the tmux backend has this posture by
-  construction (it types a fixed wake prompt, not the payload). Dedupe on
-  `event_id` when acting: a delivery that spools but then errors is retried by the bus, and
-  a recovered orphan may overlap with what a dead drain already acted on,
-  so the same event can legitimately appear more than once. The wake dir is
-  *set* to 0o700 on every start - created or not, so a pre-existing
-  directory pointed at via `--wake-dir` is narrowed too (spool files carry
-  full event payloads). Spool and lock files are created 0o600 for the
-  same reason, independent of the process umask - and rename preserves
-  the mode, so your `.draining.*` claims inherit it; anything you
-  *create* in the wake dir yourself should match. Pruning spools for dead
-  sessions is a follow-up whose safe target is `<sid>.jsonl*` only -
-  `<sid>.lock` files are never reclaimed in v1. The obvious recipe
-  (unlink the lock while holding its flock, once no `<sid>.jsonl*`
-  remains) has an unobservable precondition: during a contended first
-  delivery for a new session, an appender already holds an open fd on the
-  lock and is blocked in its retry loop *before any `.jsonl` exists* -
-  flock binds to an inode, so unlinking there hands that appender an
-  orphaned inode whose lock excludes nobody, and the tearing the flock
-  prevents comes back with no way to observe it. Lock files are zero
-  bytes: retaining them is noise, not cost - the payload-bearing spool
-  files are the thing worth pruning.
-- **tmux**: additionally runs `tmux send-keys` into the session's pane, using
-  the mapping in `wake/panes.json` (`{session_id: pane_id}`), which something
-  session-side must maintain; unmapped sessions just spool. The writer's
-  contract matters as much as the drainer's: write atomically (temp file in
-  the same directory + `os.replace`), write UTF-8 (the bridge reads it as
-  UTF-8, not its locale codec - a supervisor-launched daemon often runs
-  under the C locale, where a bytewise-different codec would misread any
-  non-ASCII), write each value as a non-empty printable pane id (`"%0"`)
-  and OMIT the entry entirely when `$TMUX_PANE` is unset rather than
-  writing `null` or `""` - `panes[sid] = os.environ.get("TMUX_PANE")`
-  emits `null` outside tmux, which the bridge treats as a *present-but-bad*
-  value (it warns and names the entry to fix), a different diagnosis and
-  repair than the quiet *absent* path an omitted entry takes; a value with
-  a control character (e.g. an embedded NUL) is rejected the same way
-  before it can reach the `send-keys` argv - and serialize the
-  read-modify-write
-  under an flock on a sibling `panes.lock` - concurrent SessionStart hooks
-  otherwise silently lose entries (the loser reads as absent, the
-  documented *normal* outcome, so nothing errors on either side), and a
-  non-atomic in-place write produces the torn read the bridge degrades on.
-  A broken writer never surfaces as an error - only as wakes that quietly
-  never happen. Requires a tmux
-  binary on the daemon's PATH at startup - the bridge REFUSES TO START
-  otherwise, and the check is PATH-sensitive: a supervisor's minimal PATH
-  (launchd defaults to `/usr/bin:/bin:/usr/sbin:/sbin`) can hide a Homebrew
-  tmux your shell sees, so put tmux on the daemon's PATH, not just yours.
-  A tmux that breaks *later* degrades per-wake to spool instead. A stale mapping
-  types the wake prompt into whatever now owns the pane (usually a shell
-  after the session exits), so the maintainer of `panes.json` should prune
-  entries when sessions end.
-- Per-session cooldown (default 30s, `--cooldown`) bounds *successful tmux
-  injections*; events during cooldown are spooled, never dropped, and a
-  failed tmux attempt doesn't burn the window. In the default spool backend
-  the cooldown never engages - a spool line only becomes a wake when the
-  drain hook acts on it, so loop prevention there is the consuming hook's
-  job: bound how often you act on a drained spool, and dedupe on `event_id`.
-- Startup is idempotent: stale active webhooks at this bridge's URL (from
-  unclean exits) are removed before registering, so restarts never stack
-  duplicate deliveries. The sweep matches the URL being registered NOW -
-  after changing `--port` or `--hook-url`, drop the row at the old URL
-  yourself (`agent-event-bus-cli webhook list` / `webhook unregister`) or
-  the bus keeps dispatching to the dead address forever. Because that sweep
-  can't tell a stale row from a *live peer's*, the CLI takes two flock'd
-  singletons at startup (both released on exit): one keyed on the **hook
-  URL** (in a machine- and uid-scoped lock dir under `$XDG_RUNTIME_DIR`, else
-  the system temp dir - `$TMPDIR`, or `/tmp` when unset; the dir is
-  create-and-verified private, not adopted - HOME-independent so a second
-  instance registering the same URL refuses *regardless of wake dir or
-  `$HOME`* - the URL is what the sweep contends on), and one on the **wake
-  dir** (`bridge.singleton.lock` there -
-  two bridges would otherwise interleave the same spool files). To run two
-  bridges at once they need BOTH a distinct hook URL (a different `--port`
-  *and* `--hook-url`) and a distinct `--wake-dir`; changing only
-  `--wake-dir` leaves the hook URL colliding, and changing only the port
-  leaves the wake dir colliding. One case is out of scope for v1: two
-  *different Unix users* on one machine sharing a bus (the loopback-trusting
-  auth lets a second account's default bus URL land on the first's bus) get
-  different uid-scoped lock dirs, so they do not contend - give each user's
-  bridge a distinct `--port`/`--hook-url` there. Embedders manage their own
-  single-instance story.
-- Set `AGENT_EVENT_BUS_BRIDGE_SECRET` to HMAC-authenticate the bus->bridge
-  hop (the bridge registers its webhook with the same secret).
-- The hook body is capped at 1 MiB (the HMAC can only be checked after
-  buffering the whole body, so the cap bounds what an unauthenticated peer
-  can make the bridge hold). The bus does not cap event payloads, so a DM
-  larger than that is refused (413, retried twice, then dropped) and stays
-  pull-only: it reaches the session by polling, never as a wake.
-- `POST /hook` carries two browser guards, because "loopback needs no
-  secret" is only true if a page in the operator's browser cannot reach
-  the handler. (1) It requires `Content-Type: application/json` (415
-  otherwise) - what the bus's dispatch always sends. A *cross-origin* page
-  can POST preflight-free via `fetch(mode:"no-cors")` only with a
-  CORS-safelisted content type (text/plain et al); requiring the bus's
-  media type forces a preflight the bridge never answers. (2) It requires
-  a recognized `Host` (421 otherwise): loopback literals, the hook URL's
-  hostname, and the bound interface's address when `--bind` pins a
-  non-wildcard one (so a monitoring probe can address it by IP). This closes
-  DNS rebinding, where the attacker page is *same-origin* (served from
-  `evil.example:<port>`, A record then flipped to 127.0.0.1) so CORS never
-  applies - but the browser fills `Host` from the page's URL, so a rebound
-  request necessarily carries the attacker's hostname, never a loopback
-  literal or the bound address; allowlisting the bind address weakens
-  nothing. Both guards run in middleware ahead of routing, so a 405/404
-  cannot confirm a bridge is here either. Neither authenticates the
-  *sender* - that is the secret's job, and off-box topologies still require
-  it. When poking the endpoint with `curl`, send the JSON content type and
-  address the bridge by a loopback literal, the hook URL's hostname, or the
-  bound address.
-
-  **Behind a reverse proxy**, list the `Host` it forwards with
-  `--allowed-hosts` (comma-separated, or `AGENT_EVENT_BUS_BRIDGE_ALLOWED_HOSTS`).
-  nginx's `proxy_pass` rewrites `Host` to the *upstream* address unless the
-  operator adds `proxy_set_header Host $host`, and that rewritten value is in
-  no derived entry: a non-loopback hook URL derives the wildcard bind
-  `0.0.0.0`, which is deliberately not allowlisted, and pinning `--bind`
-  instead would drop the wildcard (and cannot cover a proxy rewriting to a
-  *name* at all). Without it every forwarded dispatch 421s while `/health`
-  still reports `registered: true`. The bridge log names the rejected `Host`
-  and this flag on the first rejection.
-- `GET /health` reports `registered`: whether the *startup* registration
-  succeeded. The row is not re-verified afterwards, so unregistering the
-  webhook by hand (or restoring the bus DB from a backup) leaves
-  `registered: true` on a bridge the bus no longer dispatches to - restart
-  the bridge after manual webhook surgery. Periodic re-assertion is a
-  follow-up. `/health` carries the same `Host` allowlist as `/hook` (421
-  otherwise) - a supervisor probing `http://127.0.0.1:<port>/health` sends
-  a loopback `Host` and passes, but a rebound browser tab cannot even
-  confirm a bridge runs here. Probe it by a loopback literal, the hook
-  URL's hostname, or the bound address *when `--bind` pins a specific one* -
-  under a wildcard bind (the derived default for a non-loopback hook URL)
-  the bind is not in the allowlist, so probe by the hook URL hostname, a
-  loopback literal, or any value listed with `--allowed-hosts` - the same
-  allowlist covers both endpoints, so a monitoring probe arriving through
-  the same reverse proxy as the deliveries passes on the proxy's Host.
-- Each delivered `200` carries an `action` field naming what happened:
-  `spool` (spool backend, working as designed), `tmux` (wake injected),
-  `spool-cooldown` (within the per-session window), `spool-unmapped` (tmux
-  backend, no usable pane mapping - *normally* because the session lives
-  on another machine, but also when `panes.json` is missing, unreadable,
-  malformed, or its entry is not a pane id; the misconfiguration shapes
-  warn, so check the log), or `spool-tmux-failed` (the `send-keys` attempt itself
-  failed). Only the last one means tmux is broken on this host. The bus
-  discards the response body (it logs just the status code, at debug), so
-  `action` is visible only to a direct caller of `/hook` - the bridge's own
-  log is the operator-facing surface: failed wakes at warning, the quiet
-  arms (`spool-unmapped`, `spool-cooldown`) at debug under `DEV_MODE=1`.
-
-Flags mirror env vars: `--port`/`AGENT_EVENT_BUS_BRIDGE_PORT`,
-`--backend`/`AGENT_EVENT_BUS_BRIDGE_BACKEND`,
-`--cooldown`/`AGENT_EVENT_BUS_BRIDGE_COOLDOWN`,
-`--wake-dir`/`AGENT_EVENT_BUS_WAKE_DIR`, `--bus-url`/`AGENT_EVENT_BUS_URL`,
-`--hook-url`/`AGENT_EVENT_BUS_BRIDGE_HOOK_URL`,
-`--bind`/`AGENT_EVENT_BUS_BRIDGE_BIND`. `AGENT_EVENT_BUS_WAKE_DIR`
-deliberately lacks the `_BRIDGE_` infix its siblings carry: the wake dir is
-the one bridge setting a *non-bridge* process (the drain hook) must also
-read, so its name must not read as bridge-internal.
-`AGENT_EVENT_BUS_BRIDGE_SECRET` is
-deliberately env-only - a `--secret` flag would expose the value in `ps`
-output and shell history. `DEV_MODE=1` turns on debug logging (the
-per-event reasons a delivery did nothing) - the same switch the bus server
-honors.
-
-**Remote-bus topology**: the defaults assume the bus runs on the same
-machine. With a remote bus (`AGENT_EVENT_BUS_URL` pointing off-host), a
-loopback hook URL would make the bus POST to *itself* - silently - so the
-bridge refuses to start unless `--hook-url` advertises an address the bus
-host can reach (e.g. your Tailscale hostname). The listener then binds
-non-loopback, and the bridge refuses to start without
-`AGENT_EVENT_BUS_BRIDGE_SECRET`: the HMAC signature is the only
-authentication on that hop - and it authenticates but neither encrypts nor
-expires, so run the hop over an encrypted transport (your tailnet, or a TLS
-terminator); replay freshness is an RFC-level follow-up. `--bind` can pin
-the listener to a single interface (e.g. the tailnet address) instead of
-all interfaces - any non-loopback bind requires the secret too. `/health`
-is intentionally unauthenticated (readiness probes shouldn't need the
-secret); it exposes only `status`/`service`/`registered`, but on a
-non-loopback bind anyone who can reach the port can read it. Keep `--port` and the port in `--hook-url` in agreement
-unless a proxy genuinely forwards between them (a mismatch is logged). Note webhooks have no machine scoping - every bridge receives
-every `session:` DM; tmux wakes only work for sessions on the bridge's own
-machine, and spool files for foreign sessions accumulate until the pruning
-follow-up lands. That accumulation is unbounded in the adversarial case:
-`deliver` spools before any existence check and the id is only
-charset-validated, never checked against `list_sessions`, so any publisher
-on the bus can create a `<id>.jsonl`+`<id>.lock` pair for every distinct
-never-registered id it invents - two inodes and up to ~1 MiB each, at its
-publish rate. On a loopback-only bus that is the operator's own trust
-boundary; on the recommended tailnet topology it is any session on the
-shared bus. Pruning must bound this, not just the benign foreign-session
-case; the real fix is the `list_sessions`-based scoping tracked for v2,
-which drops unknown ids before they reach the filesystem. Machine-scoped
-delivery is a v2 item.
-
-Supervision is deliberately out of scope for the v1 prototype: there is no
-`make install-bridge`, launchd plist, or systemd unit yet - run the bridge in
-a terminal (or your own supervisor) while experimenting. Startup ordering is
-already safe for a future supervisor (registration retries until the bus is
-up); unit files land once the prototype proves out (RFC #122).
+If you are a session being woken, all you need is: drain
+`~/.claude/contrib/agent-event-bus/wake/<your session_id>.jsonl`, one JSON
+event per line, same field names as a webhook delivery.
 
 ## Best Practices
 

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -3,6 +3,7 @@
 Provides tools for cross-session Claude Code communication:
 - register_session: Announce session presence
 - list_sessions: See active sessions
+- list_channels: See channels with subscriber counts
 - publish_event: Broadcast events (auto-refreshes heartbeat)
 - get_events: Poll for new events (auto-refreshes heartbeat)
 - unregister_session: Clean up on exit
@@ -114,6 +115,11 @@ EVENT_TYPE_SIGNAL_LEVELS = {
     "ci_failed": "actionable",
     "error_broadcast": "actionable",
 }
+
+
+def _preview(text: str) -> str:
+    """Truncate a payload for a notification or log preview."""
+    return text[:MAX_PAYLOAD_PREVIEW] + "..." if len(text) > MAX_PAYLOAD_PREVIEW else text
 
 
 def _get_signal_level(event: Event) -> str:
@@ -242,14 +248,11 @@ def _notify_dm_recipient(
         # If sender not found, keep "anonymous" - don't log (normal during tests/cleanup)
 
     # Send notification to alert the human
-    payload_preview = (
-        payload[:MAX_PAYLOAD_PREVIEW] + "..." if len(payload) > MAX_PAYLOAD_PREVIEW else payload
-    )
     try:
         project_name = target_session.get_project_name()
         send_notification(
             title=f"📨 {target_session.name} • {project_name}",
-            message=f"From: {sender_name}\n{payload_preview}",
+            message=f"From: {sender_name}\n{_preview(payload)}",
         )
     except Exception as e:
         # Notification failure is non-critical, but log for debugging
@@ -470,10 +473,7 @@ def _publish_event_impl(
     # Dispatch to matching webhooks (async, non-blocking)
     _schedule_webhook_dispatch(event)
 
-    truncated = (
-        payload[:MAX_PAYLOAD_PREVIEW] + "..." if len(payload) > MAX_PAYLOAD_PREVIEW else payload
-    )
-    _dev_notify("publish_event", f"{event_type} [{channel}] {truncated}")
+    _dev_notify("publish_event", f"{event_type} [{channel}] {_preview(payload)}")
 
     result = {
         "event_id": event.id,
@@ -527,35 +527,40 @@ async def publish_event(
     )
 
 
-def _get_implicit_channels(session_id: str | None) -> list[str] | None:
-    """Get the channels a session is implicitly subscribed to.
+def _event_wire_dict(event: Event, *, id_key: str) -> dict:
+    """The one wire shape for an event, keyed by `id_key` for the event id.
 
-    Returns None to disable filtering - all sessions see all events (broadcast model).
-    Channel metadata is preserved on events for informational purposes.
+    Two consumers serialize the same event: get_events (as "id") and webhook
+    deliveries (as "event_id"). They differed only in that key, so they share
+    a builder - a field added for one is now automatically visible to the
+    other, and neither can silently drift from the other's `signal_level`.
+
+    Both spellings are wire contracts. The bridge resolves its wake target
+    from `channel`, filters on `signal_level`, and dedupes spool lines on
+    `event_id` (tests/test_bridge.py pins those keys), and the CLI reads the
+    get_events keys - so removing or renaming a key is a breaking change.
+    Additions are additive: consumers read the keys they know.
     """
-    # Broadcast model: everyone sees everything
-    # Explicit channel filtering via get_events(channel=X) still works if needed
-    return None
+    d = {
+        id_key: event.id,
+        "event_type": event.event_type,
+        "payload": event.payload,
+        "session_id": event.session_id,
+        "timestamp": event.timestamp.isoformat(),
+        "channel": event.channel,
+        "correlation_id": event.correlation_id,
+        "signal_level": _get_signal_level(event),
+    }
+    if event.meta:
+        for key in ("title", "tags"):
+            if key in event.meta:
+                d[key] = event.meta[key]
+    return d
 
 
 def _event_to_dict(e: Event) -> dict:
-    """Convert an Event to its wire representation."""
-    d = {
-        "id": e.id,
-        "event_type": e.event_type,
-        "payload": e.payload,
-        "session_id": e.session_id,
-        "timestamp": e.timestamp.isoformat(),
-        "channel": e.channel,
-        "correlation_id": e.correlation_id,
-        "signal_level": _get_signal_level(e),
-    }
-    if e.meta:
-        if "title" in e.meta:
-            d["title"] = e.meta["title"]
-        if "tags" in e.meta:
-            d["tags"] = e.meta["tags"]
-    return d
+    """An event as get_events returns it (event id under "id")."""
+    return _event_wire_dict(e, id_key="id")
 
 
 def _get_events_impl(
@@ -608,13 +613,10 @@ def _get_events_impl(
 
     storage.cleanup_stale_sessions()
 
-    # Determine channel filtering:
-    # - If explicit channel provided, filter to that channel
-    # - Otherwise, return all events (broadcast model)
-    if channel:
-        channels = [channel]
-    else:
-        channels = _get_implicit_channels(session_id)
+    # Broadcast model: with no explicit channel filter, every session sees
+    # every event. Channel is metadata on the event, not a subscription, so
+    # there is nothing implicit to derive from session_id.
+    channels = [channel] if channel else None
 
     raw_events, next_cursor, has_more = storage.get_events(
         cursor=cursor,
@@ -815,29 +817,12 @@ def _compute_signature(payload: bytes, secret: str) -> str:
 
 
 def _webhook_payload(event: Event) -> dict:
-    """The JSON body every webhook receives for an event - a wire contract
-    with external consumers, split out so it is directly assertable. The
-    bridge resolves its wake target from `channel`, filters on
-    `signal_level`, and dedupes spool lines on `event_id`
-    (tests/test_bridge.py pins those keys against THIS function), so
-    removing or renaming a key is a breaking change; additions are
-    additive - consumers read the keys they know."""
-    payload = {
-        "event_id": event.id,
-        "event_type": event.event_type,
-        "payload": event.payload,
-        "session_id": event.session_id,
-        "timestamp": event.timestamp.isoformat(),
-        "channel": event.channel,
-        "correlation_id": event.correlation_id,
-        # Derived level, matching what get_events reports for the same event
-        "signal_level": _get_signal_level(event),
-    }
-    if event.meta:
-        for key in ("title", "tags"):
-            if key in event.meta:
-                payload[key] = event.meta[key]
-    return payload
+    """The JSON body every webhook receives (event id under "event_id").
+
+    Kept as a named function - separate from _event_to_dict - because
+    tests/test_bridge.py pins the delivery contract against THIS name.
+    """
+    return _event_wire_dict(event, id_key="event_id")
 
 
 async def _dispatch_webhook(webhook: Webhook, event: Event) -> bool:

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -10,6 +10,7 @@ Provides tools for cross-session Claude Code communication:
 - notify: Send system notifications
 - register_webhook: Register HTTP endpoint for push notifications
 - list_webhooks: List registered webhooks
+- set_webhook_active: Pause/resume a webhook without unregistering it
 - unregister_webhook: Remove a webhook
 """
 
@@ -1045,6 +1046,26 @@ async def list_webhooks(active_only: bool = True) -> list[dict]:
         active_only: If True, only return active webhooks (default: True)
     """
     return await _run_sync(_list_webhooks_impl, active_only=active_only)
+
+
+def _set_webhook_active_impl(webhook_id: int, active: bool) -> dict:
+    """Sync implementation of set_webhook_active (runs in a worker thread)."""
+    if not storage.set_webhook_active(webhook_id, active):
+        return {"success": False, "error": "Webhook not found", "webhook_id": webhook_id}
+
+    _dev_notify("set_webhook_active", f"#{webhook_id} {'enabled' if active else 'disabled'}")
+    return {"success": True, "webhook_id": webhook_id, "active": active}
+
+
+@mcp.tool()
+async def set_webhook_active(webhook_id: int, active: bool) -> dict:
+    """Pause or resume a webhook without unregistering it.
+
+    Args:
+        webhook_id: ID of the webhook
+        active: False stops deliveries and keeps the registration; True resumes
+    """
+    return await _run_sync(_set_webhook_active_impl, webhook_id=webhook_id, active=active)
 
 
 def _unregister_webhook_impl(webhook_id: int) -> dict:

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -689,40 +689,27 @@ class SQLiteStorage:
                 except ValueError:
                     since_id = 0  # Malformed cursor, reset to start
 
-            # Build WHERE clause based on cursor
-            if since_id == 0:
-                where_clause = ""
-                params_base: tuple = ()
-            else:
-                where_clause = "WHERE id > ?"
-                params_base = (since_id,)
+            # Build the WHERE clause from whichever filters are present.
+            # Every condition is parameterized; the only interpolated text is
+            # the placeholder run for the IN clauses, whose length comes from
+            # the caller's list, never its contents.
+            conditions: list[str] = []
+            params_base: list = []
 
+            if since_id:
+                conditions.append("id > ?")
+                params_base.append(since_id)
             if channels:
-                placeholders = ",".join("?" * len(channels))
-                channel_filter = f"channel IN ({placeholders})"
-                if where_clause:
-                    where_clause += f" AND {channel_filter}"
-                else:
-                    where_clause = f"WHERE {channel_filter}"
-                params_base = (*params_base, *channels)
-
-            if event_types and len(event_types) > 0:
-                placeholders = ",".join("?" * len(event_types))
-                type_filter = f"event_type IN ({placeholders})"
-                if where_clause:
-                    where_clause += f" AND {type_filter}"
-                else:
-                    where_clause = f"WHERE {type_filter}"
-                params_base = (*params_base, *event_types)
-
+                conditions.append(f"channel IN ({','.join('?' * len(channels))})")
+                params_base.extend(channels)
+            if event_types:
+                conditions.append(f"event_type IN ({','.join('?' * len(event_types))})")
+                params_base.extend(event_types)
             if correlation_id:
-                corr_filter = "correlation_id = ?"
-                if where_clause:
-                    where_clause += f" AND {corr_filter}"
-                else:
-                    where_clause = f"WHERE {corr_filter}"
-                params_base = (*params_base, correlation_id)
+                conditions.append("correlation_id = ?")
+                params_base.append(correlation_id)
 
+            where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
             params = (*params_base, limit)
 
             query = f"""

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import shutil
 import sqlite3
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -16,7 +15,7 @@ logger = logging.getLogger("agent-event-bus")
 
 # Schema version for migrations
 # Increment this when adding new migrations
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Migration function type: takes a connection, returns nothing
 MigrationFunc = Callable[[sqlite3.Connection], None]
@@ -141,6 +140,29 @@ def migrate_v4(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_events_correlation ON events(correlation_id)")
 
 
+@migration(5, "backfill_pre_registry_columns")
+def migrate_v5(conn: sqlite3.Connection) -> None:
+    """Add the two columns that pre-registry code added inline.
+
+    sessions.last_cursor and events.channel were added by bare ALTER TABLE
+    statements sitting in _init_db, each wrapped in
+    except-OperationalError-pass, from before the @migration registry
+    existed. Fresh installs get both from CREATE TABLE; a database old enough
+    to lack them is upgraded here instead, so the registry is now the single
+    mechanism for schema change and _init_db only ever creates.
+
+    Conditional, so it is a no-op on every database that already has them -
+    which is every database at v4.
+    """
+    session_columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+    if "last_cursor" not in session_columns:
+        conn.execute("ALTER TABLE sessions ADD COLUMN last_cursor TEXT")
+
+    event_columns = {row[1] for row in conn.execute("PRAGMA table_info(events)")}
+    if "channel" not in event_columns:
+        conn.execute("ALTER TABLE events ADD COLUMN channel TEXT NOT NULL DEFAULT 'all'")
+
+
 # Register datetime adapters/converters (required for Python 3.12+)
 # See: https://docs.python.org/3/library/sqlite3.html#default-adapters-and-converters-deprecated
 
@@ -252,40 +274,41 @@ class SQLiteStorage:
 
         self.db_path = Path(db_path)
 
-        # Migrate from old location if needed (only for default path, not custom/test paths)
+        # Report a pre-rename database if one is lying around (only for the
+        # default path, not custom/test paths)
         if self.db_path == DEFAULT_DB_PATH:
-            self._migrate_db_location()
+            self._warn_about_legacy_db_location()
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._init_db()
 
-    def _migrate_db_location(self) -> None:
-        """Migrate database from old location to new location.
+    def _warn_about_legacy_db_location(self) -> None:
+        """Point out a database left at a pre-rename path. Never moves it.
 
-        Old: ~/.claude/event-bus.db or ~/.claude/contrib/event-bus/data.db
-        New: ~/.claude/contrib/agent-event-bus/data.db
+        The repo was renamed in January 2026 and the automatic move has had
+        months to run everywhere it was going to. What remains is a
+        move-the-user's-only-copy operation that fires on a path this code
+        has not written to since - so it now reports instead of acting, and
+        the operator runs a WAL-aware copy at a moment of their choosing.
 
-        Moving only data.db is safe here ONLY because the old paths predate
-        WAL mode (single-file databases). Do not reuse this pattern for a
-        WAL-era path: data.db-wal / data.db-shm are part of the database and
-        would be left behind.
+        Silence is not an option either: without this, a stale old-path
+        database would present as a brand-new empty bus with the real history
+        sitting unnoticed on disk.
         """
         if self.db_path.exists():
-            return  # Already at new location, nothing to do
+            return  # Already at the current location, nothing to say
 
-        # Try old contrib path first (more recent)
-        if OLD_CONTRIB_DB_PATH.exists():
-            logger.info(f"Migrating database from {OLD_CONTRIB_DB_PATH} to {self.db_path}")
-            self.db_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(OLD_CONTRIB_DB_PATH), str(self.db_path))
-            logger.info("Database migration complete")
-        # Fall back to very old path
-        elif OLD_DB_PATH.exists():
-            logger.info(f"Migrating database from {OLD_DB_PATH} to {self.db_path}")
-            self.db_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(OLD_DB_PATH), str(self.db_path))
-            logger.info("Database migration complete")
+        for legacy in (OLD_CONTRIB_DB_PATH, OLD_DB_PATH):
+            if legacy.exists():
+                logger.warning(
+                    f"Found a database at the pre-rename path {legacy}, and none at "
+                    f"{self.db_path} - starting with an EMPTY database. To keep the old "
+                    f"history, stop the server and run:\n"
+                    f'  sqlite3 "{legacy}" ".backup \'{self.db_path}\'"\n'
+                    f"(sqlite3 .backup, not cp: it is WAL-aware.)"
+                )
+                return
 
     @contextmanager
     def _connect(self):
@@ -312,19 +335,27 @@ class SQLiteStorage:
         finally:
             conn.close()
 
-    def _migrate_sessions_schema(self, conn: sqlite3.Connection) -> None:
-        """Migrate from old pid-based schema to client_id schema.
+    def _reject_prehistoric_schema(self, conn: sqlite3.Connection) -> None:
+        """Refuse to open a pre-RFC-#29 (pid-based) sessions table.
 
-        This is a breaking change migration - we drop the old sessions table
-        and recreate with the new schema. Approved for clean break in RFC #29.
+        This used to silently DROP TABLE sessions and recreate it - a clean
+        break approved when the pid schema was weeks old and the data was
+        worth nothing. It has long since stopped being a migration anyone
+        needs, and what it still is, is an unconditional destructive
+        statement aimed at user data.
+
+        A database in this shape cannot realistically exist. If one does,
+        refusing is right: the operator keeps their rows and decides.
         """
-        # Check if sessions table exists with old schema (pid column)
         cursor = conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
 
         if "pid" in columns and "client_id" not in columns:
-            logger.warning("Migrating sessions table: dropping old pid-based schema")
-            conn.execute("DROP TABLE sessions")
+            raise RuntimeError(
+                f"{self.db_path} has a pre-RFC-#29 pid-based sessions table, which this "
+                f"version cannot upgrade. Its session rows are obsolete but its events are "
+                f"not: back the file up, then drop the sessions table by hand to continue."
+            )
 
     def _get_schema_version(self, conn: sqlite3.Connection) -> int:
         """Get current schema version from database."""
@@ -350,9 +381,13 @@ class SQLiteStorage:
     def _init_db(self):
         """Create tables if they don't exist.
 
-        NOTE: Schema elements are defined here for fresh installs.
-        Migrations incrementally upgrade existing databases.
-        Both paths must result in identical schemas.
+        This path CREATES for fresh installs; the @migration registry ALTERs
+        for existing databases. Nothing here alters - a schema change belongs
+        in a migration (and in the CREATE below, for fresh installs).
+        Migrations run for fresh installs too (version 0 -> SCHEMA_VERSION),
+        so anything a migration creates need not be repeated here.
+
+        TestSchemaParity enforces that the two paths agree.
         """
         with self._connect() as conn:
             # Create schema_version table first
@@ -362,8 +397,7 @@ class SQLiteStorage:
                 )
             """)
 
-            # Check if we need to migrate from pid to client_id schema
-            self._migrate_sessions_schema(conn)
+            self._reject_prehistoric_schema(conn)
 
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS sessions (
@@ -380,11 +414,6 @@ class SQLiteStorage:
                     deleted_at TIMESTAMP
                 )
             """)
-            # Add last_cursor column if upgrading from older schema
-            try:
-                conn.execute("ALTER TABLE sessions ADD COLUMN last_cursor TEXT")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS events (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -397,17 +426,11 @@ class SQLiteStorage:
                     payload_meta TEXT
                 )
             """)
-            # Add channel column if upgrading from older schema
-            try:
-                conn.execute("ALTER TABLE events ADD COLUMN channel TEXT NOT NULL DEFAULT 'all'")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
             # Index for efficient event polling
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_events_id ON events(id)
             """)
-            # idx_events_correlation is created by migration v4, which runs for
-            # fresh installs too (version 0 -> SCHEMA_VERSION)
+            # idx_events_correlation comes from migration v4
             # Index for efficient session ordering by activity
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_sessions_heartbeat ON sessions(last_heartbeat)
@@ -416,18 +439,9 @@ class SQLiteStorage:
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_sessions_dedup ON sessions(machine, client_id)
             """)
-            # Webhooks table for push notifications
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS webhooks (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    url TEXT NOT NULL,
-                    channel_filter TEXT,
-                    event_types TEXT,
-                    created_at TIMESTAMP NOT NULL,
-                    active INTEGER NOT NULL DEFAULT 1,
-                    secret TEXT
-                )
-            """)
+            # The webhooks table comes from migration v3, which runs for fresh
+            # installs too - repeating its CREATE here would be a second
+            # definition to keep in sync for no gain
 
             # Run any pending migrations (also handles fresh installs where version=0)
             current_version = self._get_schema_version(conn)

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -801,8 +801,14 @@ class SQLiteStorage:
             secret=row["secret"],
         )
 
-    def list_webhooks(self, active_only: bool = False) -> list[Webhook]:
-        """List all webhooks, optionally filtering to active only."""
+    def list_webhooks(self, active_only: bool = True) -> list[Webhook]:
+        """List webhooks, active ones only unless active_only=False.
+
+        Defaults to active-only to match the MCP tool, and because the unsafe
+        direction is asymmetric: a caller that forgets the argument while
+        deciding whom to deliver to would otherwise wake every webhook its
+        owner had deliberately paused.
+        """
         with self._connect() as conn:
             if active_only:
                 rows = conn.execute(

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -364,6 +364,13 @@ class SQLiteStorage:
 
         A database in this shape cannot realistically exist. If one does,
         refusing is right: the operator keeps their rows and decides.
+
+        Runs before _init_db creates anything, so the refusal adds no tables
+        of its own - it only reads PRAGMA table_info. One caveat, since the
+        promise above should be exact: merely opening the file asserts
+        journal_mode=WAL (in _connect, before any statement here), which
+        rewrites the journal format. That is format, not content; no row is
+        read, written, or dropped.
         """
         cursor = conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
@@ -408,14 +415,15 @@ class SQLiteStorage:
         TestSchemaParity enforces that the two paths agree.
         """
         with self._connect() as conn:
-            # Create schema_version table first
+            # Before anything is created: a refusal should not leave its own
+            # scaffolding in the file it refused to touch.
+            self._reject_prehistoric_schema(conn)
+
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY
                 )
             """)
-
-            self._reject_prehistoric_schema(conn)
 
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS sessions (

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -274,14 +274,23 @@ class SQLiteStorage:
 
         self.db_path = Path(db_path)
 
-        # Report a pre-rename database if one is lying around (only for the
-        # default path, not custom/test paths)
-        if self.db_path == DEFAULT_DB_PATH:
-            self._warn_about_legacy_db_location()
-
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._init_db()
+
+        # Report a pre-rename database if one is lying around (only for the
+        # default path, not custom/test paths). After _init_db, so the
+        # still-empty check below has tables to query.
+        if self.db_path == DEFAULT_DB_PATH:
+            self._warn_about_legacy_db_location()
+
+    def _is_empty(self) -> bool:
+        """True when this database holds no sessions and no events."""
+        with self._connect() as conn:
+            sessions = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+            if sessions:
+                return False
+            return not conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
 
     def _warn_about_legacy_db_location(self) -> None:
         """Point out a database left at a pre-rename path. Never moves it.
@@ -295,20 +304,29 @@ class SQLiteStorage:
         Silence is not an option either: without this, a stale old-path
         database would present as a brand-new empty bus with the real history
         sitting unnoticed on disk.
-        """
-        if self.db_path.exists():
-            return  # Already at the current location, nothing to say
 
-        for legacy in (OLD_CONTRIB_DB_PATH, OLD_DB_PATH):
-            if legacy.exists():
-                logger.warning(
-                    f"Found a database at the pre-rename path {legacy}, and none at "
-                    f"{self.db_path} - starting with an EMPTY database. To keep the old "
-                    f"history, stop the server and run:\n"
-                    f'  sqlite3 "{legacy}" ".backup \'{self.db_path}\'"\n'
-                    f"(sqlite3 .backup, not cp: it is WAL-aware.)"
-                )
-                return
+        Which is why the condition is "this database is still empty" and not
+        "this database does not exist yet". The latter is true on exactly one
+        boot - the one that creates it - so the operator would get a single
+        line at the moment they are least likely to be reading logs, then
+        silence forever while the bus runs empty. Keyed on emptiness, the
+        warning repeats for as long as it is actionable and stops on its own
+        once real history accumulates here (or the operator restores the old
+        file), without nagging anyone who deliberately started fresh.
+        """
+        legacy = next((p for p in (OLD_CONTRIB_DB_PATH, OLD_DB_PATH) if p.exists()), None)
+        if legacy is None:
+            return
+        if not self._is_empty():
+            return  # real history lives here now; the operator has moved on
+
+        logger.warning(
+            f"Found a database at the pre-rename path {legacy}, and this one "
+            f"({self.db_path}) is EMPTY. To keep the old history, stop the server "
+            f"and run:\n"
+            f'  sqlite3 "{legacy}" ".backup \'{self.db_path}\'"\n'
+            f"(sqlite3 .backup, not cp: it is WAL-aware.)"
+        )
 
     @contextmanager
     def _connect(self):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -2080,10 +2080,11 @@ class TestBusRegistration:
         assert any("bus unreachable" in r.message for r in caplog.records)
 
     def test_unregister_logs_real_cause_for_non_connection_failures(self, tmp_path, caplog):
-        """The except-Exception arm: with debug=True a 401/timeout/bad body
-        re-raises out of call_tool - shutdown must stay best-effort AND the
-        one log line an operator has when a row leaks must carry the real
-        cause, not the connection-error misdiagnosis."""
+        """The except-Exception arm: a 401/timeout/bad body propagates out of
+        call_tool with its own type (only unreachability is wrapped), so
+        shutdown must stay best-effort AND the one log line an operator has
+        when a row leaks must carry the real cause, not the
+        connection-error misdiagnosis."""
         import logging
 
         config = BridgeConfig(wake_dir=tmp_path / "wake")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1732,8 +1732,8 @@ class TestBusRegistration:
         )
         calls = []
 
-        def fake_call_tool(tool_name, arguments, url=None, debug=False, **kwargs):
-            calls.append({"tool": tool_name, "arguments": arguments, "url": url, "debug": debug})
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
             if tool_name == "list_webhooks":
                 return []
             return {"webhook_id": 42}
@@ -1742,12 +1742,6 @@ class TestBusRegistration:
             webhook_id = bridge.register_with_bus(config)
 
         assert webhook_id == 42
-        # debug=True is the whole mechanism behind the named-cause logs:
-        # without it call_tool swallows a 401/timeout/bad body into a bare
-        # SystemExit(1) with the reason on stderr. Every registration call
-        # must carry it, or the daemon silently reverts to logging
-        # "SystemExit(1)" for every failure alike.
-        assert all(c["debug"] is True for c in calls)
         register = next(c for c in calls if c["tool"] == "register_webhook")
         assert register["arguments"]["url"] == "http://127.0.0.1:9999/hook"
         assert register["arguments"]["secret"] == "s3cret"
@@ -1817,7 +1811,7 @@ class TestBusRegistration:
             return {"webhook_id": 43}
 
         with patch.object(bridge, "call_tool", fake_call_tool):
-            with pytest.raises(SystemExit, match="unexpected result"):
+            with pytest.raises(bridge.BridgeRegistrationError, match="unexpected result"):
                 bridge.register_with_bus(config)
 
     def test_already_gone_stale_row_is_benign(self, tmp_path):
@@ -1840,8 +1834,8 @@ class TestBusRegistration:
         config = BridgeConfig(wake_dir=tmp_path / "wake", bus_url="http://bus/mcp")
         calls = []
 
-        def fake_call_tool(tool_name, arguments, url=None, debug=False, **kwargs):
-            calls.append({"tool": tool_name, "arguments": arguments, "url": url, "debug": debug})
+        def fake_call_tool(tool_name, arguments, url=None, **kwargs):
+            calls.append({"tool": tool_name, "arguments": arguments, "url": url})
             return {"success": True}
 
         with patch.object(bridge, "call_tool", fake_call_tool):
@@ -1852,7 +1846,6 @@ class TestBusRegistration:
                 "tool": "unregister_webhook",
                 "arguments": {"webhook_id": 42},
                 "url": "http://bus/mcp",
-                "debug": True,
             }
         ]
 
@@ -1897,11 +1890,11 @@ class TestBusRegistration:
         assert config.secret == "s3cret"
 
     def test_registration_retries_until_bus_is_up(self, tmp_path, caplog):
-        """call_tool exits the process on connection errors, and at boot the
-        bus is often not up yet - the daemon must retry, not die. The bare
-        SystemExit(1) must render as the connection error it provably is
-        (debug=True re-raises everything else), not as "SystemExit(1)"."""
+        """At boot the bus is often not up yet - the daemon must retry, not
+        die, and the log must name the real cause."""
         import logging
+
+        from agent_event_bus.cli import BusUnreachableError
 
         config = BridgeConfig(wake_dir=tmp_path / "wake")
         attempts = []
@@ -1909,7 +1902,7 @@ class TestBusRegistration:
         def flaky_register(cfg):
             attempts.append(1)
             if len(attempts) < 3:
-                raise SystemExit(1)
+                raise BusUnreachableError("Cannot connect to agent event bus at http://bus/mcp")
             return 42
 
         state: dict = {}
@@ -1919,7 +1912,29 @@ class TestBusRegistration:
 
         assert state["webhook_id"] == 42
         assert len(attempts) == 3
-        assert any("bus unreachable (connection error)" in r.message for r in caplog.records)
+        assert any("Cannot connect to agent event bus" in r.message for r in caplog.records)
+
+    def test_registration_retries_on_named_check_failures_too(self, tmp_path, caplog):
+        """A bus that answers with something unusable is retryable as well,
+        and its own message - not a generic one - must reach the log."""
+        import logging
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake")
+        attempts = []
+
+        def flaky_register(cfg):
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise bridge.BridgeRegistrationError("register_webhook returned no webhook_id: {}")
+            return 7
+
+        state: dict = {}
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "register_with_bus", flaky_register):
+                bridge.register_with_retry(config, state, threading.Event(), initial_delay=0.01)
+
+        assert state["webhook_id"] == 7
+        assert any("no webhook_id" in r.message for r in caplog.records)
 
     def test_registration_without_id_is_retryable(self, tmp_path):
         """A bus that answers but returns no webhook_id must be a retryable
@@ -1933,7 +1948,7 @@ class TestBusRegistration:
             return {}  # answered, but no webhook_id
 
         with patch.object(bridge, "call_tool", fake_call_tool):
-            with pytest.raises(SystemExit, match="no webhook_id"):
+            with pytest.raises(bridge.BridgeRegistrationError, match="no webhook_id"):
                 bridge.register_with_bus(config)
 
     def test_non_dict_webhook_rows_are_skipped(self, tmp_path):
@@ -1962,7 +1977,7 @@ class TestBusRegistration:
             return {"webhook_id": 5}
 
         with patch.object(bridge, "call_tool", fake_call_tool):
-            with pytest.raises(SystemExit, match="list_webhooks"):
+            with pytest.raises(bridge.BridgeRegistrationError, match="list_webhooks"):
                 bridge.register_with_bus(config)
 
     def test_registration_retries_on_unexpected_errors(self, tmp_path, caplog):
@@ -2004,14 +2019,20 @@ class TestBusRegistration:
         with patch.object(bridge, "register_with_bus", never_called):
             bridge.register_with_retry(config, {}, stop, initial_delay=0.01)
 
-    def test_unregister_swallows_bus_unreachable(self, tmp_path):
+    def test_unregister_swallows_bus_unreachable(self, tmp_path, caplog):
+        import logging
+
+        from agent_event_bus.cli import BusUnreachableError
+
         config = BridgeConfig(wake_dir=tmp_path / "wake")
 
         def fake_call_tool(*args, **kwargs):
-            raise SystemExit(1)
+            raise BusUnreachableError("Cannot connect to agent event bus at http://bus/mcp")
 
-        with patch.object(bridge, "call_tool", fake_call_tool):
-            bridge.unregister_from_bus(config, 42)  # must not raise
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus-bridge"):
+            with patch.object(bridge, "call_tool", fake_call_tool):
+                bridge.unregister_from_bus(config, 42)  # must not raise
+        assert any("bus unreachable" in r.message for r in caplog.records)
 
     def test_unregister_logs_real_cause_for_non_connection_failures(self, tmp_path, caplog):
         """The except-Exception arm: with debug=True a 401/timeout/bad body
@@ -2031,14 +2052,14 @@ class TestBusRegistration:
         assert any("401" in r.message and "#42" in r.message for r in caplog.records)
         assert not any("bus unreachable" in r.message for r in caplog.records)
 
-    def test_call_tool_debug_contract(self):
-        """A bare SystemExit(1) meaning 'connection error' is a cross-module
-        contract with cli.call_tool: its ConnectionError arm exits WITHOUT
-        consulting debug, while the trailing except honours debug=True and
-        re-raises. Pin both halves against the real call_tool - the same
-        idiom as sign() and the signal-level and session-filter contract
-        tests - since either half moving would turn the named-cause log
-        lines into confident misdiagnoses with every mocked test green."""
+    def test_call_tool_failure_contract(self):
+        """The failure TYPES are a cross-module contract with cli.call_tool,
+        and this module branches on them: BusUnreachableError means "the bus isn't
+        up, back off and retry", everything else is a real fault whose own
+        exception reaches the daemon log. Pinned against the REAL call_tool -
+        the same idiom as the signal-level and session-filter contract tests -
+        because if that mapping moved, every mocked test here would stay
+        green while the daemon's log lines became confident misdiagnoses."""
         import requests
 
         from agent_event_bus import cli
@@ -2046,15 +2067,35 @@ class TestBusRegistration:
         with patch.object(
             cli.requests, "post", side_effect=requests.exceptions.ConnectionError("refused")
         ):
-            with pytest.raises(SystemExit) as exc:
-                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp", debug=True)
-        assert exc.value.code == 1
+            with pytest.raises(cli.BusUnreachableError):
+                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp")
 
         with patch.object(
             cli.requests, "post", side_effect=requests.exceptions.HTTPError("401 Client Error")
         ):
             with pytest.raises(requests.exceptions.HTTPError, match="401"):
-                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp", debug=True)
+                cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp")
+
+    def test_call_tool_does_not_exit_the_bridge(self):
+        """The whole point of the split: call_tool must never terminate the
+        process that imports it. A daemon killed by its own HTTP helper stops
+        waking sessions with nothing in its log to explain why."""
+        import requests
+
+        from agent_event_bus import cli
+
+        for side_effect in (
+            requests.exceptions.ConnectionError("refused"),
+            requests.exceptions.HTTPError("401 Client Error"),
+            requests.exceptions.Timeout("slow"),
+        ):
+            with patch.object(cli.requests, "post", side_effect=side_effect):
+                try:
+                    cli.call_tool("list_webhooks", {}, url="http://127.0.0.1:1/mcp")
+                except SystemExit:  # pragma: no cover - the regression itself
+                    pytest.fail(f"call_tool exited the process on {side_effect!r}")
+                except Exception:
+                    pass  # any ordinary exception is fine; exiting is not
 
 
 class TestDaemonLifecycle:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1873,6 +1873,51 @@ class TestBusRegistration:
         unregisters = [c["arguments"] for c in calls if c["tool"] == "unregister_webhook"]
         # Only the stale hook at OUR url is removed, not other consumers'
         assert unregisters == [{"webhook_id": 7}]
+        # The sweep must see paused rows too - see the next test for why
+        listings = [c["arguments"] for c in calls if c["tool"] == "list_webhooks"]
+        assert listings == [{"active_only": False}]
+
+    def test_startup_sweep_removes_a_paused_row_at_our_url(self, tmp_path):
+        """A PAUSED webhook at this bridge's URL must be swept like any other.
+
+        Regression for a sweep that listed active rows only. That held while
+        nothing could set `active = 0`; `set_webhook_active` removes the
+        guarantee, and pausing a hook that is spamming you is precisely what
+        that feature is for - so the bridge's own endpoint is a likely target.
+        Missing the paused row means: restart adds a SECOND row at this URL,
+        re-enabling the first makes the bus deliver every DM twice, and
+        shutdown unregisters only the newer id so the paused one leaks.
+
+        Driven through the REAL bus tool implementations rather than a
+        canned listing, so the paused row is genuinely absent from an
+        active-only listing and a regression cannot pass by mocking around
+        it.
+        """
+        from agent_event_bus import server
+
+        config = BridgeConfig(wake_dir=tmp_path / "wake", port=9999)
+        hook_url = bridge.bridge_hook_url(config)
+
+        stale = server._register_webhook_impl(url=hook_url, channel="session:")
+        server._set_webhook_active_impl(webhook_id=stale["webhook_id"], active=False)
+        assert server._list_webhooks_impl(active_only=True) == [], "precondition: row is paused"
+
+        def bus_call_tool(tool_name, arguments, url=None, **kwargs):
+            impls = {
+                "list_webhooks": server._list_webhooks_impl,
+                "unregister_webhook": server._unregister_webhook_impl,
+                "register_webhook": server._register_webhook_impl,
+            }
+            return impls[tool_name](**arguments)
+
+        with patch.object(bridge, "call_tool", bus_call_tool):
+            new_id = bridge.register_with_bus(config)
+
+        rows = server._list_webhooks_impl(active_only=False)
+        assert [r["webhook_id"] for r in rows] == [new_id], (
+            "exactly one row must remain at this hook URL; the paused one was "
+            f"left behind and will double-deliver once re-enabled: {rows}"
+        )
 
     def test_empty_secret_env_is_normalized_to_none(self, monkeypatch):
         """An accidentally empty secret must not split registration (skips

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -631,12 +631,20 @@ class TestMainErrorHandling:
         assert exc.code == 1
         assert "401 Unauthorized" in capsys.readouterr().err
 
-    def test_debug_flag_reraises_instead_of_exiting(self):
+    @pytest.mark.parametrize(
+        "failure",
+        [ValueError("boom"), cli.BusUnreachableError("boom")],
+        ids=["generic", "unreachable-bus"],
+    )
+    def test_debug_flag_reraises_every_failure(self, failure):
+        """--debug means the same thing for every failure, including an
+        unreachable bus - the one a user reaching for the flag is most likely
+        to be debugging."""
         import sys
 
         with patch.object(sys, "argv", ["cli", "--debug", "sessions"]):
-            with patch("agent_event_bus.cli.cmd_sessions", side_effect=ValueError("boom")):
-                with pytest.raises(ValueError, match="boom"):
+            with patch("agent_event_bus.cli.cmd_sessions", side_effect=failure):
+                with pytest.raises(type(failure), match="boom"):
                     cli.main()
 
     def test_handler_sys_exit_passes_through_untouched(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -967,6 +967,21 @@ class TestWebhookCommands:
         assert calls[0]["arguments"] == {"webhook_id": 7}
         assert calls[0]["posted_to"] == cli.DEFAULT_URL
 
+    def test_disable_posts_active_false(self, monkeypatch):
+        calls = self._run_main(["webhook", "disable", "7"], monkeypatch)
+
+        assert calls[0]["tool"] == "set_webhook_active"
+        assert calls[0]["arguments"] == {"webhook_id": 7, "active": False}
+        assert calls[0]["posted_to"] == cli.DEFAULT_URL
+
+    def test_enable_posts_active_true(self, monkeypatch):
+        """The two verbs share one handler, so the mapping is the thing that
+        can silently invert - pin both directions, not just one."""
+        calls = self._run_main(["webhook", "enable", "7"], monkeypatch)
+
+        assert calls[0]["tool"] == "set_webhook_active"
+        assert calls[0]["arguments"] == {"webhook_id": 7, "active": True}
+
 
 class TestCmdEventsPeek:
     """CLI-level tests for events --peek (issue #131)."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,16 +39,51 @@ class TestCallTool:
         assert result == {"success": True}
 
     @patch("agent_event_bus.cli.requests.post")
-    def test_connection_error(self, mock_post):
-        """Test connection error handling."""
+    def test_connection_error_raises_bus_unreachable(self, mock_post):
+        """A bus that isn't listening raises BusUnreachableError, naming the URL.
+
+        The type is the contract, not just the message: bridge.py branches on
+        it to tell "not up yet, retry" from a real fault.
+        """
         import requests
 
         mock_post.side_effect = requests.exceptions.ConnectionError()
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(cli.BusUnreachableError) as exc_info:
+            cli.call_tool("list_sessions", {}, url="http://bus.example/mcp")
+
+        assert "http://bus.example/mcp" in str(exc_info.value)
+        assert isinstance(exc_info.value, cli.BusError)
+
+    @patch("agent_event_bus.cli.requests.post")
+    def test_call_tool_never_exits_the_process(self, mock_post, capsys):
+        """call_tool is a library function: it raises, it does not exit or print.
+
+        Regression guard for the coupling this replaced - bridge.py imports
+        call_tool, so a sys.exit here would take the daemon down with it.
+        """
+        mock_post.side_effect = ValueError("Something went wrong")
+
+        with pytest.raises(ValueError, match="Something went wrong"):
             cli.call_tool("list_sessions", {})
 
-        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    @patch("agent_event_bus.cli.requests.post")
+    def test_http_status_errors_propagate_untyped(self, mock_post):
+        """A 401/500 keeps its own exception type - only unreachability is wrapped."""
+        import requests
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "401 Client Error"
+        )
+        mock_post.return_value = mock_response
+
+        with pytest.raises(requests.exceptions.HTTPError, match="401"):
+            cli.call_tool("list_sessions", {})
 
     @patch("agent_event_bus.cli.requests.post")
     def test_empty_response(self, mock_post):
@@ -61,28 +96,6 @@ class TestCallTool:
         result = cli.call_tool("list_sessions", {})
 
         assert result == {}
-
-    @patch("agent_event_bus.cli.requests.post")
-    def test_debug_false_prints_error_and_exits(self, mock_post, capsys):
-        """Test that debug=False (default) prints error and exits."""
-        mock_post.side_effect = ValueError("Something went wrong")
-
-        with pytest.raises(SystemExit) as exc_info:
-            cli.call_tool("list_sessions", {}, debug=False)
-
-        assert exc_info.value.code == 1
-        captured = capsys.readouterr()
-        assert "Something went wrong" in captured.err
-
-    @patch("agent_event_bus.cli.requests.post")
-    def test_debug_true_propagates_exception(self, mock_post):
-        """Test that debug=True causes exception to propagate."""
-        mock_post.side_effect = ValueError("Something went wrong")
-
-        with pytest.raises(ValueError) as exc_info:
-            cli.call_tool("list_sessions", {}, debug=True)
-
-        assert "Something went wrong" in str(exc_info.value)
 
     @patch("agent_event_bus.cli.requests.post")
     def test_multiline_sse_response(self, mock_post):
@@ -118,7 +131,6 @@ class TestCmdRegister:
             "register_session",
             {"name": "my-session", "cwd": "/home/user/project"},
             url=None,
-            debug=False,
         )
 
     @patch("agent_event_bus.cli.call_tool")
@@ -135,7 +147,6 @@ class TestCmdRegister:
             "register_session",
             {"name": "my-project", "cwd": "/home/user/my-project"},
             url=None,
-            debug=False,
         )
 
     @patch("agent_event_bus.cli.call_tool")
@@ -167,7 +178,6 @@ class TestCmdUnregister:
             "unregister_session",
             {"session_id": "abc123"},
             url=None,
-            debug=False,
         )
 
     @patch("agent_event_bus.cli.call_tool")
@@ -182,7 +192,6 @@ class TestCmdUnregister:
             "unregister_session",
             {"client_id": "my-client-123"},
             url=None,
-            debug=False,
         )
 
     def test_unregister_requires_identifier(self):
@@ -248,7 +257,6 @@ class TestCmdPublish:
             "publish_event",
             {"event_type": "test_event", "payload": "hello", "channel": "all"},
             url=None,
-            debug=False,
         )
 
     @patch("agent_event_bus.cli.call_tool")
@@ -590,6 +598,54 @@ class TestCmdNotify:
         assert call_args["sound"] is True
 
 
+class TestMainErrorHandling:
+    """main() owns the exit policy that call_tool used to own.
+
+    Moving it here is what lets bridge.py import call_tool safely; these
+    tests make sure the CLI's own behavior - a friendly message and exit 1 -
+    survived the move intact.
+    """
+
+    def _run(self, argv, side_effect):
+        import sys
+
+        with patch.object(sys, "argv", argv):
+            with patch("agent_event_bus.cli.cmd_sessions", side_effect=side_effect):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+        return exc_info.value
+
+    def test_unreachable_bus_exits_1_with_start_hint(self, capsys):
+        exc = self._run(
+            ["cli", "sessions"], cli.BusUnreachableError("Cannot connect at http://x/mcp")
+        )
+
+        assert exc.code == 1
+        err = capsys.readouterr().err
+        assert "Cannot connect at http://x/mcp" in err
+        assert "agent-event-bus" in err
+
+    def test_other_failures_exit_1_with_the_message(self, capsys):
+        exc = self._run(["cli", "sessions"], ValueError("401 Unauthorized"))
+
+        assert exc.code == 1
+        assert "401 Unauthorized" in capsys.readouterr().err
+
+    def test_debug_flag_reraises_instead_of_exiting(self):
+        import sys
+
+        with patch.object(sys, "argv", ["cli", "--debug", "sessions"]):
+            with patch("agent_event_bus.cli.cmd_sessions", side_effect=ValueError("boom")):
+                with pytest.raises(ValueError, match="boom"):
+                    cli.main()
+
+    def test_handler_sys_exit_passes_through_untouched(self):
+        """A handler's own exit for a logical error is not an Exception, so
+        the new except-Exception arm must not intercept and relabel it."""
+        exc = self._run(["cli", "sessions"], SystemExit(3))
+        assert exc.code == 3
+
+
 class TestMainArgumentParsing:
     """Tests for main function argument parsing."""
 
@@ -717,7 +773,7 @@ class TestCmdChannels:
         args = Namespace(url=None, debug=False)
         cli.cmd_channels(args)
 
-        mock_call.assert_called_once_with("list_channels", {}, url=None, debug=False)
+        mock_call.assert_called_once_with("list_channels", {}, url=None)
 
 
 class TestCmdSessionsWithChannels:

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -15,21 +15,45 @@ from agent_event_bus.storage import BUSY_TIMEOUT_MS, Event
 class TestAsyncToolWrappers:
     """Tool functions must not block the server's event loop."""
 
+    def _registered_tools(self):
+        """Every @mcp.tool()-decorated function, taken from the registry.
+
+        Enumerated rather than hand-listed: a hand-list silently stops
+        covering the next tool someone adds, which is how set_webhook_active
+        arrived uncovered. The registry cannot fall behind the code.
+
+        Matched by TYPE, anchored on one known tool, rather than by duck-typing
+        on .fn/.name - conftest's autouse fixture patches a MagicMock into this
+        module, and a MagicMock answers hasattr for every name.
+        """
+        tool_type = type(server.register_session)
+        tools = [v for v in vars(server).values() if isinstance(v, tool_type)]
+        assert tools, "found no registered tools - has FastMCP's tool wrapper changed shape?"
+        return tools
+
     def test_all_tools_are_async(self):
-        tools = [
-            server.register_session,
-            server.list_sessions,
-            server.list_channels,
-            server.publish_event,
-            server.get_events,
-            server.unregister_session,
-            server.notify,
-            server.register_webhook,
-            server.list_webhooks,
-            server.unregister_webhook,
-        ]
-        for tool in tools:
+        """The #112 invariant: a blocking tool body freezes the whole server."""
+        for tool in self._registered_tools():
             assert inspect.iscoroutinefunction(tool.fn), f"{tool.name} is not async"
+
+    def test_tool_coverage_includes_every_known_tool(self):
+        """Guard the guard: if the registry scan ever silently matches
+        nothing (or stops matching some tools), the loop above passes
+        vacuously. Pin the roster so a shape change fails loudly."""
+        found = {tool.name for tool in self._registered_tools()}
+        assert found == {
+            "register_session",
+            "list_sessions",
+            "list_channels",
+            "publish_event",
+            "get_events",
+            "unregister_session",
+            "notify",
+            "register_webhook",
+            "list_webhooks",
+            "set_webhook_active",
+            "unregister_webhook",
+        }, f"tool roster changed: {sorted(found)} - update this list and guide.md together"
 
     def test_wrappers_pass_through_end_to_end(self):
         async def main():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -571,28 +571,37 @@ class TestUnregisterSession:
         assert "session_unregistered" in event_types
 
 
-class TestGetImplicitChannels:
-    """Tests for _get_implicit_channels helper."""
+class TestBroadcastModel:
+    """A registered session sees events from every channel, not just its own.
 
-    def test_no_session_id(self):
-        """Test with no session ID."""
-        assert server._get_implicit_channels(None) is None
+    Replaces the old tests for the _get_implicit_channels helper, which only
+    ever returned None. Asserting the observable behavior instead pins the
+    design decision itself (channels are metadata, not subscriptions) rather
+    than one constant-valued helper.
+    """
 
-    def test_nonexistent_session(self):
-        """Test with nonexistent session."""
-        assert server._get_implicit_channels("nonexistent") is None
-
-    def test_broadcast_model_returns_none(self):
-        """Test that broadcast model returns None (no filtering)."""
-        reg = register_session(
-            name="test",
-            machine="my-machine",
-            cwd="/home/user/myrepo",
-        )
+    def test_session_sees_events_from_other_channels(self):
+        reg = register_session(name="test", machine="my-machine", cwd="/home/user/myrepo")
         session_id = reg["session_id"]
+        cursor = reg["cursor"]
 
-        # Broadcast model: always returns None (no filtering)
-        assert server._get_implicit_channels(session_id) is None
+        publish_event(event_type="e", payload="broadcast", channel="all")
+        publish_event(event_type="e", payload="other repo", channel="repo:not-mine")
+        publish_event(event_type="e", payload="someone else's DM", channel="session:stranger")
+
+        result = get_events(cursor=cursor, session_id=session_id, order="asc")
+        payloads = [e["payload"] for e in result["events"]]
+        assert payloads == ["broadcast", "other repo", "someone else's DM"]
+
+    def test_explicit_channel_still_narrows(self):
+        reg = register_session(name="test", machine="my-machine", cwd="/home/user/myrepo")
+        cursor = reg["cursor"]
+
+        publish_event(event_type="e", payload="broadcast", channel="all")
+        publish_event(event_type="e", payload="mine", channel="repo:myrepo")
+
+        result = get_events(cursor=cursor, channel="repo:myrepo", order="asc")
+        assert [e["payload"] for e in result["events"]] == ["mine"]
 
 
 class TestAutoHeartbeat:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,6 +3,8 @@
 import sqlite3
 from datetime import datetime, timedelta
 
+import pytest
+
 from agent_event_bus.storage import SCHEMA_VERSION, SESSION_TIMEOUT, Session, SQLiteStorage
 
 
@@ -742,7 +744,13 @@ class TestSchemaParity:
     """
 
     def _build_v1_db(self, db_path):
-        """A pre-display_id, pre-webhooks database, as v1 actually shipped."""
+        """A v1 database predating every column later code bolted on.
+
+        Deliberately omits sessions.last_cursor and events.channel - the two
+        that used to be added by inline try/except ALTERs in _init_db and are
+        now migration 5. Building the fixture WITH them would let that
+        migration rot unnoticed while this test stayed green.
+        """
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
         conn.execute("INSERT INTO schema_version VALUES (1)")
@@ -755,8 +763,7 @@ class TestSchemaParity:
                 repo TEXT NOT NULL,
                 registered_at TIMESTAMP NOT NULL,
                 last_heartbeat TIMESTAMP NOT NULL,
-                client_id TEXT,
-                last_cursor TEXT
+                client_id TEXT
             )
         """)
         conn.execute("""
@@ -765,8 +772,7 @@ class TestSchemaParity:
                 event_type TEXT NOT NULL,
                 payload TEXT NOT NULL,
                 session_id TEXT NOT NULL,
-                timestamp TIMESTAMP NOT NULL,
-                channel TEXT NOT NULL DEFAULT 'all'
+                timestamp TIMESTAMP NOT NULL
             )
         """)
         conn.commit()
@@ -856,21 +862,102 @@ class TestSoftDelete:
         assert row["deleted_at"] is not None, "deleted_at should be set"
 
 
-class TestDbLocationMigration:
-    """Tests for database location migration."""
+class TestLegacyDbLocation:
+    """A database left at a pre-rename path is reported, never moved.
 
-    def test_migrate_db_from_old_to_new_location(self, tmp_path, monkeypatch):
-        """Test database migration moves file from old to new location."""
+    The automatic move was removed: it relocated the user's only copy, on a
+    path this code has not written to since January, using a plain file move
+    that is unsafe for a WAL-era database. Reporting is what remains - and it
+    has to happen, or a stale old-path database would present as a brand-new
+    empty bus with the real history sitting unnoticed on disk.
+    """
+
+    def _legacy_paths(self, tmp_path, monkeypatch, *, which="old"):
         import agent_event_bus.storage as storage_module
 
         old_path = tmp_path / ".claude" / "event-bus.db"
+        contrib_path = tmp_path / ".claude" / "contrib" / "event-bus" / "data.db"
         new_path = tmp_path / ".claude" / "contrib" / "agent-event-bus" / "data.db"
 
-        # Create old-style DB with proper schema (v1 style)
+        monkeypatch.setattr(storage_module, "OLD_DB_PATH", old_path)
+        monkeypatch.setattr(storage_module, "OLD_CONTRIB_DB_PATH", contrib_path)
+        monkeypatch.setattr(storage_module, "DEFAULT_DB_PATH", new_path)
+        return old_path, contrib_path, new_path
+
+    def test_legacy_db_is_left_in_place_and_reported(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        old_path, _, new_path = self._legacy_paths(tmp_path, monkeypatch)
         old_path.parent.mkdir(parents=True)
-        conn = sqlite3.connect(str(old_path))
-        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
-        conn.execute("INSERT INTO schema_version VALUES (1)")
+        old_path.write_bytes(b"not really a database, and never opened")
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            storage = SQLiteStorage(db_path=str(new_path))
+
+        assert old_path.exists(), "the legacy database must not be moved or removed"
+        assert old_path.read_bytes() == b"not really a database, and never opened"
+        assert new_path.exists()
+        assert storage.session_count() == 0
+
+        warning = "\n".join(r.message for r in caplog.records)
+        assert str(old_path) in warning
+        assert "EMPTY database" in warning
+        assert ".backup" in warning, "the hint must be the WAL-aware command, not cp"
+
+    def test_contrib_path_takes_precedence(self, tmp_path, monkeypatch, caplog):
+        """Both legacy paths present: name the newer one, and only it."""
+        import logging
+
+        old_path, contrib_path, new_path = self._legacy_paths(tmp_path, monkeypatch)
+        old_path.parent.mkdir(parents=True)
+        old_path.write_bytes(b"older")
+        contrib_path.parent.mkdir(parents=True)
+        contrib_path.write_bytes(b"newer")
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            SQLiteStorage(db_path=str(new_path))
+
+        warning = "\n".join(r.message for r in caplog.records)
+        assert str(contrib_path) in warning
+        assert str(old_path) not in warning
+
+    def test_silent_when_no_legacy_db_exists(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        _, _, new_path = self._legacy_paths(tmp_path, monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            SQLiteStorage(db_path=str(new_path))
+
+        assert new_path.exists()
+        assert not [r for r in caplog.records if "pre-rename" in r.message]
+
+    def test_silent_when_current_db_already_exists(self, tmp_path, monkeypatch, caplog):
+        """The common case: nothing to say once the current path is populated."""
+        import logging
+
+        old_path, _, new_path = self._legacy_paths(tmp_path, monkeypatch)
+        old_path.parent.mkdir(parents=True)
+        old_path.write_bytes(b"stale")
+        SQLiteStorage(db_path=str(new_path))  # populate the current path first
+        caplog.clear()  # that first open legitimately warned; this one must not
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            SQLiteStorage(db_path=str(new_path))
+
+        assert not [r for r in caplog.records if "pre-rename" in r.message]
+
+
+class TestPrehistoricSchemaRefusal:
+    """A pid-based sessions table is refused, not silently dropped.
+
+    The old code ran an unconditional DROP TABLE sessions on this shape. Such
+    a database cannot realistically exist any more, but if one does, the
+    operator's rows are theirs to lose - not ours.
+    """
+
+    def _build_pid_schema_db(self, db_path):
+        conn = sqlite3.connect(str(db_path))
         conn.execute("""
             CREATE TABLE sessions (
                 id TEXT PRIMARY KEY,
@@ -880,118 +967,33 @@ class TestDbLocationMigration:
                 repo TEXT NOT NULL,
                 registered_at TIMESTAMP NOT NULL,
                 last_heartbeat TIMESTAMP NOT NULL,
-                client_id TEXT,
-                last_cursor TEXT
+                pid INTEGER
             )
         """)
         conn.execute("""
-            CREATE TABLE events (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                event_type TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                timestamp TIMESTAMP NOT NULL,
-                channel TEXT NOT NULL DEFAULT 'all'
-            )
+            INSERT INTO sessions VALUES
+            ('old-1', 'legacy', 'localhost', '/tmp', 'tmp', '2026-01-02', '2026-01-02', 4242)
         """)
+        conn.commit()
         conn.close()
 
-        # Monkeypatch the paths (including OLD_CONTRIB_DB_PATH to prevent real path interference)
-        monkeypatch.setattr(storage_module, "OLD_DB_PATH", old_path)
-        monkeypatch.setattr(storage_module, "OLD_CONTRIB_DB_PATH", tmp_path / "nonexistent")
-        monkeypatch.setattr(storage_module, "DEFAULT_DB_PATH", new_path)
+    def test_refuses_and_preserves_the_rows(self, tmp_path):
+        db_path = tmp_path / "prehistoric.db"
+        self._build_pid_schema_db(db_path)
 
-        # Initialize storage with the new default path - should trigger migration
-        storage = SQLiteStorage(db_path=str(new_path))
+        with pytest.raises(RuntimeError, match="pid-based"):
+            SQLiteStorage(db_path=str(db_path))
 
-        # Verify migration occurred
-        assert new_path.exists(), "New DB should exist after migration"
-        assert not old_path.exists(), "Old DB should be moved (not exist)"
-
-        # Verify storage is functional after migration
-        assert storage.session_count() == 0, "Storage should work after migration"
-
-    def test_no_migration_when_old_db_missing(self, tmp_path, monkeypatch):
-        """Test that no migration occurs if old DB doesn't exist."""
-        import agent_event_bus.storage as storage_module
-
-        old_path = tmp_path / ".claude" / "event-bus.db"
-        new_path = tmp_path / ".claude" / "contrib" / "agent-event-bus" / "data.db"
-
-        # Don't create old DB
-        monkeypatch.setattr(storage_module, "OLD_DB_PATH", old_path)
-        monkeypatch.setattr(storage_module, "OLD_CONTRIB_DB_PATH", tmp_path / "nonexistent")
-        monkeypatch.setattr(storage_module, "DEFAULT_DB_PATH", new_path)
-
-        # Initialize storage - should create fresh DB
-        SQLiteStorage(db_path=str(new_path))
-
-        assert new_path.exists(), "New DB should be created"
-        assert not old_path.exists(), "Old DB should still not exist"
-
-    def test_no_migration_when_new_db_already_exists(self, tmp_path, monkeypatch):
-        """Test that migration is skipped if new DB already exists."""
-        import agent_event_bus.storage as storage_module
-
-        old_path = tmp_path / ".claude" / "event-bus.db"
-        new_path = tmp_path / ".claude" / "contrib" / "agent-event-bus" / "data.db"
-
-        # Create old DB
-        old_path.parent.mkdir(parents=True)
-        conn = sqlite3.connect(str(old_path))
-        conn.execute("CREATE TABLE old_marker (id INTEGER)")
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT id FROM sessions").fetchall()
         conn.close()
+        assert rows == [("old-1",)], "the refusal must not have touched user rows"
 
-        # Create new DB with current schema (so SQLiteStorage doesn't fail)
-        new_path.parent.mkdir(parents=True)
-        conn = sqlite3.connect(str(new_path))
-        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
-        conn.execute("INSERT INTO schema_version VALUES (2)")
-        conn.execute("""
-            CREATE TABLE sessions (
-                id TEXT PRIMARY KEY,
-                display_id TEXT,
-                name TEXT NOT NULL,
-                machine TEXT NOT NULL,
-                cwd TEXT NOT NULL,
-                repo TEXT NOT NULL,
-                registered_at TIMESTAMP NOT NULL,
-                last_heartbeat TIMESTAMP NOT NULL,
-                client_id TEXT,
-                last_cursor TEXT,
-                deleted_at TIMESTAMP
-            )
-        """)
-        conn.execute("""
-            CREATE TABLE events (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                event_type TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                timestamp TIMESTAMP NOT NULL,
-                channel TEXT NOT NULL DEFAULT 'all'
-            )
-        """)
-        conn.close()
-
-        monkeypatch.setattr(storage_module, "OLD_DB_PATH", old_path)
-        monkeypatch.setattr(storage_module, "OLD_CONTRIB_DB_PATH", tmp_path / "nonexistent")
-        monkeypatch.setattr(storage_module, "DEFAULT_DB_PATH", new_path)
-
-        # Initialize storage - should NOT overwrite existing new DB
-        SQLiteStorage(db_path=str(new_path))
-
-        # Old DB should still exist (not moved because new already exists)
-        assert old_path.exists(), "Old DB should still exist when migration skipped"
-
-        # Verify new DB doesn't have old_marker table (wasn't overwritten)
-        conn = sqlite3.connect(str(new_path))
-        cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='old_marker'"
-        )
-        row = cursor.fetchone()
-        conn.close()
-        assert row is None, "New DB should not have old_marker table (wasn't overwritten)"
+    def test_current_schema_is_unaffected(self, tmp_path):
+        """The guard keys on pid-without-client_id; a normal database opens."""
+        db_path = tmp_path / "normal.db"
+        SQLiteStorage(db_path=str(db_path))
+        SQLiteStorage(db_path=str(db_path))  # must not raise on reopen
 
 
 class TestNextCursorHighWater:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -697,12 +697,30 @@ class TestDatabaseInitialization:
         )
 
 
+# (table, column) pairs whose NOT NULL / DEFAULT is KNOWN to differ between a
+# fresh CREATE and a migrated database, and is accepted as-is. Only the
+# declared type is compared for these.
+#
+# sessions.display_id: _init_db declares it TEXT NOT NULL, but migration v2
+# can only add it with a bare `ALTER TABLE ... ADD COLUMN display_id TEXT` -
+# SQLite has no ALTER COLUMN, and v2's own closing comment records the
+# decision to enforce the constraint in application code instead. Closing it
+# needs a full table rebuild on live user data; that is its own change, not a
+# line in a cleanup pass. This list is the honest boundary of the guard - a
+# NOT NULL or DEFAULT divergence anywhere NOT listed here fails.
+KNOWN_CONSTRAINT_DIVERGENCES = {("sessions", "display_id")}
+
+
 def _schema_snapshot(db_path) -> dict:
-    """Columns (name → declared type) per table, plus index names per table.
+    """Per table: columns as name → (type, notnull, default), and indexes as
+    name → CREATE statement.
 
     Column ORDER is deliberately not compared: ALTER TABLE appends, so a
     migrated database legitimately orders columns differently from a fresh
-    CREATE TABLE. Everything that affects queries is compared.
+    CREATE TABLE. Everything else that affects queries is compared - notnull
+    and default because a constraint landing in one path only is exactly the
+    drift this guards, and the index SQL because comparing index NAMES alone
+    would let an index over the wrong columns match.
     """
     conn = sqlite3.connect(str(db_path))
     try:
@@ -715,13 +733,15 @@ def _schema_snapshot(db_path) -> dict:
         ]
         snapshot = {}
         for table in tables:
+            # PRAGMA table_info rows: (cid, name, type, notnull, dflt_value, pk)
             columns = {
-                row[1]: row[2].upper() for row in conn.execute(f"PRAGMA table_info({table})")
+                row[1]: (row[2].upper(), row[3], row[5], row[4])
+                for row in conn.execute(f"PRAGMA table_info({table})")
             }
             indexes = {
-                row[0]
+                row[0]: row[1]
                 for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? "
+                    "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=? "
                     "AND name NOT LIKE 'sqlite_%'",
                     (table,),
                 )
@@ -730,6 +750,28 @@ def _schema_snapshot(db_path) -> dict:
         return snapshot
     finally:
         conn.close()
+
+
+def _compare_columns(table: str, migrated: dict, fresh: dict) -> None:
+    """Assert column parity, allowing only the recorded constraint divergences."""
+    assert migrated.keys() == fresh.keys(), (
+        f"Column sets diverged on '{table}': "
+        f"only in fresh={sorted(fresh.keys() - migrated.keys())}, "
+        f"only in migrated={sorted(migrated.keys() - fresh.keys())}"
+    )
+    for column, fresh_spec in fresh.items():
+        migrated_spec = migrated[column]
+        if (table, column) in KNOWN_CONSTRAINT_DIVERGENCES:
+            assert migrated_spec[0] == fresh_spec[0], (
+                f"'{table}.{column}' is an accepted CONSTRAINT divergence, but its "
+                f"declared TYPE diverged too: {migrated_spec[0]} vs {fresh_spec[0]}"
+            )
+            continue
+        assert migrated_spec == fresh_spec, (
+            f"'{table}.{column}' diverged (type, notnull, pk, default): "
+            f"migrated={migrated_spec}, fresh={fresh_spec}. A schema change landed "
+            f"in one of _init_db / the @migration registry but not the other."
+        )
 
 
 class TestSchemaParity:
@@ -793,13 +835,21 @@ class TestSchemaParity:
             f"Table sets diverged: fresh={sorted(fresh)}, migrated={sorted(migrated)}"
         )
         for table in fresh:
-            assert migrated[table]["columns"] == fresh[table]["columns"], (
-                f"Columns diverged on '{table}'. A schema change landed in one of "
-                f"_init_db / the @migration registry but not the other."
-            )
+            _compare_columns(table, migrated[table]["columns"], fresh[table]["columns"])
             assert migrated[table]["indexes"] == fresh[table]["indexes"], (
-                f"Indexes diverged on '{table}'."
+                f"Indexes diverged on '{table}' (name → CREATE statement)."
             )
+
+    def test_the_recorded_divergences_are_still_real(self):
+        """An allowance nobody rechecks becomes a permanent blind spot.
+
+        If a rebuild migration ever fixes sessions.display_id, this fails and
+        the entry comes out of the list - rather than silently exempting a
+        column that no longer needs exempting.
+        """
+        assert KNOWN_CONSTRAINT_DIVERGENCES == {("sessions", "display_id")}, (
+            "Update this test alongside the list, and say why in the comment there."
+        )
 
     def test_reopening_is_idempotent(self, tmp_path):
         """Re-opening an up-to-date database must not re-run or re-alter anything."""
@@ -901,7 +951,7 @@ class TestLegacyDbLocation:
 
         warning = "\n".join(r.message for r in caplog.records)
         assert str(old_path) in warning
-        assert "EMPTY database" in warning
+        assert "EMPTY" in warning
         assert ".backup" in warning, "the hint must be the WAL-aware command, not cp"
 
     def test_contrib_path_takes_precedence(self, tmp_path, monkeypatch, caplog):
@@ -932,16 +982,41 @@ class TestLegacyDbLocation:
         assert new_path.exists()
         assert not [r for r in caplog.records if "pre-rename" in r.message]
 
-    def test_silent_when_current_db_already_exists(self, tmp_path, monkeypatch, caplog):
-        """The common case: nothing to say once the current path is populated."""
+    def test_warning_repeats_while_the_current_db_is_still_empty(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Keyed on emptiness, not existence.
+
+        Gating on db_path.exists() would warn on exactly one boot - the one
+        that creates the file - and then go quiet forever while the bus ran
+        empty and the real history sat at the old path.
+        """
         import logging
 
         old_path, _, new_path = self._legacy_paths(tmp_path, monkeypatch)
         old_path.parent.mkdir(parents=True)
         old_path.write_bytes(b"stale")
-        SQLiteStorage(db_path=str(new_path))  # populate the current path first
-        caplog.clear()  # that first open legitimately warned; this one must not
 
+        for restart in range(3):
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+                SQLiteStorage(db_path=str(new_path))
+            assert [r for r in caplog.records if "pre-rename" in r.message], (
+                f"restart {restart}: the warning must persist while it is actionable"
+            )
+
+    def test_warning_stops_once_real_history_accumulates(self, tmp_path, monkeypatch, caplog):
+        """Self-limiting: one real event here and the operator has moved on."""
+        import logging
+
+        old_path, _, new_path = self._legacy_paths(tmp_path, monkeypatch)
+        old_path.parent.mkdir(parents=True)
+        old_path.write_bytes(b"stale")
+
+        storage = SQLiteStorage(db_path=str(new_path))
+        storage.add_event(event_type="task_completed", payload="real history", session_id="s1")
+
+        caplog.clear()
         with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
             SQLiteStorage(db_path=str(new_path))
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -712,8 +712,11 @@ KNOWN_CONSTRAINT_DIVERGENCES = {("sessions", "display_id")}
 
 
 def _schema_snapshot(db_path) -> dict:
-    """Per table: columns as name → (type, notnull, default), and indexes as
-    name → CREATE statement.
+    """Per table: columns as name → (type, notnull, pk, default), and indexes
+    as name → CREATE statement.
+
+    That tuple order is load-bearing: _compare_columns indexes [0] for the
+    declared type and [1:] for the constraints it relaxes on an exempt column.
 
     Column ORDER is deliberately not compared: ALTER TABLE appends, so a
     migrated database legitimately orders columns differently from a fresh
@@ -840,16 +843,40 @@ class TestSchemaParity:
                 f"Indexes diverged on '{table}' (name → CREATE statement)."
             )
 
-    def test_the_recorded_divergences_are_still_real(self):
-        """An allowance nobody rechecks becomes a permanent blind spot.
+    def test_the_recorded_divergences_are_still_real(self, tmp_path):
+        """Every recorded allowance must still be earning its place.
 
-        If a rebuild migration ever fixes sessions.display_id, this fails and
-        the entry comes out of the list - rather than silently exempting a
-        column that no longer needs exempting.
+        OBSERVES the divergence rather than asserting the constant against its
+        own literal. The literal form would be a change-detector: a rebuild
+        migration that made display_id NOT NULL on migrated databases too
+        would leave the constant untouched (green here) and the parity test
+        green as well - an exemption only ever relaxes a comparison - so the
+        stale allowance would survive precisely the event meant to retire it,
+        and its blind spot would be permanent from then on.
+
+        Compares everything except the declared type, since type is compared
+        for exempt columns anyway: an entry whose (notnull, pk, default) all
+        match is exempting nothing.
         """
-        assert KNOWN_CONSTRAINT_DIVERGENCES == {("sessions", "display_id")}, (
-            "Update this test alongside the list, and say why in the comment there."
-        )
+        fresh_path = tmp_path / "fresh.db"
+        SQLiteStorage(db_path=str(fresh_path))
+
+        migrated_path = tmp_path / "migrated.db"
+        self._build_v1_db(migrated_path)
+        SQLiteStorage(db_path=str(migrated_path))
+
+        fresh = _schema_snapshot(fresh_path)
+        migrated = _schema_snapshot(migrated_path)
+
+        for table, column in KNOWN_CONSTRAINT_DIVERGENCES:
+            migrated_spec = migrated[table]["columns"][column]
+            fresh_spec = fresh[table]["columns"][column]
+            assert migrated_spec[1:] != fresh_spec[1:], (
+                f"'{table}.{column}' no longer diverges between a fresh and a migrated "
+                f"database (both {fresh_spec[1:]} for notnull/pk/default). The entry in "
+                f"KNOWN_CONSTRAINT_DIVERGENCES is now exempting nothing - delete it, so "
+                f"the column goes back to being compared in full."
+            )
 
     def test_reopening_is_idempotent(self, tmp_path):
         """Re-opening an up-to-date database must not re-run or re-alter anything."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,7 @@
 import sqlite3
 from datetime import datetime, timedelta
 
-from agent_event_bus.storage import SESSION_TIMEOUT, Session, SQLiteStorage
+from agent_event_bus.storage import SCHEMA_VERSION, SESSION_TIMEOUT, Session, SQLiteStorage
 
 
 class TestSessionOperations:
@@ -693,6 +693,123 @@ class TestDatabaseInitialization:
         assert version == SCHEMA_VERSION, (
             f"Schema version should be {SCHEMA_VERSION}, got {version}"
         )
+
+
+def _schema_snapshot(db_path) -> dict:
+    """Columns (name → declared type) per table, plus index names per table.
+
+    Column ORDER is deliberately not compared: ALTER TABLE appends, so a
+    migrated database legitimately orders columns differently from a fresh
+    CREATE TABLE. Everything that affects queries is compared.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = [
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+        ]
+        snapshot = {}
+        for table in tables:
+            columns = {
+                row[1]: row[2].upper() for row in conn.execute(f"PRAGMA table_info({table})")
+            }
+            indexes = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? "
+                    "AND name NOT LIKE 'sqlite_%'",
+                    (table,),
+                )
+            }
+            snapshot[table] = {"columns": columns, "indexes": indexes}
+        return snapshot
+    finally:
+        conn.close()
+
+
+class TestSchemaParity:
+    """A fresh install and a migrated database must end up with ONE schema.
+
+    _init_db creates the current schema for fresh installs while the
+    @migration registry upgrades existing databases incrementally - two
+    independent definitions of the same thing, and _init_db's docstring can
+    only assert they agree. This test is the mechanism behind that assertion:
+    add a column to one path and forget the other, and it fails here rather
+    than as a "no such column" on someone's live bus.
+    """
+
+    def _build_v1_db(self, db_path):
+        """A pre-display_id, pre-webhooks database, as v1 actually shipped."""
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO schema_version VALUES (1)")
+        conn.execute("""
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                machine TEXT NOT NULL,
+                cwd TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                registered_at TIMESTAMP NOT NULL,
+                last_heartbeat TIMESTAMP NOT NULL,
+                client_id TEXT,
+                last_cursor TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                timestamp TIMESTAMP NOT NULL,
+                channel TEXT NOT NULL DEFAULT 'all'
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    def test_migrated_v1_matches_fresh_install(self, tmp_path):
+        fresh_path = tmp_path / "fresh.db"
+        SQLiteStorage(db_path=str(fresh_path))
+
+        migrated_path = tmp_path / "migrated.db"
+        self._build_v1_db(migrated_path)
+        SQLiteStorage(db_path=str(migrated_path))
+
+        fresh = _schema_snapshot(fresh_path)
+        migrated = _schema_snapshot(migrated_path)
+
+        assert migrated.keys() == fresh.keys(), (
+            f"Table sets diverged: fresh={sorted(fresh)}, migrated={sorted(migrated)}"
+        )
+        for table in fresh:
+            assert migrated[table]["columns"] == fresh[table]["columns"], (
+                f"Columns diverged on '{table}'. A schema change landed in one of "
+                f"_init_db / the @migration registry but not the other."
+            )
+            assert migrated[table]["indexes"] == fresh[table]["indexes"], (
+                f"Indexes diverged on '{table}'."
+            )
+
+    def test_reopening_is_idempotent(self, tmp_path):
+        """Re-opening an up-to-date database must not re-run or re-alter anything."""
+        db_path = tmp_path / "reopen.db"
+        SQLiteStorage(db_path=str(db_path))
+        first = _schema_snapshot(db_path)
+
+        storage = SQLiteStorage(db_path=str(db_path))
+        assert _schema_snapshot(db_path) == first
+
+        # And exactly one version row survives (earlier versions accumulated rows)
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT version FROM schema_version").fetchall()
+        conn.close()
+        assert rows == [(SCHEMA_VERSION,)]
+        assert storage.session_count() == 0
 
 
 class TestSoftDelete:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -843,8 +843,28 @@ class TestSchemaParity:
                 f"Indexes diverged on '{table}' (name → CREATE statement)."
             )
 
+    def test_no_new_divergences_have_been_recorded(self):
+        """Watches the list GROWING. Deliberately a change-detector.
+
+        Silencing a real parity failure by adding its column here is the easy
+        wrong move, and nothing else would catch it: the parity test relaxes
+        for whatever is listed, and the staleness test below would confirm the
+        new entry genuinely diverges - which is precisely why someone added
+        it. Widening the guard's blind spot should cost a deliberate edit and
+        a written reason, not a one-word append.
+        """
+        assert KNOWN_CONSTRAINT_DIVERGENCES == {("sessions", "display_id")}, (
+            "KNOWN_CONSTRAINT_DIVERGENCES changed. Adding an entry widens a blind "
+            "spot in TestSchemaParity - do it only for a divergence that genuinely "
+            "cannot be migrated away, document why in the comment above the "
+            "constant, and update this test to match."
+        )
+
     def test_the_recorded_divergences_are_still_real(self, tmp_path):
-        """Every recorded allowance must still be earning its place.
+        """Watches the list going STALE - the opposite direction to the test
+        above, and the reason a change-detector alone is not enough here.
+
+        Every recorded allowance must still be earning its place.
 
         OBSERVES the divergence rather than asserting the constant against its
         own literal. The literal form would be a change-detector: a rebuild
@@ -869,6 +889,23 @@ class TestSchemaParity:
         migrated = _schema_snapshot(migrated_path)
 
         for table, column in KNOWN_CONSTRAINT_DIVERGENCES:
+            # Retirement has two shapes and both must reach the same
+            # conclusion. The constraint converging is handled below; the
+            # column or table going away is handled here, because a rebuild
+            # migration - the standard SQLite create-copy-drop-rename dance,
+            # and the likeliest way display_id ever gets fixed - would
+            # otherwise surface as a bare KeyError with the reasoning lost.
+            for label, snapshot in (("migrated", migrated), ("fresh", fresh)):
+                assert table in snapshot, (
+                    f"KNOWN_CONSTRAINT_DIVERGENCES names table '{table}', which no "
+                    f"longer exists in a {label} database - the entry is stale, delete it."
+                )
+                assert column in snapshot[table]["columns"], (
+                    f"KNOWN_CONSTRAINT_DIVERGENCES names '{table}.{column}', and that "
+                    f"column no longer exists in a {label} database - the entry is "
+                    f"stale, delete it."
+                )
+
             migrated_spec = migrated[table]["columns"][column]
             fresh_spec = fresh[table]["columns"][column]
             assert migrated_spec[1:] != fresh_spec[1:], (

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1125,8 +1125,21 @@ class TestPrehistoricSchemaRefusal:
 
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute("SELECT id FROM sessions").fetchall()
+        tables = {
+            r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type = ?", ("table",))
+        }
         conn.close()
+
         assert rows == [("old-1",)], "the refusal must not have touched user rows"
+        # Pins the ORDER of the check inside _init_db, which its docstring
+        # promises ("runs before _init_db creates anything") and which the row
+        # assertion above cannot see - rows survived under the old ordering
+        # too. Move the call back below the schema_version CREATE and this is
+        # the assertion that fails.
+        assert tables == {"sessions"}, (
+            f"the refusal created scaffolding of its own: {sorted(tables)}. Only "
+            f"journal_mode=WAL may change on a refused database - format, not content."
+        )
 
     def test_current_schema_is_unaffected(self, tmp_path):
         """The guard keys on pid-without-client_id; a normal database opens."""

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -400,6 +400,63 @@ class TestWebhookMCPTools:
         assert result["webhook_id"] == 99999
 
 
+class TestSetWebhookActive:
+    """set_webhook_active pauses deliveries without losing the registration.
+
+    The storage method and the `active` column existed from the start, but
+    nothing in MCP or the CLI could reach them, so `active` could never
+    actually be 0 in production and list_webhooks(active_only=...) was a
+    distinction without a difference. These tests cover the tool that closes
+    that gap - including the part that matters, that a paused webhook really
+    stops receiving deliveries.
+    """
+
+    def test_disable_then_enable_round_trip(self):
+        from agent_event_bus import server
+
+        wh = server._register_webhook_impl(url="https://example.com/hook")
+
+        disabled = server._set_webhook_active_impl(webhook_id=wh["webhook_id"], active=False)
+        assert disabled == {"success": True, "webhook_id": wh["webhook_id"], "active": False}
+        assert server._list_webhooks_impl(active_only=True) == []
+        assert len(server._list_webhooks_impl(active_only=False)) == 1
+
+        enabled = server._set_webhook_active_impl(webhook_id=wh["webhook_id"], active=True)
+        assert enabled["active"] is True
+        assert len(server._list_webhooks_impl(active_only=True)) == 1
+
+    def test_unknown_webhook_reports_failure(self):
+        from agent_event_bus import server
+
+        result = server._set_webhook_active_impl(webhook_id=99999, active=False)
+
+        assert result["success"] is False
+        assert result["error"] == "Webhook not found"
+        assert result["webhook_id"] == 99999
+
+    def test_disabled_webhook_receives_no_deliveries(self):
+        """The whole point: a paused webhook must drop out of the dispatch
+        set. Asserted through the real matcher, not just the listing."""
+        from agent_event_bus import server
+        from agent_event_bus.storage import Event
+
+        wh = server._register_webhook_impl(url="https://example.com/hook")
+        event = Event(
+            id=1,
+            event_type="task_completed",
+            payload="done",
+            session_id="s1",
+            timestamp=datetime.now(),
+        )
+        assert len(server.storage.get_matching_webhooks(event)) == 1
+
+        server._set_webhook_active_impl(webhook_id=wh["webhook_id"], active=False)
+        assert server.storage.get_matching_webhooks(event) == []
+
+        server._set_webhook_active_impl(webhook_id=wh["webhook_id"], active=True)
+        assert len(server.storage.get_matching_webhooks(event)) == 1
+
+
 class TestWebhookIntegration:
     """Integration tests for webhook dispatch on publish."""
 


### PR DESCRIPTION
Audit-driven cleanup ahead of feature development. Four cleanup commits plus a review-fix commit, each independently reviewable. No feature work; the only user-visible addition is the webhook pause/resume tool that closes a half-built surface.

**596 tests pass** (569 on main before this branch), lint and format clean. Merged up to `main` — includes #137.

## `c7f5c70` — dead code, duplicated wire shape, schema-parity guard

- **`_get_implicit_channels` deleted.** It took a `session_id` it never read and always returned `None`. Its three tests asserted that constant; `TestBroadcastModel` replaces them by asserting the actual design decision — a session sees events on channels it doesn't belong to.
- **`_event_to_dict` and `_webhook_payload` built identical dicts**, differing only in `id` vs `event_id`, each with its own do-not-break-this comment. Both now delegate to `_event_wire_dict`, so a field added for one consumer reaches the other and the two can't drift on `signal_level`. Both names kept — tests pin the delivery contract against `_webhook_payload` specifically.
- `_preview()` for truncation duplicated in two places; `storage.get_events` rebuilds its WHERE clause from a condition list instead of four copies of the same block.
- **`TestSchemaParity` added.** `_init_db` defines the schema for fresh installs while the `@migration` registry upgrades existing databases, and nothing checked that they agree. A migrated database is now compared against a fresh one.

## `144357d` — `call_tool` raises instead of exiting

`call_tool` lives in `cli.py` but is imported by `bridge.py`, and it terminated the process on failure. The bridge had three catch sites reverse-engineering intent from the exit code — `isinstance(e, SystemExit) and e.code == 1` — each wrapped in a paragraph explaining why that inference held.

It now raises `BusUnreachableError` when nothing answers and lets every other failure propagate with its own type. It never prints and never exits; `main()` owns that policy in one place, and a handler's own `sys.exit` for a logical error still passes through. The `debug` parameter is gone from `call_tool` (it only ever controlled printing and exiting) and stays a `main()`-level flag. The bridge gains `BridgeRegistrationError` for its own named checks.

**Net −60 lines of source, and the diagnostics improve.** Registration retries used to log `SystemExit(1)` for a down bus, a 401, and a malformed body alike:

```
Registration on http://127.0.0.1:8098/mcp failed (BusUnreachableError('Cannot
connect to agent event bus at http://127.0.0.1:8098/mcp')); retrying in 1s
```

## `3ec41d8` — webhook pause/resume, and bridge docs out of the MCP guide

**`set_webhook_active`.** The `active` column, the storage method, and `list_webhooks(active_only=)` have existed since webhooks landed, but nothing in MCP or the CLI could set `active` to 0 — so in production it was always 1, making `active_only` and `webhook list --all` a distinction without a difference. Adds the MCP tool and `webhook disable/enable <id>`. Pausing keeps the registration, filters, and secret; unregistering stays permanent.

`storage.list_webhooks` now defaults to `active_only=True`, matching the MCP tool. The two disagreed, and the unsafe direction is asymmetric: a caller that forgets the argument while deciding whom to deliver to would otherwise wake every webhook its owner had deliberately paused. Every existing caller passes it explicitly, so nothing changes today.

**`docs/BRIDGE.md`.** `guide.md` was 658 lines, 300 of them the experimental bridge — longer than the entire rest of the API guide, in a file served as an MCP resource and therefore paid for in every session that reads it. Moved verbatim, with headings added (it had none) and a status banner. The guide keeps a pointer plus the one fact a woken session needs: drain `wake/<session_id>.jsonl`, one JSON event per line.

## `0f5fe74` — one mechanism for schema change

Four ways to change a schema existed, two invisible to tests. Now `_init_db` only CREATEs and migrations only ALTER:

- `@migration(5, "backfill_pre_registry_columns")` takes over adding `sessions.last_cursor` and `events.channel` from the inline `try/except ALTER TABLE` blocks. Conditional, so it's a no-op on any database at v4.
- Dropped the duplicate `webhooks` CREATE — migration v3 owns it and runs for fresh installs too.
- `TestSchemaParity`'s v1 fixture now omits those two columns, so it actually exercises migration 5.

Two destructive legacy paths removed, neither replaced by silence:

- `_migrate_db_location` moved the user's only copy out of a pre-rename path using a plain file move that is WAL-unsafe by this repo's own rules. It now reports the stale file and prints the `sqlite3 .backup` command, leaving it untouched — reporting matters, or a stale old-path database presents as a brand-new empty bus with the real history unnoticed on disk.
- `_migrate_sessions_schema` ran an unconditional `DROP TABLE sessions` on a pre-RFC-#29 schema. It refuses with instructions instead, and a test asserts the rows survive the refusal.

## `398f64d` — review round 1

One real defect this PR had introduced, plus five suggestions — all valid, all fixed:

- **`bridge.py` (blocking).** `register_with_bus` swept stale rows at its own hook URL with `active_only=True`. Correct only while nothing could set `active = 0` — which `set_webhook_active` changes. A paused row at the bridge's URL survived the sweep, a restart added a second row there, re-enabling the first made the bus deliver every DM twice, and shutdown unregistered only the newer id. Swept with `active_only=False`. The regression test drives the real bus tool implementations, so reverting the argument reproduces two rows at one URL.
- **`TestSchemaParity` was weaker than its own description.** It compared declared type only, so `NOT NULL`/`DEFAULT` divergences passed silently — and one already did: `sessions.display_id` is `NOT NULL` fresh, nullable migrated, because migration v2 can only `ADD COLUMN`. Now compares `(type, notnull, pk, default)` and index `CREATE` statements. That one divergence is recorded in `KNOWN_CONSTRAINT_DIVERGENCES` with its reason (closing it needs a table rebuild — its own change); anything unlisted fails, type is still compared for listed columns, and a second test pins the list.
- **The legacy-path warning was once-only**, gated on "file doesn't exist" — true on exactly the boot that creates it. Now keyed on "this database is still empty": repeats while actionable, stops once real history accumulates.
- **`set_webhook_active` was missing from the hand-listed async-tool guard.** Derived from the registry instead, matched by tool *type* (duck-typing on `.fn`/`.name` catches conftest's `MagicMock`), with a companion test pinning the roster.
- **`--debug` didn't apply to `BusUnreachableError`** — the one failure a user reaching for the flag is most likely debugging. Now checked first, uniform everywhere.
- **`docs/BRIDGE.md`**: `Delivery outcomes` promoted out of `Security and operation`; blank lines before headings.

## `d5bc7a2` — merge `main`

Brings in #137 (`CLAUDE_CODE_SESSION_ID` fallback), which touched the same two CLI handlers this PR refactored. Auto-merged cleanly, and verified as more than textual: `_session_id_from_env()` and the `debug`-less `call_tool` signature coexist, precedence still holds (`--session-id` > `AGENT_EVENT_BUS_SESSION_ID` > `CLAUDE_CODE_SESSION_ID`), and the new webhook verbs still work against a live bus.

### Database verification

Given `CLAUDE.md`'s protection rules, this was verified on a real upgrade rather than fixtures. A v4 database built by the **previous revision** of `storage.py`, populated with sessions, events (meta, `correlation_id`, `channel`), and a secret-carrying webhook, opens at v5 with every field intact, a single version row, and a schema matching a fresh v5 install.

Also exercised against a live server and bridge: CLI error paths and exit codes; a bridge started *before* the bus retrying, registering when it came up, and spooling a DM to its wake file; and the full `webhook register → disable → list --all → enable` cycle.

`SCHEMA_VERSION` moves 4 → 5, so back up before deploying:

```bash
sqlite3 ~/.claude/contrib/agent-event-bus/data.db ".backup $HOME/.claude/contrib/agent-event-bus/data.db.backup-$(date +%Y%m%d-%H%M%S)"
```

## Not done

Left from the audit, unaddressed: duplicate SSE parsing in `middleware.py` and `cli.py`; ~4.5s of the suite spent on real webhook backoff sleeps; `make fmt` linting `.` while CI lints `src tests`; no coverage measurement; the stale `docs/superpowers/specs/` design doc. Also noted: closing the `sessions.display_id` constraint divergence needs a table-rebuild migration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N11TJkcFv2Bn4YQvbYsQ37)_