### PR TITLE
fix: reject get_events polls from soft-deleted sessions (#140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ CLI and MCP expose the same functionality:
 - **Cursor auto-tracking**: `get_events(session_id=X)` persists cursor; `resume=True` uses it
 - **Non-consuming narrowed reads**: `channel`/`event_types`/`correlation_id` filters never advance the session cursor (their SQL-filtered max would mark non-matching events as seen); `min_level` filters post-bookkeeping and does
 - **High-water cursors**: `next_cursor` is the batch MAX id in both orders; feeding it back never re-serves events
+- **Deleted sessions fail loudly (#140)**: `get_events` with a soft-deleted `session_id` returns `{"error": "Session deleted", "session_deleted": true, ...}` on *every* read path, not just `resume`. A deleted session's cursor and heartbeat are both frozen, so an empty batch is indistinguishable from "up to date" while the session is also absent from `list_sessions` - the failure was silent on every axis. Ids never registered here stay silent (foreign session ids are a supported way to read the bus)
 - **UUID session IDs**: `session_id` is UUID; `display_id` is human-readable ("brave-trex")
 - **Client deduplication**: `(machine, client_id)` enables session resumption
 - **Structured payload (RFC #121)**: `payload` stays free-form; optional `title`/`tags`/`correlation_id`/`signal_level` ride alongside (soft validation - warn, never reject)

--- a/src/agent_event_bus/cli.py
+++ b/src/agent_event_bus/cli.py
@@ -315,12 +315,17 @@ def cmd_events(args):
         "get_events", arguments, url=args.url, timeout_ms=args.timeout, debug=args.debug
     )
 
-    # Check for server-side errors (e.g., session not found)
+    # Check for server-side errors (e.g., session not found or deleted)
     if "error" in result:
         if args.json:
             print(json.dumps(result))
         else:
-            print(f"Error: {result['error']}", file=sys.stderr)
+            message = f"Error: {result['error']}"
+            # #140: the hint carries the actionable half ("re-register or stop
+            # polling") - dropping it leaves an orphaned poller with no next step
+            if result.get("hint"):
+                message += f"\n{result['hint']}"
+            print(message, file=sys.stderr)
         sys.exit(1)
 
     # Result is now a dict with "events", "next_cursor", and "has_more"

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -44,6 +44,8 @@ get_events(session_id="my-unique-id", resume=True, order="asc")
 ```
 - `resume=True` picks up where you left off (cursor auto-tracked)
 - `order="asc"` returns events chronologically
+- An empty `events` list means "you are up to date" — a *deleted* session gets
+  an error instead, never an empty batch (see [Deleted sessions](#deleted-sessions))
 
 ### 3. Publish to coordinate
 ```
@@ -163,6 +165,48 @@ get_events(session_id=session_id, resume=True, peek=True)
 get_events(session_id=session_id, resume=True, order="asc")
 ```
 CLI: `agent-event-bus-cli events --session-id ID --resume --peek`
+
+### Deleted sessions
+
+Polling as a session that has been unregistered — or soft-deleted by the
+24-hour heartbeat timeout — is an **error**, not an empty result:
+
+```
+get_events(session_id="stale-id", resume=True)
+→ {
+    error: "Session deleted",
+    session_deleted: true,
+    session_id: "stale-id",
+    display_id: "grand-bison",
+    deleted_at: "2026-03-21T11:04:00",
+    hint: "..."
+  }
+```
+
+Every read path is checked (`resume`, an explicit `cursor`, `peek`, and
+narrowed reads), because a deleted session's cursor and heartbeat are both
+frozen: it can never advance, never appears in `list_sessions`, and would
+otherwise poll forever getting batches indistinguishable from "up to date".
+
+**Handling it**: call `register_session` with the same `client_id` to revive
+the session (it keeps its `display_id` and `last_cursor`), or stop polling.
+Do not retry the same `session_id` — the result will not change on its own.
+The CLI exits non-zero and prints the hint to stderr.
+
+Session ids that were *never* registered here stay silent — foreign ids (like
+Claude Code's own UUIDs) are a supported way to read the bus. Only ids the bus
+knows it deleted are an error. The one exception predates this: `resume=True`
+with an unknown id returns `{"error": "Session not found"}`, since there is no
+cursor to resume from.
+
+**Finding orphaned pollers** on a bus host:
+
+```sql
+SELECT display_id, last_cursor, deleted_at FROM sessions WHERE deleted_at IS NOT NULL;
+```
+
+Then grep the server log for those `display_id`s — recent hits render as
+`ERROR: Session deleted`.
 
 ## Structured Payload Fields
 

--- a/src/agent_event_bus/guide.md
+++ b/src/agent_event_bus/guide.md
@@ -190,8 +190,11 @@ otherwise poll forever getting batches indistinguishable from "up to date".
 
 **Handling it**: call `register_session` with the same `client_id` to revive
 the session (it keeps its `display_id` and `last_cursor`), or stop polling.
-Do not retry the same `session_id` — the result will not change on its own.
-The CLI exits non-zero and prints the hint to stderr.
+`client_id` is the only key revival matches on — a session originally
+registered without one cannot be revived, and re-registering mints a fresh
+`session_id`, `display_id`, and cursor. Either way, do not retry the same
+`session_id`: the result will not change on its own. The CLI exits non-zero
+and prints the hint to stderr.
 
 Session ids that were *never* registered here stay silent — foreign ids (like
 Claude Code's own UUIDs) are a supported way to read the bus. Only ids the bus
@@ -205,8 +208,15 @@ cursor to resume from.
 SELECT display_id, last_cursor, deleted_at FROM sessions WHERE deleted_at IS NOT NULL;
 ```
 
-Then grep the server log for those `display_id`s — recent hits render as
-`ERROR: Session deleted`.
+Then grep the server log for those `display_id`s. The request log prefixes
+every call with the caller's name, so an orphaned poller's rejections read:
+
+```
+[grand-bison] get_events(order=asc, limit=20, resume=true) → ERROR: Session deleted
+```
+
+Recent hits mean the poller is still running. The server also logs one
+`WARNING` naming the session the first time it is rejected after a restart.
 
 ## Structured Payload Fields
 

--- a/src/agent_event_bus/middleware.py
+++ b/src/agent_event_bus/middleware.py
@@ -31,11 +31,17 @@ def _lookup_session_display_id(session_id: str) -> str | None:
     Session IDs are now UUIDs (or client_ids). This resolves them to
     human-readable display names like "brave-trex".
 
+    Soft-deleted sessions resolve too (#140): they are exactly the ones an
+    operator needs to find in the log - a deleted session's rejected polls
+    would otherwise log under a truncated UUID, and a deleted publisher would
+    drop out of the "from:" list entirely rather than rendering in red as the
+    active/inactive colouring below intends.
+
     Returns the display_id if found, None otherwise.
     """
     try:
         storage = _get_storage()
-        session = storage.get_session(session_id)
+        session = storage.get_session(session_id, include_deleted=True)
         return session.display_id if session else None
     except Exception:
         return None

--- a/src/agent_event_bus/middleware.py
+++ b/src/agent_event_bus/middleware.py
@@ -198,7 +198,13 @@ def _format_result(result) -> str:
         s = str(result)
         return s[:60] + "..." if len(s) > 60 else s
 
-    # Handle common result patterns with colors
+    # Handle common result patterns with colors.
+    # Errors are checked first: they carry the same keys as success results
+    # (an error about a session still has "session_id"), so a later branch
+    # would render them as if nothing were wrong - which is how #140's
+    # deleted-session polling stayed invisible in the log for months.
+    if "error" in result:
+        return f"{_RED}ERROR:{_RESET} {result['error']}"
     if "session_id" in result:
         # For session results, prefer display_id if available, otherwise look it up
         sid = result["session_id"]
@@ -284,8 +290,6 @@ def _format_result(result) -> str:
         return f"{_CYAN}{len(result['channels'])} channels{_RESET}"
     if "success" in result:
         return f"{_GREEN}OK{_RESET}" if result["success"] else f"{_RED}FAILED{_RESET}"
-    if "error" in result:
-        return f"{_RED}ERROR:{_RESET} {result['error']}"
 
     # Fallback: show keys
     keys = ", ".join(result.keys()) if result else "{}"

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -545,8 +545,20 @@ def _get_implicit_channels(session_id: str | None) -> list[str] | None:
 _warned_deleted_sessions: set[tuple[str, str]] = set()
 
 
-def _deleted_session_error(session_id: str | None) -> dict | None:
-    """Return an error dict if `session_id` names a soft-deleted session (#140).
+def _load_polling_session(session_id: str | None) -> Session | None:
+    """Load the session behind a read, soft-deleted ones included (#140).
+
+    One lookup serves both the deleted-session check and the resume branch's
+    cursor read - `get_events` is the highest-frequency call on the bus, and
+    an orphaned poller is exactly the load this change exists to surface.
+    """
+    if not session_id or session_id == "anonymous":
+        return None
+    return storage.get_session(session_id, include_deleted=True)
+
+
+def _deleted_session_error(session: Session | None) -> dict | None:
+    """Return an error dict if `session` is soft-deleted (#140).
 
     A deleted session's cursor and heartbeat are both frozen (every write is
     guarded by `deleted_at IS NULL`), so an orphaned poller re-asks from the
@@ -558,12 +570,10 @@ def _deleted_session_error(session_id: str | None) -> dict | None:
     ids (Claude Code's own UUIDs) that were never registered here. Only an id
     we know we deleted is an error.
     """
-    if not session_id or session_id == "anonymous":
-        return None
-    session = storage.get_session(session_id, include_deleted=True)
     if session is None or session.deleted_at is None:
         return None
 
+    session_id = session.id
     deleted_at = session.deleted_at
     deleted_at_str = deleted_at.isoformat() if hasattr(deleted_at, "isoformat") else str(deleted_at)
 
@@ -627,17 +637,19 @@ def _get_events_impl(
     # Fail loudly for soft-deleted sessions (#140) - checked on every read
     # path, not just resume: a client feeding next_cursor back by hand never
     # touches the resume branch and would otherwise poll forever unnoticed.
-    deleted = _deleted_session_error(session_id)
+    session = _load_polling_session(session_id)
+    deleted = _deleted_session_error(session)
     if deleted:
         return deleted
 
     # Auto-refresh heartbeat when session polls
     _auto_heartbeat(session_id)
 
-    # Resume from saved cursor if requested
+    # Resume from saved cursor if requested. `session` is the row loaded
+    # above - active by this point, and _auto_heartbeat only touches
+    # last_heartbeat, so its last_cursor is still current.
     # Only applies when: resume=True, session_id provided, cursor not provided
     if resume and session_id and cursor is None:
-        session = storage.get_session(session_id)
         if session and session.last_cursor:
             cursor = session.last_cursor
         elif session and (peek or channel or event_types or correlation_id):

--- a/src/agent_event_bus/server.py
+++ b/src/agent_event_bus/server.py
@@ -538,6 +538,59 @@ def _get_implicit_channels(session_id: str | None) -> list[str] | None:
     return None
 
 
+# (session_id, deleted_at) pairs already warned about, so an orphaned poller
+# hammering the bus every 5s contributes one WARNING rather than 100k of them.
+# Keyed on deleted_at too: a session that is revived and later deleted again is
+# a fresh incident and warns again. Bounded by the sessions table.
+_warned_deleted_sessions: set[tuple[str, str]] = set()
+
+
+def _deleted_session_error(session_id: str | None) -> dict | None:
+    """Return an error dict if `session_id` names a soft-deleted session (#140).
+
+    A deleted session's cursor and heartbeat are both frozen (every write is
+    guarded by `deleted_at IS NULL`), so an orphaned poller re-asks from the
+    same position forever and gets an empty batch that is indistinguishable
+    from "you are up to date" - while staying invisible in `list_sessions`.
+    Failing the read loudly is the only thing either side can notice.
+
+    Unregistered ids stay silent: callers legitimately pass foreign session
+    ids (Claude Code's own UUIDs) that were never registered here. Only an id
+    we know we deleted is an error.
+    """
+    if not session_id or session_id == "anonymous":
+        return None
+    session = storage.get_session(session_id, include_deleted=True)
+    if session is None or session.deleted_at is None:
+        return None
+
+    deleted_at = session.deleted_at
+    deleted_at_str = deleted_at.isoformat() if hasattr(deleted_at, "isoformat") else str(deleted_at)
+
+    warn_key = (session_id, deleted_at_str)
+    if warn_key not in _warned_deleted_sessions:
+        _warned_deleted_sessions.add(warn_key)
+        logger.warning(
+            f"get_events: rejecting polls from deleted session {session.display_id} "
+            f"({session_id[:8]}..., deleted_at={deleted_at_str}) - an orphaned "
+            f"client is still polling. Further rejections are logged per-call by "
+            f"the request middleware."
+        )
+        _dev_notify("get_events", f"deleted session polled: {session.display_id}")
+
+    return {
+        "error": "Session deleted",
+        "session_deleted": True,
+        "session_id": session_id,
+        "display_id": session.display_id,
+        "deleted_at": deleted_at_str,
+        "hint": (
+            "This session was unregistered or timed out, and its cursor is frozen. "
+            "Call register_session to get a live session, or stop polling."
+        ),
+    }
+
+
 def _event_to_dict(e: Event) -> dict:
     """Convert an Event to its wire representation."""
     d = {
@@ -571,6 +624,13 @@ def _get_events_impl(
     min_level: Literal["lifecycle", "info", "actionable"] | None = None,
 ) -> dict:
     """Sync implementation of get_events (runs in a worker thread)."""
+    # Fail loudly for soft-deleted sessions (#140) - checked on every read
+    # path, not just resume: a client feeding next_cursor back by hand never
+    # touches the resume branch and would otherwise poll forever unnoticed.
+    deleted = _deleted_session_error(session_id)
+    if deleted:
+        return deleted
+
     # Auto-refresh heartbeat when session polls
     _auto_heartbeat(session_id)
 
@@ -599,7 +659,7 @@ def _get_events_impl(
                 "has_more": False,
             }
         else:
-            # Session doesn't exist
+            # Session was never registered (deleted ones are rejected above)
             logger.debug(
                 f"get_events: resume failed, session not found session_id={session_id[:8]}..."
             )
@@ -683,7 +743,9 @@ async def get_events(
     """Get events. Auto-refreshes heartbeat. Returns events list and next_cursor for pagination.
 
     Narrowed reads (channel/event_types/correlation_id) never advance the
-    session cursor; min_level does.
+    session cursor; min_level does. A deleted session_id returns
+    {"error": ..., "session_deleted": true} instead of an empty batch -
+    re-register or stop polling.
 
     Args:
         cursor: Position from register_session or previous call

--- a/src/agent_event_bus/storage.py
+++ b/src/agent_event_bus/storage.py
@@ -505,16 +505,20 @@ class SQLiteStorage:
             deleted_at=row["deleted_at"] if "deleted_at" in row.keys() else None,
         )
 
-    def get_session(self, session_id: str) -> Session | None:
-        """Get an active session by ID.
+    def get_session(self, session_id: str, include_deleted: bool = False) -> Session | None:
+        """Get a session by ID.
 
-        Only returns active (non-deleted) sessions.
+        Args:
+            include_deleted: If True, also return soft-deleted sessions (check
+                `session.deleted_at` to tell them apart). Callers that need to
+                distinguish "never registered" from "registered then deleted"
+                need this - the default hides both behind None (#140).
         """
+        query = "SELECT * FROM sessions WHERE id = ?"
+        if not include_deleted:
+            query += " AND deleted_at IS NULL"
         with self._connect() as conn:
-            row = conn.execute(
-                "SELECT * FROM sessions WHERE id = ? AND deleted_at IS NULL",
-                (session_id,),
-            ).fetchone()
+            row = conn.execute(query, (session_id,)).fetchone()
             if row:
                 return self._row_to_session(row)
             return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -564,6 +564,27 @@ class TestCmdEventsErrorSurfacing:
         captured = capsys.readouterr()
         assert "Session not found" in captured.err
 
+    @patch("agent_event_bus.cli.call_tool")
+    def test_events_deleted_session_prints_hint(self, mock_call, capsys):
+        """#140: the hint is the actionable half - re-register or stop polling."""
+        mock_call.return_value = {
+            "error": "Session deleted",
+            "session_deleted": True,
+            "session_id": "stale-id",
+            "display_id": "grand-bison",
+            "hint": "Call register_session to get a live session, or stop polling.",
+        }
+
+        args = make_events_args(session_id="stale-id", resume=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli.cmd_events(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Session deleted" in captured.err
+        assert "register_session" in captured.err
+
 
 class TestCmdUnregisterErrorSurfacing:
     """Tests for CLI surfacing server-side errors in unregister command."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -18,6 +18,7 @@ from agent_event_bus.middleware import (
     _format_session_id_value,
     _get_active_sessions_map,
     _is_human_readable_id,
+    _lookup_session_display_id,
     _parse_sse_response,
 )
 
@@ -216,6 +217,17 @@ class TestFormatResult:
         result = _format_result({"error": "Something went wrong"})
         assert "ERROR:" in result
         assert "Something went wrong" in result
+
+    def test_deleted_session_resolves_to_display_id(self):
+        """The #140 detection procedure is "grep the log for the display_id",
+        so a deleted session's calls must still log under its name rather than
+        a truncated UUID."""
+        from agent_event_bus import server
+
+        reg = server._register_session_impl(name="log-lookup", client_id="log-lookup-client")
+        server.storage.delete_session(reg["session_id"])
+
+        assert _lookup_session_display_id(reg["session_id"]) == reg["display_id"]
 
     def test_error_wins_over_session_id(self):
         """An error about a session still carries session_id; rendering it as

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -217,6 +217,21 @@ class TestFormatResult:
         assert "ERROR:" in result
         assert "Something went wrong" in result
 
+    def test_error_wins_over_session_id(self):
+        """An error about a session still carries session_id; rendering it as
+        a plain session result is how #140 hid in the log for four months."""
+        result = _format_result(
+            {
+                "error": "Session deleted",
+                "session_deleted": True,
+                "session_id": "tender-hawk",
+                "display_id": "tender-hawk",
+            }
+        )
+        assert "ERROR:" in result
+        assert "Session deleted" in result
+        assert "session=" not in result
+
     def test_structured_content_unwrapping(self):
         """FastMCP structuredContent wrapper is unwrapped."""
         wrapped = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1499,3 +1499,129 @@ class TestNarrowedReadsDoNotConsumeCursor:
 
         # The narrowed resume read from the tip without persisting it
         assert server.storage.get_session(sid).last_cursor is None
+
+
+class TestDeletedSessionPolling:
+    """A soft-deleted session must not be able to poll silently (#140).
+
+    Its cursor and heartbeat are frozen, so every poll re-asks from the same
+    position and gets an empty batch - byte-identical to "you are up to date"
+    while the session is also missing from list_sessions. Every read path has
+    to reject it, not just resume.
+    """
+
+    def _deleted_session(self, name):
+        reg = register_session(name=name, client_id=f"{name}-client")
+        sid = reg["session_id"]
+        assert server.storage.delete_session(sid)
+        return sid, reg
+
+    def test_resume_poll_reports_deletion(self):
+        sid, _ = self._deleted_session("deleted-resume")
+
+        result = get_events(session_id=sid, resume=True, order="asc", limit=20)
+
+        assert result["error"] == "Session deleted"
+        assert result["session_deleted"] is True
+        assert result["session_id"] == sid
+        assert result["deleted_at"]
+        assert "events" not in result
+
+    def test_explicit_cursor_poll_reports_deletion(self):
+        """The hole #140 was actually reported through: a client feeding
+        next_cursor back never enters the resume branch."""
+        sid, reg = self._deleted_session("deleted-cursor")
+        publish_event(event_type="note", payload="after deletion")
+
+        result = get_events(session_id=sid, cursor=reg["cursor"], order="asc", limit=20)
+
+        assert result["error"] == "Session deleted"
+        assert result["session_deleted"] is True
+
+    def test_cursorless_poll_reports_deletion(self):
+        sid, _ = self._deleted_session("deleted-bare")
+
+        result = get_events(session_id=sid)
+
+        assert result["error"] == "Session deleted"
+
+    def test_peek_reports_deletion(self):
+        sid, _ = self._deleted_session("deleted-peek")
+
+        result = get_events(session_id=sid, resume=True, peek=True)
+
+        assert result["error"] == "Session deleted"
+
+    def test_narrowed_poll_reports_deletion(self):
+        sid, _ = self._deleted_session("deleted-narrow")
+
+        result = get_events(session_id=sid, channel="all", order="asc")
+
+        assert result["error"] == "Session deleted"
+
+    def test_error_carries_display_id_for_operator_lookup(self):
+        """The detection path in #140 starts from display_id, so the error has
+        to name one - a UUID alone is not greppable against the server log."""
+        sid, reg = self._deleted_session("deleted-display")
+
+        result = get_events(session_id=sid, resume=True)
+
+        assert result["display_id"] == reg["display_id"]
+
+    def test_stale_cleanup_deletion_is_reported(self):
+        """Sessions soft-deleted by the heartbeat timeout - not by an explicit
+        unregister - are the ones that go unnoticed longest."""
+        reg = register_session(name="deleted-stale", client_id="deleted-stale-client")
+        sid = reg["session_id"]
+        server.storage.cleanup_stale_sessions(timeout_seconds=0)
+
+        result = get_events(session_id=sid, resume=True)
+
+        assert result["error"] == "Session deleted"
+
+    def test_unregistered_session_id_stays_silent(self):
+        """Foreign ids (Claude Code's own UUIDs) were never registered here and
+        must keep working - only ids we know we deleted are an error."""
+        publish_event(event_type="note", payload="visible to strangers")
+
+        result = get_events(session_id="never-registered-anywhere", order="desc")
+
+        assert "error" not in result
+        assert len(result["events"]) >= 1
+
+    def test_unregistered_session_id_still_errors_on_resume(self):
+        """Pre-existing behaviour from #115 is unchanged."""
+        result = get_events(session_id="never-registered-either", resume=True)
+
+        assert result["error"] == "Session not found"
+        assert "session_deleted" not in result
+
+    def test_re_registering_restores_polling(self):
+        """The hint tells the caller to re-register; that has to actually work."""
+        sid, _ = self._deleted_session("deleted-revive")
+        assert "error" in get_events(session_id=sid, resume=True)
+
+        register_session(name="deleted-revive", client_id="deleted-revive-client")
+        publish_event(event_type="note", payload="after revival")
+
+        result = get_events(session_id=sid, resume=True, order="asc")
+        assert "error" not in result
+
+    def test_anonymous_session_id_is_not_rejected(self):
+        result = get_events(session_id="anonymous")
+
+        assert "error" not in result
+
+    def test_warning_is_logged_once_per_deletion(self, caplog):
+        """An orphaned poller runs every few seconds; one WARNING per incident
+        is discoverable, 100k of them is the log volume that hid #140."""
+        sid, reg = self._deleted_session("deleted-warn-once")
+
+        with caplog.at_level(logging.WARNING, logger="agent-event-bus"):
+            for _ in range(3):
+                get_events(session_id=sid, resume=True)
+
+        rejections = [r for r in caplog.records if "deleted session" in r.message]
+        assert len(rejections) == 1
+        # display_id is what an operator greps the request log for
+        assert reg["display_id"] in rejections[0].message

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1612,9 +1612,12 @@ class TestDeletedSessionPolling:
 
         assert "error" not in result
 
-    def test_warning_is_logged_once_per_deletion(self, caplog):
+    def test_warning_is_logged_once_per_deletion(self, monkeypatch, caplog):
         """An orphaned poller runs every few seconds; one WARNING per incident
         is discoverable, 100k of them is the log volume that hid #140."""
+        # The warn-once set is module state no fixture resets; isolate it
+        # rather than leaning on deleted_at differing between suite runs
+        monkeypatch.setattr(server, "_warned_deleted_sessions", set())
         sid, reg = self._deleted_session("deleted-warn-once")
 
         with caplog.at_level(logging.WARNING, logger="agent-event-bus"):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -210,6 +210,32 @@ class TestSessionDeduplication:
         assert found.id == "test-123"
         assert found.display_id == "cool-cat"
 
+    def test_get_session_include_deleted(self, storage):
+        """include_deleted=True distinguishes "deleted" from "never existed"."""
+        now = datetime.now()
+        storage.add_session(
+            Session(
+                id="test-123",
+                display_id="cool-cat",
+                name="test-session",
+                machine="localhost",
+                cwd="/test",
+                repo="test",
+                registered_at=now,
+                last_heartbeat=now,
+                client_id="12345",
+            )
+        )
+        storage.delete_session("test-123")
+
+        assert storage.get_session("test-123") is None
+
+        found = storage.get_session("test-123", include_deleted=True)
+        assert found is not None
+        assert found.deleted_at is not None
+
+        assert storage.get_session("no-such-session", include_deleted=True) is None
+
     def test_find_session_by_client_include_deleted_prefers_active(self, storage):
         """Test that include_deleted=True prefers active over deleted sessions."""
         now = datetime.now()


### PR DESCRIPTION
Fixes #140.

## Problem

A client polling as a soft-deleted session got `200` with an empty batch — byte-identical to what a healthy, caught-up client gets. Its cursor and heartbeat are both frozen (every write is guarded by `deleted_at IS NULL`), so it re-asked from the same position forever and never reappeared in `list_sessions`. Silent on every axis. Two sessions on the mac-mini bus host polled every ~5s for four and a half months — ~101k no-op calls — found only by accident.

Reproducing it first showed the hole was narrower and worse than "resume returns empty":

- `resume=True` + no cursor already returned `{"error": "Session not found"}` (from #115).
- **But an explicit `cursor` skips that branch entirely.** A client feeding `next_cursor` back by hand — or polling with no cursor at all, or with `peek`, or narrowed — got a normal result and never learned its session was gone. That is the path the reported case fell through.
- It stayed invisible in the log for a second, independent reason: `_format_result` matched on `session_id` **before** `error`, so a session-shaped error dict rendered as `session=grand-bison`, indistinguishable from success.

## Changes

`get_events` now rejects any `session_id` the bus knows it deleted, checked **before every read path** (resume, explicit cursor, bare, `peek`, narrowed):

```json
{"error": "Session deleted", "session_deleted": true, "session_id": "...",
 "display_id": "grand-bison", "deleted_at": "...", "hint": "..."}
```

Both options the issue proposed — the flag rides along free with the error, so a client can branch on either.

- `storage.get_session(session_id, include_deleted=False)` — lets a caller tell "never registered" from "registered then deleted"; the old default hid both behind `None`.
- `middleware._format_result` checks `error` first, so deleted polls log as `ERROR: Session deleted`.
- One `WARNING` per deletion incident rather than one per poll (keyed on `deleted_at`, so a revived-then-redeleted session warns again); the request middleware already logs per call.
- CLI prints the `hint` to stderr and exits non-zero.

## Backward compatibility

Ids **never registered** here stay silent — foreign session ids (Claude Code's own UUIDs) are a supported way to read the bus, and the existing `_get_events_impl` bookkeeping explicitly tolerates them. Only a row with `deleted_at` set is an error. `resume=True` with an unknown id keeps returning `"Session not found"` (#115), unchanged. A client that hits the new error recovers by calling `register_session` with the same `client_id`, which revives the session with its `display_id` and `last_cursor` intact — covered by a test.

## Relationship to #134

Orthogonal, and deliberately so. This rejects reads by a session that no longer exists, rather than changing what a live client may assume about cursor state it does not own. If #134 introduces explicit acks, `session_deleted` is the natural signal for an ack to fail on too.

## Testing

`make check` — format clean, lint clean, **591 passed** (15 new tests). New coverage: each read path rejected independently, stale-cleanup deletions, foreign ids staying silent, `resume` on unknown ids unchanged, re-registration restoring polling, warn-once, error-wins-over-session_id in the log formatter, and the CLI hint.

## Docs

`guide.md` gains a "Deleted sessions" section including the detection SQL from the issue; `CLAUDE.md` gains the design decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtguxUePLRqPUx3nPq6ikL)_