### PR TITLE
Harden the bridge installer; correct two claims the bus host disproved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Resource URI | `agent-event-bus://guide` |
 | Data directory | `~/.claude/contrib/agent-event-bus/` |
 | Database | `~/.claude/contrib/agent-event-bus/data.db` |
-| Log files | `agent-event-bus.log`, `agent-event-bus.err`; bridge: `agent-event-bus-bridge.log`, `agent-event-bus-bridge.err` (the bridge's are launchd's stdout/stderr capture; launchd APPENDS across restarts, so no file handler of its own is needed. Bridge records go to `.err` - it logs to stderr - while `.log` gets uvicorn access lines) |
+| Log files | Bus: `agent-event-bus.log` (the Python `FileHandler`, the one `_LOG` moves), `agent-event-bus.err`, plus `agent-event-bus.stdout` - launchd's stdout capture, hardcoded in the plist and therefore the one file no env var relocates. Bridge: `agent-event-bus-bridge.log`, `agent-event-bus-bridge.err` (both launchd captures; launchd APPENDS across restarts, so no file handler of its own is needed. Bridge records go to `.err` - it logs to stderr - while `.log` gets uvicorn access lines) |
 | LaunchAgent | `com.evansenter.agent-event-bus.plist`; bridge: `com.evansenter.agent-event-bus-bridge.plist` (separate unit - a bus host need not run a bridge) |
 | systemd service | `agent-event-bus.service` |
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Resource URI | `agent-event-bus://guide` |
 | Data directory | `~/.claude/contrib/agent-event-bus/` |
 | Database | `~/.claude/contrib/agent-event-bus/data.db` |
-| Log files | `agent-event-bus.log`, `agent-event-bus.err`; bridge: `agent-event-bus-bridge.log`, `agent-event-bus-bridge.err` (the bridge's are launchd's stdout/stderr capture, which launchd TRUNCATES on every restart - it has no append-mode file logger of its own yet) |
+| Log files | `agent-event-bus.log`, `agent-event-bus.err`; bridge: `agent-event-bus-bridge.log`, `agent-event-bus-bridge.err` (the bridge's are launchd's stdout/stderr capture; launchd APPENDS across restarts, so no file handler of its own is needed. Bridge records go to `.err` - it logs to stderr - while `.log` gets uvicorn access lines) |
 | LaunchAgent | `com.evansenter.agent-event-bus.plist`; bridge: `com.evansenter.agent-event-bus-bridge.plist` (separate unit - a bus host need not run a bridge) |
 | systemd service | `agent-event-bus.service` |
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@ Follow these patterns consistently (aligned with agent-session-analytics):
 | Wake spool dir | `~/.claude/contrib/agent-event-bus/wake/` (bridge spool/lock files + `panes.json` + `bridge.singleton.lock` - transient; the DB protection below does NOT extend to it. Safe to hand-clear **while no bridge is running** - clearing it under a live bridge orphans its `bridge.singleton.lock` inode, so a second instance acquires a fresh one) |
 | Bridge hook-lock dir | `$XDG_RUNTIME_DIR/agent-event-bus-bridge-<uid>/`, else the system temp dir (`$TMPDIR`, or `/tmp` when unset; macOS: per-user `/var/folders/.../T`) - zero-byte, uid-scoped `hook.<hash>.lock` files, machine-scoped so a same-URL double-start refuses regardless of `$HOME`. Create-and-verified private (not adopted). Safe to remove when no bridge is running |
 
