### PR TITLE
Supervise the RFC #122 bridge as a LaunchAgent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,17 +17,18 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Repo | `agent-event-bus` |
 | Python package | `agent_event_bus` |
 | MCP server name | `agent-event-bus` |
-| CLI commands | `agent-event-bus`, `agent-event-bus-cli`, `agent-event-bus-bridge` (bridge is venv-only for now - run via `uv run`) |
+| CLI commands | `agent-event-bus`, `agent-event-bus-cli`, `agent-event-bus-bridge` (supervised on macOS via `make install-bridge`; elsewhere run via `uv run`) |
 | Resource URI | `agent-event-bus://guide` |
 | Data directory | `~/.claude/contrib/agent-event-bus/` |
 | Database | `~/.claude/contrib/agent-event-bus/data.db` |
-| Log files | `agent-event-bus.log`, `agent-event-bus.err` |
-| LaunchAgent | `com.evansenter.agent-event-bus.plist` |
+| Log files | `agent-event-bus.log`, `agent-event-bus.err`; bridge: `agent-event-bus-bridge.log`, `agent-event-bus-bridge.err` (the bridge's are launchd's stdout/stderr capture, which launchd TRUNCATES on every restart - it has no append-mode file logger of its own yet) |
+| LaunchAgent | `com.evansenter.agent-event-bus.plist`; bridge: `com.evansenter.agent-event-bus-bridge.plist` (separate unit - a bus host need not run a bridge) |
 | systemd service | `agent-event-bus.service` |
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |
 | Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/`, else the system temp dir (`$TMPDIR`, or `/tmp` when unset; macOS: per-user `/var/folders/.../T`) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Create-and-verified private (not adopted). Safe to remove when no bridge is running |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_BRIDGE_ALLOWED_HOSTS`, `_WAKE_DIR`)
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_BRIDGE_ALLOWED_HOSTS`, `_BRIDGE_LOG`, `_BRIDGE_ERR`, `_WAKE_DIR`).
+One consulted variable is deliberately outside the prefix: **`CLAUDE_CODE_SESSION_ID`**, which the CLI reads as a session-attribution fallback when `--session-id` and `AGENT_EVENT_BUS_SESSION_ID` are both absent (#137).
 
 ---
 
@@ -65,10 +66,12 @@ make uninstall  # Remove everything (preserves DB)
 make dev        # Install with dev dependencies
 make check      # Format + lint + test
 make restart    # Lightweight service restart (no dependency sync)
+make install-bridge    # Supervise the RFC #122 bridge (macOS LaunchAgent, idempotent)
+make uninstall-bridge  # Stop supervising it (leaves the bus, DB, and wake/ alone)
 ./scripts/dev.sh  # Dev mode (foreground, auto-reload)
 ```
 
-**When to restart**: Code changes to `server.py`, `storage.py`, `helpers.py` require `make install-server` (or `make restart`). `guide.md` is read fresh each request. Dev mode auto-reloads. The bridge is a separate process with no install target - after `bridge.py` changes, restart whatever runs `uv run agent-event-bus-bridge`.
+**When to restart**: Code changes to `server.py`, `storage.py`, `helpers.py` require `make install-server` (or `make restart`). `guide.md` is read fresh each request. Dev mode auto-reloads. After `bridge.py` changes, restart the bridge: `make install-bridge` if it is supervised (macOS LaunchAgent, idempotent), else whatever runs `uv run agent-event-bus-bridge`.
 
 ## Testing
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt lint test clean install-server install-client uninstall dev venv restart logs
+.PHONY: check fmt lint test clean install-server install-client uninstall dev venv restart logs install-bridge uninstall-bridge
 
 # Canonical paths (override with matching AGENT_EVENT_BUS_* env vars)
 LOG_FILE := $(or $(AGENT_EVENT_BUS_LOG),$(HOME)/.claude/contrib/agent-event-bus/agent-event-bus.log)
@@ -95,6 +95,27 @@ install-client:
 	@echo ""
 	@echo "Add to your shell profile (~/.zshrc, ~/.bashrc, or ~/.extra):"
 	@echo '  export AGENT_EVENT_BUS_URL="$(REMOTE_URL)"'