-**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_BRIDGE_ALLOWED_HOSTS`, `_BRIDGE_LOG`, `_BRIDGE_ERR`, `_WAKE_DIR`).
+**Environment variables**: `AGENT_EVENT_BUS_*` prefix (e.g., `_DB`, `_LOG`, `_ERR`, `_URL`, `_AUTH_DISABLED`, `_ICON`, `_TESTING`, `_SESSION_ID`; bridge: `_BRIDGE_PORT`, `_BRIDGE_BACKEND`, `_BRIDGE_COOLDOWN`, `_BRIDGE_SECRET`, `_BRIDGE_HOOK_URL`, `_BRIDGE_BIND`, `_BRIDGE_ALLOWED_HOSTS`, `_WAKE_DIR`; and `_BRIDGE_LOG` / `_BRIDGE_ERR`, which -
+unlike every other `_BRIDGE_*` name - are **install-time only**: they are read by
+`scripts/install-bridge-launchagent.sh` and baked into the plist, so they must be in
+the environment of `make install-bridge` itself. Setting them for a running bridge
+does nothing, exactly as with the bus's `_LOG` / `_ERR` pair).
 One consulted variable is deliberately outside the prefix: **`CLAUDE_CODE_SESSION_ID`**, which the CLI reads as a session-attribution fallback when `--session-id` and `AGENT_EVENT_BUS_SESSION_ID` are both absent (#137).
 
 ---

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -63,6 +63,12 @@ accumulates rather than overwrites, and the bridge needs no append-mode file
 handler of its own. The split follows from `basicConfig` being stderr-only:
 bridge records land in `.err`, while `.log` collects uvicorn's access lines.
 
+Both default under the data dir and are overridable with
+`AGENT_EVENT_BUS_BRIDGE_LOG` / `_ERR` - but unlike every other `_BRIDGE_*`
+name, those two are **install-time only**: the installer reads them and bakes
+the result into the plist, so they must be in the environment of
+`make install-bridge` itself. Setting them for a running bridge does nothing.
+
 ## Verifying supervision
 
 The test suite mocks launchd entirely, so these four are manual - and two of
@@ -78,11 +84,14 @@ them check claims the unit's own comments make:
    bus-less: `/health` shows `registered: false`. Load the bus; within ~30s
    it flips to `true` with no intervention. This is `register_with_retry`'s
    backoff doing its job. The restart is the step that makes this
-   reproducible - `registered` is the *startup* result and is never
-   re-verified, so unloading the bus under a bridge that `install-bridge`
-   just left registered leaves `/health` still reporting `true`. Corollary:
-   `/health` is not a bus-liveness probe. It answers "did I register at
-   startup", not "am I registered now".
+   reproducible - `registered` is the result of the *last registration
+   attempt*, never re-checked against the bus afterwards. (The retry thread
+   writes it, which is what the flip above is; what never happens is
+   re-validation once that thread succeeds and stops.) So unloading the bus
+   under a bridge that `install-bridge` just left registered leaves `/health`
+   still reporting `true`. Corollary: `/health` is not a bus-liveness probe.
+   It answers "did my last registration attempt succeed", not "am I
+   registered now".
 3. **Reboot** - the actual requirement. `RunAtLoad` plus login.
 4. **Clean unload** - `make uninstall-bridge`, then confirm the webhook row
    is gone and port 8082 is free.

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -56,12 +56,12 @@ bridge can start before the bus is listening. `register_with_retry` backs off
 does. That is also why the installer's `registered: false` is a status line
 and not an error.
 
-**The bridge log is launchd's stdout/stderr capture** and launchd
-**truncates it on every restart** - the bridge logs via `basicConfig`
-(stderr) and has no append-mode file logger like the bus does. A crash loop
-therefore overwrites earlier iterations; `ThrottleInterval` (10s) is what
-keeps the surviving window useful. Giving the bridge its own file handler is
-the follow-up that removes this caveat.
+**The bridge log is launchd's stdout/stderr capture**, and launchd
+**appends** across restarts - verified on the bus host: after a `kill -9`
+respawn the `.err` still held the prior PID's startup lines. So a crash loop
+accumulates rather than overwrites, and the bridge needs no append-mode file
+handler of its own. The split follows from `basicConfig` being stderr-only:
+bridge records land in `.err`, while `.log` collects uvicorn's access lines.
 
 ## Verifying supervision
 
@@ -74,9 +74,15 @@ them check claims the unit's own comments make:
    the startup sweep reclaims the dead instance's webhook row instead of
    leaving a duplicate: `agent-event-bus-cli webhook list --all` should show
    one.
-2. **Boot order** - unload the bus, load the bridge: `/health` shows
-   `registered: false`. Load the bus; within ~30s it flips to `true` with no
-   intervention. This is `register_with_retry`'s backoff doing its job.
+2. **Boot order** - unload the bus, then **restart the bridge** so it starts
+   bus-less: `/health` shows `registered: false`. Load the bus; within ~30s
+   it flips to `true` with no intervention. This is `register_with_retry`'s
+   backoff doing its job. The restart is the step that makes this
+   reproducible - `registered` is the *startup* result and is never
+   re-verified, so unloading the bus under a bridge that `install-bridge`
+   just left registered leaves `/health` still reporting `true`. Corollary:
+   `/health` is not a bus-liveness probe. It answers "did I register at
+   startup", not "am I registered now".
 3. **Reboot** - the actual requirement. `RunAtLoad` plus login.
 4. **Clean unload** - `make uninstall-bridge`, then confirm the webhook row
    is gone and port 8082 is free.

--- a/scripts/com.evansenter.agent-event-bus-bridge.plist
+++ b/scripts/com.evansenter.agent-event-bus-bridge.plist
@@ -50,19 +50,18 @@
     <key>KeepAlive</key>
     <true/>
 
-    <!-- launchd's default respawn throttle, stated explicitly because it is
-         load-bearing here: it bounds how fast a crash loop rewrites the log
-         below, and how fast a failing bridge re-registers against the bus. -->
+    <!-- launchd's default respawn throttle, stated explicitly so the unit
+         describes its own restart cadence: it bounds how fast a failing
+         bridge re-registers against the bus. -->
     <key>ThrottleInterval</key>
     <integer>10</integer>
 
     <!-- The bridge logs via logging.basicConfig, which is stderr-only, so
-         this file IS the bridge's log - there is no separate append-mode
-         file logger like the bus has. launchd TRUNCATES these on every
-         process start, so a crash loop overwrites the evidence of earlier
-         iterations; ThrottleInterval above is what keeps the surviving
-         window useful. Giving the bridge its own append-mode file handler
-         is the follow-up that removes this caveat. -->
+         the .err file IS the bridge's log; the .log file receives uvicorn's
+         access lines. launchd APPENDS to both across restarts (verified on
+         the bus host: after a kill -9 respawn the .err still held the prior
+         PID's startup lines), so history survives a crash loop and the
+         bridge needs no file handler of its own. -->
     <key>StandardOutPath</key>
     <string>__BRIDGE_LOG_FILE__</string>
 

--- a/scripts/com.evansenter.agent-event-bus-bridge.plist
+++ b/scripts/com.evansenter.agent-event-bus-bridge.plist
@@ -52,7 +52,10 @@
 
     <!-- launchd's default respawn throttle, stated explicitly so the unit
          describes its own restart cadence: it bounds how fast a failing
-         bridge re-registers against the bus. -->
+         bridge re-registers against the bus.
+         install-bridge-launchagent.sh sleeps this out (12s = this + margin)
+         on a re-install so /health answers from the NEW instance - raise
+         this and raise that sleep too, or the gate under-waits. -->
     <key>ThrottleInterval</key>
     <integer>10</integer>
 

--- a/scripts/com.evansenter.agent-event-bus.plist
+++ b/scripts/com.evansenter.agent-event-bus.plist
@@ -38,7 +38,8 @@
     <key>KeepAlive</key>
     <true/>
 
-    <!-- Note: launchd truncates on restart; Python logger handles append to .log file -->
+    <!-- launchd APPENDS to these across restarts (verified empirically);
+         the Python logger also appends to its own .log file. -->
     <key>StandardOutPath</key>
     <string>__HOME__/.claude/contrib/agent-event-bus/agent-event-bus.stdout</string>
 

--- a/scripts/com.evansenter.agent-event-bus.plist
+++ b/scripts/com.evansenter.agent-event-bus.plist
@@ -38,8 +38,11 @@
     <key>KeepAlive</key>
     <true/>
 
-    <!-- launchd APPENDS to these across restarts (verified empirically);
-         the Python logger also appends to its own .log file. -->
+    <!-- launchd APPENDS to these across restarts - verified on the bridge's
+         equivalents, where a kill -9 respawn left the prior PID's lines in
+         place; same launchd behaviour applies here. Note StandardOutPath is
+         a THIRD file (.stdout), not the Python logger's .log, which
+         AGENT_EVENT_BUS_LOG moves and which appends on its own. -->
     <key>StandardOutPath</key>
     <string>__HOME__/.claude/contrib/agent-event-bus/agent-event-bus.stdout</string>
 

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -27,8 +27,8 @@ fi
 # the module alone would not surface its absence - and a missing uvicorn is
 # precisely the crash-loop this check exists to prevent. A stale venv missing
 # a bridge dependency would otherwise become an import crash-loop under
-# KeepAlive - the one case where the log-truncation caveat bites hardest, since
-# every respawn wipes the previous traceback. Checking beats syncing: `uv sync
+# KeepAlive - respawning every ThrottleInterval forever, never serving a
+# delivery, with /health never answering to say so. Checking beats syncing: `uv sync
 # --no-dev` (what install-server runs) would silently strip pytest/ruff from a
 # venv someone just set up with `make dev`.
 # mktemp, not a predictable /tmp path: the 2> redirect follows symlinks, so a