+
+# Supervise the RFC #122 bridge (macOS only; idempotent, restarts on crash).
+# Separate from install-server on purpose: the bridge is experimental, the bus
+# is not, and a bus host does not have to run one. Requires the venv that
+# install-server (or `make dev`) creates.
+install-bridge:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		echo "install-bridge is macOS-only (LaunchAgent)."; \
+		echo "On Linux, run the bridge under your own supervisor:"; \
+		echo "  uv run agent-event-bus-bridge"; \
+		exit 1; \
+	fi
+	./scripts/install-bridge-launchagent.sh
+
+# Stop supervising the bridge. Leaves the bus, the database, and wake/ alone.
+uninstall-bridge:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		echo "uninstall-bridge is macOS-only (LaunchAgent)."; \
+		exit 1; \
+	fi
+	./scripts/uninstall-bridge-launchagent.sh
 
 # Uninstall: service + CLI + MCP config
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,11 @@ uninstall-bridge:
 uninstall:
 	@echo "Uninstalling..."
 	@if [ "$$(uname)" = "Darwin" ]; then \
+		if [ -f "$$HOME/Library/LaunchAgents/com.evansenter.agent-event-bus-bridge.plist" ]; then \
+			echo "Removing bridge LaunchAgent first (KeepAlive would respawn it against a bus that is gone)..."; \
+			./scripts/uninstall-bridge-launchagent.sh; \
+			echo ""; \
+		fi; \
 		./scripts/uninstall-launchagent.sh; \
 	else \
 		./scripts/uninstall-systemd.sh; \
@@ -146,7 +151,7 @@ restart:
 			launchctl unload "$$PLIST" 2>/dev/null || true; \
 			launchctl load "$$PLIST"; \
 			sleep 1; \
-			if launchctl list | grep -q "com.evansenter.agent-event-bus"; then \
+			if launchctl list | grep -q "com.evansenter.agent-event-bus$$"; then \
 				echo "Service restarted successfully"; \
 			else \
 				echo "Error: Service failed to start. Check $(ERR_FILE)"; \

--- a/scripts/com.evansenter.agent-event-bus-bridge.plist
+++ b/scripts/com.evansenter.agent-event-bus-bridge.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.evansenter.agent-event-bus-bridge</string>
+
+    <!-- Runs as a module, matching the bus unit. bridge.py has the __main__
+         guard, so this is equivalent to the agent-event-bus-bridge console
+         script without depending on the venv's bin/ being on PATH. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>__VENV_PYTHON__</string>
+        <string>-m</string>
+        <string>agent_event_bus.bridge</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_DIR__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>PYTHONPATH</key>
+        <string>__PROJECT_DIR__/src</string>
+        <!-- Pinned rather than inherited. launchd does not run a shell, so a
+             profile that exports a different backend cannot reach this
+             process - but being explicit means the unit describes what runs
+             instead of leaving it to whatever the default happens to be.
+             tmux would additionally need wake/panes.json maintained by
+             something session-side; spool has no such dependency. -->
+        <key>AGENT_EVENT_BUS_BRIDGE_BACKEND</key>
+        <string>spool</string>
+        <!-- AGENT_EVENT_BUS_URL is deliberately NOT set: unset means the
+             bridge's own default (http://127.0.0.1:8080/mcp), which is
+             correct on the machine hosting the bus. Set it here only if the
+             bus moves off this box - and then the hook URL stops being
+             loopback, which makes AGENT_EVENT_BUS_BRIDGE_SECRET mandatory
+             (validate_config refuses an exposed listener without one). -->
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart on crash. Safe with the singleton lock: flock is released
+         when the dead process's fd closes, so the replacement acquires it
+         cleanly rather than refusing to start. The startup sweep also
+         reclaims the webhook row the dead instance left registered. -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- launchd's default respawn throttle, stated explicitly because it is
+         load-bearing here: it bounds how fast a crash loop rewrites the log
+         below, and how fast a failing bridge re-registers against the bus. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- The bridge logs via logging.basicConfig, which is stderr-only, so
+         this file IS the bridge's log - there is no separate append-mode
+         file logger like the bus has. launchd TRUNCATES these on every
+         process start, so a crash loop overwrites the evidence of earlier
+         iterations; ThrottleInterval above is what keeps the surviving
+         window useful. Giving the bridge its own append-mode file handler
+         is the follow-up that removes this caveat. -->
+    <key>StandardOutPath</key>
+    <string>__BRIDGE_LOG_FILE__</string>
+
+    <key>StandardErrorPath</key>
+    <string>__BRIDGE_ERR_FILE__</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,9 +10,9 @@ SERVICE_WAS_RUNNING=false
 
 # Stop service if running (to free port 8080)
 if [[ "$(uname)" == "Darwin" ]]; then