@@ -62,11 +62,11 @@ mkdir -p "$DATA_DIR"
 # the job simply fails to start.
 mkdir -p "$(dirname "$BRIDGE_LOG_FILE")" "$(dirname "$BRIDGE_ERR_FILE")"
 
-REPLACED_LIVE_BRIDGE=false
+REPLACED_LOADED_JOB=false
 if launchctl list | grep -q "$LABEL$"; then
     echo "Stopping existing bridge service..."
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    REPLACED_LIVE_BRIDGE=true
+    REPLACED_LOADED_JOB=true
 fi
 
 echo "Installing bridge LaunchAgent..."
@@ -89,9 +89,17 @@ launchctl load "$PLIST_DEST"
 # and running" and the outgoing registered: value while the replacement had
 # just exited on the singleton flock, not to return for ~ThrottleInterval.
 # /health carries nothing instance-specific to tell them apart, so wait the
-# throttle out first. Skipped entirely on a fresh install, where the first
-# answer can only come from the process we just started.
-if [[ "$REPLACED_LIVE_BRIDGE" == true ]]; then
+# throttle out first. Skipped on a fresh install, where no job was displaced.
+#
+# Two honest limits. The flag is set from `launchctl list`, which reports the
+# JOB is loaded, not that a process is alive - a loaded-but-dead job pays the
+# wait for no handoff. And 12s bounds ThrottleInterval, not the outgoing
+# shutdown: an unregister retrying against a slow bus can outlive it, and an
+# unsupervised `uv run agent-event-bus-bridge` already holding 8082 produces
+# the same shape on the fresh-install path. Both dissolve once /health carries
+# something instance-specific (a pid or start timestamp), which would let the
+# poll assert it is talking to the new process and drop this sleep entirely.
+if [[ "$REPLACED_LOADED_JOB" == true ]]; then
     echo "Waiting out the restart throttle so /health reports the NEW instance..."
     sleep 12
 fi

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -22,20 +22,26 @@ if [[ ! -f "$VENV_PYTHON" ]]; then
     exit 1
 fi
 