-    LABEL="com.evansenter.agent-event-bus"
+    LABEL="com.evansenter.agent-event-bus"  # matched anchored: the bridge label is a superstring
     PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
-    if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+    if launchctl list 2>/dev/null | grep -q "$LABEL$"; then
         echo "Stopping LaunchAgent for dev mode..."
         launchctl unload "$PLIST" 2>/dev/null
         SERVICE_WAS_RUNNING=true

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -22,6 +22,21 @@ if [[ ! -f "$VENV_PYTHON" ]]; then
     exit 1
 fi
 
+# Preflight the import rather than running `uv sync` here. A stale venv missing
+# a bridge dependency would otherwise become an import crash-loop under
+# KeepAlive - the one case where the log-truncation caveat bites hardest, since
+# every respawn wipes the previous traceback. Checking beats syncing: `uv sync
+# --no-dev` (what install-server runs) would silently strip pytest/ruff from a
+# venv someone just set up with `make dev`.
+if ! PYTHONPATH="$PROJECT_DIR/src" "$VENV_PYTHON" -c "import agent_event_bus.bridge" 2>/tmp/bridge-import-check.$$; then
+    echo "Error: the venv cannot import agent_event_bus.bridge:"
+    sed 's/^/  /' /tmp/bridge-import-check.$$
+    rm -f /tmp/bridge-import-check.$$
+    echo "Run: make dev   (or: uv sync)"
+    exit 1
+fi
+rm -f /tmp/bridge-import-check.$$
+
 # The bridge is useless without a bus to register against. It would retry with
 # backoff rather than die (register_with_retry), so this is a warning and not a
 # hard failure - but starting a bridge on a box with no bus is almost always a
@@ -37,7 +52,7 @@ fi
 mkdir -p "$HOME/Library/LaunchAgents"
 mkdir -p "$DATA_DIR"
 
-if launchctl list | grep -q "$LABEL"; then
+if launchctl list | grep -q "$LABEL$"; then
     echo "Stopping existing bridge service..."
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
@@ -52,27 +67,41 @@ sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
 echo "Starting bridge..."
 launchctl load "$PLIST_DEST"
 
-# Give it a moment to bind and attempt registration before probing. The
-# listener binds during startup; registration runs in a background thread and
-# may still be backing off against a bus that is not up yet.
-sleep 2
+# POLL rather than sleep a fixed interval. On a re-install over a live bridge,
+# `launchctl unload` returns as soon as SIGTERM is delivered, so the outgoing
+# process can still hold the singleton flock and port 8082 when the replacement
+# starts. The replacement then exits on the lock - correctly; that ordering is
+# what keeps the outgoing instance's unregister from racing a new registration
+# - and KeepAlive only retries after ThrottleInterval (~10s). A flat 2s probe
+# lands inside that window and reports a perfectly healthy idempotent
+# re-install as a failure. 20s covers the throttle with room to spare.
+HEALTH=""
+for _ in $(seq 1 40); do
+    HEALTH="$(curl -fsS --max-time 2 http://127.0.0.1:8082/health 2>/dev/null || true)"
+    [[ -n "$HEALTH" ]] && break
+    sleep 0.5
+done
 
-if ! launchctl list | grep -q "$LABEL"; then
+if ! launchctl list | grep -q "$LABEL$"; then
     echo "Error: bridge failed to start. Check $BRIDGE_ERR_FILE"
     exit 1
 fi
 
 echo ""
 echo "Bridge installed and running."
-echo "  Logs:   $BRIDGE_LOG_FILE"
-echo "  Errors: $BRIDGE_ERR_FILE"
+# Labelled by what each file actually receives: bridge.py logs via
+# logging.basicConfig with no stream=, which defaults to STDERR, so every
+# bridge record lands in the .err file. The .log file gets uvicorn's access
+# lines only. Following a "Logs:" pointer at the .log would show a reader no
+# bridge messages at all.
+echo "  Bridge log (records, warnings, errors): $BRIDGE_ERR_FILE"
+echo "  Access log (uvicorn requests):          $BRIDGE_LOG_FILE"
 echo "  Health: curl -s http://127.0.0.1:8082/health"
 echo ""
 
 # registered:false is not a failure here - it means registration is still
 # backing off (bus not up yet), which resolves on its own. Report what we see
 # rather than asserting success we have not confirmed.
-HEALTH="$(curl -fsS --max-time 3 http://127.0.0.1:8082/health 2>/dev/null || true)"
 if [[ -n "$HEALTH" ]]; then
     echo "  /health -> $HEALTH"
     case "$HEALTH" in
@@ -82,7 +111,7 @@ if [[ -n "$HEALTH" ]]; then
             echo "  Not registered yet - retrying with backoff (is the bus up?)." ;;
     esac
 else
-    echo "  /health did not answer yet; check $BRIDGE_ERR_FILE if this persists."
+    echo "  /health did not answer within 20s; check $BRIDGE_ERR_FILE."
 fi
 
 echo ""

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Install the RFC #122 bridge as a macOS LaunchAgent (auto-starts on login,
+# restarts on crash). The bus has its own unit - this supervises only the
+# webhook->injection bridge, which until now had no install target at all.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_PYTHON="$PROJECT_DIR/.venv/bin/python"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.evansenter.agent-event-bus-bridge.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.evansenter.agent-event-bus-bridge.plist"
+LABEL="com.evansenter.agent-event-bus-bridge"
+
+DATA_DIR="$HOME/.claude/contrib/agent-event-bus"
+BRIDGE_LOG_FILE="${AGENT_EVENT_BUS_BRIDGE_LOG:-$DATA_DIR/agent-event-bus-bridge.log}"
+BRIDGE_ERR_FILE="${AGENT_EVENT_BUS_BRIDGE_ERR:-$DATA_DIR/agent-event-bus-bridge.err}"
+
+if [[ ! -f "$VENV_PYTHON" ]]; then
+    echo "Error: Virtual environment not found at $PROJECT_DIR/.venv"
+    echo "Run: make install-server  (or: uv sync)"
+    exit 1
+fi
+
+# The bridge is useless without a bus to register against. It would retry with
+# backoff rather than die (register_with_retry), so this is a warning and not a
+# hard failure - but starting a bridge on a box with no bus is almost always a
+# mistake worth naming at install time rather than discovering in the log.
+if ! launchctl list | grep -q "com.evansenter.agent-event-bus$"; then
+    echo "Warning: the bus LaunchAgent does not appear to be loaded."
+    echo "         The bridge will start and retry registration with backoff,"
+    echo "         but it cannot deliver anything until the bus is up."
+    echo "         Install it with: make install-server"
+    echo ""
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents"
+mkdir -p "$DATA_DIR"
+
+if launchctl list | grep -q "$LABEL"; then
+    echo "Stopping existing bridge service..."
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+echo "Installing bridge LaunchAgent..."
+sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__PROJECT_DIR__|$PROJECT_DIR|g" \
+    -e "s|__BRIDGE_LOG_FILE__|$BRIDGE_LOG_FILE|g" \
+    -e "s|__BRIDGE_ERR_FILE__|$BRIDGE_ERR_FILE|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+echo "Starting bridge..."
+launchctl load "$PLIST_DEST"
+
+# Give it a moment to bind and attempt registration before probing. The
+# listener binds during startup; registration runs in a background thread and
+# may still be backing off against a bus that is not up yet.
+sleep 2
+
+if ! launchctl list | grep -q "$LABEL"; then
+    echo "Error: bridge failed to start. Check $BRIDGE_ERR_FILE"
+    exit 1
+fi
+
+echo ""
+echo "Bridge installed and running."
+echo "  Logs:   $BRIDGE_LOG_FILE"
+echo "  Errors: $BRIDGE_ERR_FILE"
+echo "  Health: curl -s http://127.0.0.1:8082/health"
+echo ""
+
+# registered:false is not a failure here - it means registration is still
+# backing off (bus not up yet), which resolves on its own. Report what we see
+# rather than asserting success we have not confirmed.
+HEALTH="$(curl -fsS --max-time 3 http://127.0.0.1:8082/health 2>/dev/null || true)"
+if [[ -n "$HEALTH" ]]; then
+    echo "  /health -> $HEALTH"
+    case "$HEALTH" in
+        *'"registered":true'*|*'"registered": true'*)
+            echo "  Registered on the bus." ;;
+        *)
+            echo "  Not registered yet - retrying with backoff (is the bus up?)." ;;
+    esac
+else
+    echo "  /health did not answer yet; check $BRIDGE_ERR_FILE if this persists."
+fi
+
+echo ""
+echo "NOTE: nothing drains wake/<session>.jsonl yet (agent-event-bus#134)."
+echo "      The bridge will spool actionable DMs durably, but no session is"
+echo "      woken by them until a drain hook exists."
+echo ""
+echo "To uninstall: $SCRIPT_DIR/uninstall-bridge-launchagent.sh"