-# Preflight the import rather than running `uv sync` here. A stale venv missing
+# Preflight the imports rather than running `uv sync` here. uvicorn is listed
+# explicitly because bridge.py imports it lazily INSIDE main(), so importing
+# the module alone would not surface its absence - and a missing uvicorn is
+# precisely the crash-loop this check exists to prevent. A stale venv missing
 # a bridge dependency would otherwise become an import crash-loop under
 # KeepAlive - the one case where the log-truncation caveat bites hardest, since
 # every respawn wipes the previous traceback. Checking beats syncing: `uv sync
 # --no-dev` (what install-server runs) would silently strip pytest/ruff from a
 # venv someone just set up with `make dev`.
-if ! PYTHONPATH="$PROJECT_DIR/src" "$VENV_PYTHON" -c "import agent_event_bus.bridge" 2>/tmp/bridge-import-check.$$; then
-    echo "Error: the venv cannot import agent_event_bus.bridge:"
-    sed 's/^/  /' /tmp/bridge-import-check.$$
-    rm -f /tmp/bridge-import-check.$$
+# mktemp, not a predictable /tmp path: the 2> redirect follows symlinks, so a
+# pre-planted file of a guessable name would be truncated as the installing
+# user. The trap also covers an interrupt between creation and cleanup.
+IMPORT_ERR="$(mktemp "${TMPDIR:-/tmp}/agent-event-bus-bridge-import.XXXXXX")"
+trap 'rm -f "$IMPORT_ERR"' EXIT
+if ! PYTHONPATH="$PROJECT_DIR/src" "$VENV_PYTHON" -c "import agent_event_bus.bridge, uvicorn" 2>"$IMPORT_ERR"; then
+    echo "Error: the venv cannot import the bridge and its runtime deps:"
+    sed 's/^/  /' "$IMPORT_ERR"
     echo "Run: make dev   (or: uv sync)"
     exit 1
 fi