--- a/scripts/install-launchagent.sh
+++ b/scripts/install-launchagent.sh
@@ -8,6 +8,10 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 VENV_PYTHON="$PROJECT_DIR/.venv/bin/python"
 PLIST_TEMPLATE="$SCRIPT_DIR/com.evansenter.agent-event-bus.plist"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.evansenter.agent-event-bus.plist"
+# Anchored at end-of-line everywhere it is matched: launchctl list prints the
+# label last, and com.evansenter.agent-event-bus-bridge is a SUPERSTRING of
+# this one, so an unanchored probe reports the bus healthy whenever only the
+# bridge is loaded.
 LABEL="com.evansenter.agent-event-bus"
 
 # Resolve paths (respect env var overrides, fall back to canonical defaults)
@@ -26,7 +30,7 @@ mkdir -p "$HOME/Library/LaunchAgents"
 mkdir -p "$HOME/.claude"
 
 # Stop existing service if running
-if launchctl list | grep -q "$LABEL"; then
+if launchctl list | grep -q "$LABEL$"; then
     echo "Stopping existing service..."
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
@@ -46,7 +50,7 @@ launchctl load "$PLIST_DEST"
 
 # Verify it's running
 sleep 1
-if launchctl list | grep -q "$LABEL"; then
+if launchctl list | grep -q "$LABEL$"; then
     echo ""
     echo "Agent Event Bus installed and running!"
     echo "  Logs: $LOG_FILE"

--- a/scripts/uninstall-bridge-launchagent.sh
+++ b/scripts/uninstall-bridge-launchagent.sh
@@ -7,7 +7,7 @@ set -e
 PLIST_DEST="$HOME/Library/LaunchAgents/com.evansenter.agent-event-bus-bridge.plist"
 LABEL="com.evansenter.agent-event-bus-bridge"
 
-if launchctl list | grep -q "$LABEL"; then
+if launchctl list | grep -q "$LABEL$"; then
     echo "Stopping bridge..."
     # SIGTERM via unload, so the shutdown path runs: the lifespan's shielded
     # stop-join-unregister removes the webhook row rather than leaving the bus