-rm -f /tmp/bridge-import-check.$$
 
 # The bridge is useless without a bus to register against. It would retry with
 # backoff rather than die (register_with_retry), so this is a warning and not a
@@ -51,10 +57,16 @@ fi
 
 mkdir -p "$HOME/Library/LaunchAgents"
 mkdir -p "$DATA_DIR"
+# The log paths are overridable and may point outside DATA_DIR; launchd
+# cannot create a missing parent for StandardOutPath/StandardErrorPath and
+# the job simply fails to start.
+mkdir -p "$(dirname "$BRIDGE_LOG_FILE")" "$(dirname "$BRIDGE_ERR_FILE")"
 
+REPLACED_LIVE_BRIDGE=false
 if launchctl list | grep -q "$LABEL$"; then
     echo "Stopping existing bridge service..."
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    REPLACED_LIVE_BRIDGE=true
 fi
 
 echo "Installing bridge LaunchAgent..."
@@ -67,14 +79,23 @@ sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
 echo "Starting bridge..."
 launchctl load "$PLIST_DEST"
 
-# POLL rather than sleep a fixed interval. On a re-install over a live bridge,
-# `launchctl unload` returns as soon as SIGTERM is delivered, so the outgoing
-# process can still hold the singleton flock and port 8082 when the replacement
-# starts. The replacement then exits on the lock - correctly; that ordering is
-# what keeps the outgoing instance's unregister from racing a new registration
-# - and KeepAlive only retries after ThrottleInterval (~10s). A flat 2s probe
-# lands inside that window and reports a perfectly healthy idempotent
-# re-install as a failure. 20s covers the throttle with room to spare.
+# POLL rather than sleep a fixed interval - but only after the handoff has
+# had time to resolve, when there was one. `launchctl unload` returns as soon
+# as SIGTERM is delivered, and the outgoing bridge keeps port 8082 through its
+# shielded stop-join-unregister. So an immediate probe is answered by the
+# instance that is about to DIE: HEALTH would be set from it, the loop would
+# break, and the `launchctl list` check below reports only that the JOB is
+# loaded, not that a process is alive - so the script would print "installed
+# and running" and the outgoing registered: value while the replacement had
+# just exited on the singleton flock, not to return for ~ThrottleInterval.
+# /health carries nothing instance-specific to tell them apart, so wait the
+# throttle out first. Skipped entirely on a fresh install, where the first
+# answer can only come from the process we just started.
+if [[ "$REPLACED_LIVE_BRIDGE" == true ]]; then
+    echo "Waiting out the restart throttle so /health reports the NEW instance..."
+    sleep 12
+fi
+
 HEALTH=""
 for _ in $(seq 1 40); do
     HEALTH="$(curl -fsS --max-time 2 http://127.0.0.1:8082/health 2>/dev/null || true)"

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -36,6 +36,10 @@ fi
 # user. The trap also covers an interrupt between creation and cleanup.
 IMPORT_ERR="$(mktemp "${TMPDIR:-/tmp}/agent-event-bus-bridge-import.XXXXXX")"
 trap 'rm -f "$IMPORT_ERR"' EXIT
+# uvicorn is named explicitly because bridge.py imports it lazily INSIDE
+# main(), so importing the module alone would not surface its absence. Keep
+# this list in sync with the deferred imports in bridge.py:main() - a second
+# one added there silently reopens the crash-loop hole this check closes.
 if ! PYTHONPATH="$PROJECT_DIR/src" "$VENV_PYTHON" -c "import agent_event_bus.bridge, uvicorn" 2>"$IMPORT_ERR"; then
     echo "Error: the venv cannot import the bridge and its runtime deps:"
     sed 's/^/  /' "$IMPORT_ERR"
@@ -91,6 +95,12 @@ launchctl load "$PLIST_DEST"
 # /health carries nothing instance-specific to tell them apart, so wait the
 # throttle out first. Skipped on a fresh install, where no job was displaced.
 #
+# The 12 is ThrottleInterval (10, set in the plist) plus margin, and the two
+# are coupled with nothing but this comment to link them: raise the plist's
+# ThrottleInterval without raising this and the gate under-waits, letting the
+# dying instance answer the poll again - the exact failure it was added to
+# close. The plist comment points back here.
+#
 # Two honest limits. The flag is set from `launchctl list`, which reports the
 # JOB is loaded, not that a process is alive - a loaded-but-dead job pays the
 # wait for no handoff. And 12s bounds ThrottleInterval, not the outgoing
@@ -140,7 +150,11 @@ if [[ -n "$HEALTH" ]]; then
             echo "  Not registered yet - retrying with backoff (is the bus up?)." ;;
     esac
 else
-    echo "  /health did not answer within 20s; check $BRIDGE_ERR_FILE."
+    # No elapsed figure: the poll's real bound is 20s only if every probe
+    # fails instantly (40 x sleep 0.5) and ~100s if they all hang out to
+    # --max-time 2, and the re-install path adds the 12s throttle wait ahead
+    # of it. The log path is what the operator needs anyway.
+    echo "  /health did not answer; check $BRIDGE_ERR_FILE."
 fi
 
 echo ""

--- a/src/agent_event_bus/bridge.py
+++ b/src/agent_event_bus/bridge.py
@@ -26,8 +26,9 @@ a spool line only becomes a wake when the drain hook acts on it, so bounding
 that belongs to the drain hook.
 
 Run:  uv run agent-event-bus-bridge [--backend tmux] [--port 8082] ...