--- a/scripts/uninstall-bridge-launchagent.sh
+++ b/scripts/uninstall-bridge-launchagent.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Remove the bridge LaunchAgent. Leaves the bus, the database, and the wake
+# directory alone - this only stops supervising the bridge.
+
+set -e
+
+PLIST_DEST="$HOME/Library/LaunchAgents/com.evansenter.agent-event-bus-bridge.plist"
+LABEL="com.evansenter.agent-event-bus-bridge"
+
+if launchctl list | grep -q "$LABEL"; then
+    echo "Stopping bridge..."
+    # SIGTERM via unload, so the shutdown path runs: the lifespan's shielded
+    # stop-join-unregister removes the webhook row rather than leaving the bus
+    # POSTing at a dead port.
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+else
+    echo "Bridge service not loaded."
+fi
+
+if [[ -f "$PLIST_DEST" ]]; then
+    rm "$PLIST_DEST"
+    echo "Removed $PLIST_DEST"
+fi
+
+echo ""
+echo "Bridge uninstalled. The bus, the database, and wake/ are untouched."
+echo "Confirm the webhook row is gone with: agent-event-bus-cli webhook list"
+echo ""
+echo "The wake directory is transient and safe to clear BY HAND once no"
+echo "bridge is running (clearing it under a live bridge orphans its"
+echo "singleton lock inode):"
+echo "  ~/.claude/contrib/agent-event-bus/wake/"

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -240,13 +240,12 @@ def _session_id_from_env() -> str | None:
     tends not to be.
 
     The fallback exists because setting the explicit var from a shell profile
-    is not reliable: the dotfiles that map one to the other live in ~/.exports,
-    which is sourced from ~/.zshrc - and zsh reads .zshrc for INTERACTIVE
-    shells only. Tool-spawned subprocesses are non-interactive, so the mapping
-    never runs there and publishes landed as "anonymous" (`zsh -i -c` sees it,
-    `zsh -c` does not). That is a property of shell startup, not of any OS -
-    it reproduces on Linux - so the fix belongs here, where it holds for every
-    shell, spawner, and machine, rather than in one shell's rc plumbing.
+    cannot be relied on: rc files are read for INTERACTIVE shells only, and a
+    tool-spawned subprocess is not interactive, so any profile-based mapping
+    is simply absent there and publishes land as "anonymous" (`zsh -i -c`
+    sees such a mapping, `zsh -c` does not). That is shell startup semantics
+    rather than a property of any OS or any particular dotfile layout, so the
+    fix belongs here, where it holds for every shell, spawner, and machine.
 
     The two ids are the same value by construction: the SessionStart hook
     registers on the bus with client_id = the Claude Code session id, which the

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -340,8 +340,54 @@ uv run agent-event-bus-bridge --backend tmux     # also types a wake prompt into
 ```
 
 (`uv run` from the repo checkout: the console script lives in the project
-venv - unlike `agent-event-bus-cli`, nothing symlinks it onto PATH yet.
-That lands with the supervision story.)
+venv - unlike `agent-event-bus-cli`, nothing symlinks it onto PATH.)
+
+### Running it supervised (macOS)
+
+```
+make install-bridge     # LaunchAgent: starts at login, restarts on crash
+make uninstall-bridge   # stops it; leaves the bus, the DB, and wake/ alone
+```
+
+A **separate unit** from the bus (`com.evansenter.agent-event-bus-bridge`)
+because a bus host does not have to run a bridge, and the bridge is
+experimental while the bus is not. The unit pins `--backend spool`; tmux
+additionally needs `wake/panes.json` maintained by something session-side.
+
+**Boot ordering is a non-issue.** launchd has no dependency ordering, so the
+bridge can start before the bus is listening. `register_with_retry` backs off
+1s->30s until the bus answers rather than exiting, so a cold boot in the
+"wrong" order self-corrects; `/health` reports `registered: false` until it
+does. That is also why the installer's `registered: false` is a status line
+and not an error.
+
+**The bridge log is launchd's stdout/stderr capture** and launchd
+**truncates it on every restart** - the bridge logs via `basicConfig`
+(stderr) and has no append-mode file logger like the bus does. A crash loop
+therefore overwrites earlier iterations; `ThrottleInterval` (10s) is what
+keeps the surviving window useful. Giving the bridge its own file handler is
+the follow-up that removes this caveat.
+
+### Verifying supervision
+
+The test suite mocks launchd entirely, so these four are manual - and two of
+them check claims the unit's own comments make:
+
+1. **Crash restart** - `kill -9` the bridge; launchd respawns it within
+   `ThrottleInterval`. Confirms the singleton flock releases on process death
+   (so the replacement acquires it rather than refusing to start) and that
+   the startup sweep reclaims the dead instance's webhook row instead of
+   leaving a duplicate: `agent-event-bus-cli webhook list` should show one.
+2. **Boot order** - unload the bus, load the bridge: `/health` shows
+   `registered: false`. Load the bus; within ~30s it flips to `true` with no
+   intervention. This is `register_with_retry`'s backoff doing its job.
+3. **Reboot** - the actual requirement. `RunAtLoad` plus login.
+4. **Clean unload** - `make uninstall-bridge`, then confirm the webhook row
+   is gone and port 8082 is free.
+
+What none of this covers: whether a session actually *wakes*. The spool line
+lands, but nothing drains it yet (see the pruning note below), so the far end
+of the pipeline stays unobservable until a drain hook exists.
 
 - **spool**: every wake event is appended to
   `~/.claude/contrib/agent-event-bus/wake/<session_id>.jsonl` for a hook to

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -657,11 +657,10 @@ case; the real fix is the `list_sessions`-based scoping tracked for v2,
 which drops unknown ids before they reach the filesystem. Machine-scoped
 delivery is a v2 item.
 
-Supervision is deliberately out of scope for the v1 prototype: there is no
-`make install-bridge`, launchd plist, or systemd unit yet - run the bridge in
-a terminal (or your own supervisor) while experimenting. Startup ordering is
-already safe for a future supervisor (registration retries until the bus is
-up); unit files land once the prototype proves out (RFC #122).
+Supervision exists on macOS only: `make install-bridge` installs a LaunchAgent
+(see "Running it supervised" above). There is no systemd unit yet - on Linux,
+run the bridge under your own supervisor. Startup ordering is safe either way,
+since registration retries until the bus is up.
 
 ## Best Practices
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,24 @@ def storage(temp_db):
     return SQLiteStorage(db_path=temp_db)
 
 
+# Both names the CLI consults when --session-id is omitted (#137).
+# CLAUDE_CODE_SESSION_ID is injected by Claude Code into every subprocess it
+# spawns - including the one running this suite - so an ambient value would
+# silently satisfy any assertion expecting NO attribution, making results
+# depend on where the suite runs. Scrubbed suite-wide rather than per-module:
+# test_structured_payload.py and test_signal_levels.py also drive
+# cmd_publish/cmd_events, and are safe today only because none of their
+# assertions check for absence. The first one that does would be silently
+# machine-dependent.
+SESSION_ID_ENV = ("AGENT_EVENT_BUS_SESSION_ID", "CLAUDE_CODE_SESSION_ID")
+
+
+@pytest.fixture(autouse=True)
+def clean_session_id_env(monkeypatch):
+    for name in SESSION_ID_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture(autouse=True)
 def clean_storage():
     """Clean the storage before each test.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,19 +9,6 @@ import pytest
 from agent_event_bus import cli
 from conftest import make_events_args, make_publish_args
 
-# Both names the CLI consults when --session-id is omitted. CLAUDE_CODE_SESSION_ID
-# is injected by Claude Code into every subprocess it spawns - including the one
-# running this suite - so without the scrub below an ambient value would silently
-# satisfy assertions that expect NO attribution, and the suite would pass on a
-# developer's machine while failing in CI (or the reverse).
-SESSION_ID_ENV = ("AGENT_EVENT_BUS_SESSION_ID", "CLAUDE_CODE_SESSION_ID")
-
-
-@pytest.fixture(autouse=True)
-def clean_session_id_env(monkeypatch):
-    for name in SESSION_ID_ENV:
-        monkeypatch.delenv(name, raising=False)
-
 
 class TestCallTool:
     """Tests for call_tool function."""


### PR DESCRIPTION
The bridge merged in #135 with **no install target** — it ran only as a foreground `uv run agent-event-bus-bridge`, so it died with its shell and never survived a reboot. The bus has had a LaunchAgent all along (which is why *it* has been up continuously); the bridge simply never had one.

Adds `com.evansenter.agent-event-bus-bridge.plist`, install/uninstall scripts, and `make install-bridge` / `make uninstall-bridge`.

## Design decisions worth reviewing

**A separate unit, not an addition to `install-server`.** A bus host doesn't have to run a bridge, and the bridge is experimental while the bus isn't. Bundling them would make every bus install start a daemon most machines don't want.

**Boot ordering needs no launchd machinery.** launchd has no dependency ordering, so the bridge can start before the bus is listening — but `register_with_retry` already backs off 1s→30s until the bus answers rather than exiting, and its docstring anticipates exactly the "same supervisor launches both" case. A cold boot in the wrong order self-corrects. That's why the installer prints `registered: false` as a *status line*, not an error.

**`KeepAlive` is safe with the singleton lock.** `flock` releases when the dead process's fd closes, so the replacement acquires it cleanly instead of refusing to start, and the startup sweep reclaims the webhook row the dead instance left registered. `ThrottleInterval` is stated explicitly rather than left to the default because it's load-bearing here — it bounds how fast a crash loop rewrites the log.

**`--backend spool` is pinned in the unit.** tmux additionally needs `wake/panes.json` maintained by something session-side, which doesn't exist. `AGENT_EVENT_BUS_URL` is deliberately left unset so the bridge's loopback default applies — correct on the machine hosting the bus, and the comment explains what changes if the bus moves off-box.

## Documented caveat, not a silent one

The bridge logs via `basicConfig` (stderr only), so launchd's capture **is** its log — and launchd truncates that on every process start. A crash loop overwrites the evidence of earlier iterations. `ThrottleInterval` keeps the surviving window useful. Giving the bridge its own append-mode file handler, like the bus has, is the follow-up that removes this properly; I kept it out of here to keep the diff focused on supervision.

## Verification

The suite mocks launchd entirely, so `guide.md` gains a four-item manual checklist — and two of them check claims this unit's own comments make rather than taking them on trust:

1. **Crash restart** — `kill -9`; launchd respawns within `ThrottleInterval`. Proves the flock actually releases and the sweep reclaims the row instead of duplicating it.
2. **Boot order** — unload the bus, load the bridge (`registered: false`), then load the bus; it should flip to `true` within ~30s unaided.
3. **Reboot** — the actual requirement.
4. **Clean unload** — webhook row gone, port 8082 free.

What none of it covers: whether a session actually *wakes*. The spool line lands, but nothing drains it until #134.

`make check` green: **576 passed**. Plist parses via `plistlib`; both scripts pass `bash -n`.

## Also: three #137 follow-ups

Deferred at that merge with a note that they'd ride the next PR:

- Hoisted the session-id env scrub from `test_cli.py` to `conftest.py`, so `test_structured_payload.py` and `test_signal_levels.py` are protected by construction rather than by the accident of what they currently assert.
- Generalized `_session_id_from_env`'s docstring off the specific `~/.exports` / `~/.zshrc` paths this repo doesn't own, keeping the durable half (rc files are interactive-only).
- Added `CLAUDE_CODE_SESSION_ID` to the CLAUDE.md env-var table — the one consulted name that will never carry the `AGENT_EVENT_BUS_` prefix.

**Not taken**, from the same review: defaulting `--client-id` in `register`/`unregister` from the same helper. The gap needs a SessionStart hook that omits `--client-id`, which isn't the current setup (dotfiles `session-start.sh:74` passes it), and auto-adopting the session id as `client_id` would change registration semantics — the `(machine, client_id)` dedupe means a manual `register` would *resume* the real session rather than mint a new one. That deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R)_