-(from the repo checkout - the console script lives in the project venv;
-nothing puts it on PATH yet, that lands with the supervision story)
+(from the repo checkout - the console script lives in the project venv and
+nothing puts it on PATH; on macOS `make install-bridge` supervises it as a
+LaunchAgent instead)
 The bridge registers its own webhook on the bus at startup (HMAC-signed when
 AGENT_EVENT_BUS_BRIDGE_SECRET is set) and unregisters it on clean shutdown.
 """


### PR DESCRIPTION
#139's round-2 review follow-ups (they merged on its approval before they were pushed), plus corrections to two claims that running #139 on the real bus host proved false — **both of them mine**.

Rebased onto `ffdfcec` (#143). Note the docs corrections now land in `docs/BRIDGE.md`, not `guide.md`: #138 moved the bridge operator docs there while this branch was open, and the rebase resolved my original `guide.md` hunks away with the section they lived in. Same corrections, re-landed in the file the content moved to.

## Corrections from the host

**launchd appends; it does not truncate.** After a `kill -9` respawn, the bridge's `.err` still held the previous PID's startup lines and both webhook entries. So:

- The "crash loop eats its own evidence" caveat I documented **doesn't exist**.
- The append-mode file handler it motivated is **moot**.
- `ThrottleInterval`'s stated justification loses that half.

The same false claim lived in the **bus** plist — which is where I copied it from — so it's corrected there too. The `.err`-vs-`.log` split is unaffected and now stated on its actual cause: `basicConfig` is stderr-only.

**`/health`'s `registered` is cached, so my boot-order check wasn't reproducible.** It reports the *startup* result and is never re-verified. Against a bridge that `make install-bridge` just left registered, unloading the bus leaves `/health` still saying `registered: true`; the `false` state only appears when the bridge itself starts bus-less. Added the missing "restart the bridge" step, and stated the corollary plainly:

> **`/health` is not a bus-liveness probe.** It answers "did I register at startup", not "am I registered now".

Notably the `/health` bullet further down that same file *already* said the row isn't re-verified — the checklist I added in #139 contradicted a caveat sitting a few hundred lines above it.

## Installer hardening

Round-2 suggestions, all against code #139 added:

- **`/tmp` symlink hazard** — the import preflight wrote stderr to a predictable path. `2>` follows symlinks, so a pre-planted file would be truncated as the installing user, and it leaked on interrupt. Now `mktemp` under `$TMPDIR` with a `trap`.
- **`uvicorn` invisible to the preflight** — it's imported lazily *inside* `main()`, so the one dependency whose absence causes the crash-loop the preflight exists to prevent was the one it couldn't see.
- **`mkdir -p` for log parents** — an `AGENT_EVENT_BUS_BRIDGE_LOG` outside the data dir left launchd unable to open `StandardOutPath`, so the job just failed to start.
- **Health poll waited on the wrong instance** — it broke on the first answer, which on a re-install comes from the *outgoing* process still holding port 8082 through its shielded stop-join-unregister. Now waits out `ThrottleInterval`, but only when a live instance was actually displaced.
- **`_BRIDGE_LOG` / `_BRIDGE_ERR` documented as install-time only** — unlike every other `_BRIDGE_*` name they're read by the installer and baked into the plist; setting them for a running bridge does nothing.
- **`bridge.py`'s module docstring** no longer defers PATH/supervision to "the supervision story" that #139 *is*.

**Declined:** reflowing the supervision sections below the backend bullet list. The suggestion is right that the bullets now attach to the wrong heading, but that reflow is larger than the fix and worth doing deliberately rather than as a rider — and #138 has since moved the whole file, so it wants doing against the new layout.

## Verified on the host, not just here

- #137's fallback attributes a non-interactive `zsh -c` publish to the real session id (event 4638) — precondition confirmed inside the subshell (`AGENT_EVENT_BUS_SESSION_ID` empty, `CLAUDE_CODE_SESSION_ID` present).
- #139 crash restart: respawn in ~1s, `webhook list` shows exactly one row, log reads `Removed stale bridge webhook #2` → `Registered bridge webhook #3`.
- #139 boot order: `registered: false` while bus-less, flipped to `true` in 5s unaided.

`make check` green on the rebase: **649 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R