### PR TITLE
docs: require host-specific claims to be marked unverified

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,46 @@ One consulted variable is deliberately outside the prefix: **`CLAUDE_CODE_SESSIO
 
 ---
 
+## VERIFICATION BOUNDARIES
+
+**Host-specific behavior cannot be verified from a dev container. State such
+claims as unverified and hand them to the bus host; do not assert them.**
+
+In scope: launchd and systemd semantics (restart, throttling, whether a log
+capture appends or truncates), `/health` and anything else about the *running*
+supervised bus or bridge, port binding, `tmux`/`zellij` injection, the real
+`~/.claude/contrib/agent-event-bus/` tree. A container has no launchd, no bus
+process, no multiplexer, and no session on the bus - so a claim about any of
+them is a guess with a confident voice.
+
+This is not hypothetical. Both corrections in #141 were exactly this failure:
+
+- launchd was documented as **truncating** its `StandardOutPath` /
+  `StandardErrorPath` captures on restart. It appends. The wrong claim had
+  propagated into three files and was motivating a follow-up - adding an
+  append-mode file handler to the bridge - that would have been pure cost for a
+  problem that does not exist. The corrected note now lives in the Log files row
+  of the naming table above.
+- A `/health` check was written up as reproducible when `registered` is the
+  cached result of the *last registration attempt* and is never re-checked
+  against the bus. Unloading the bus under a registered bridge leaves `/health`
+  still reporting `true`, so the "verification" verified nothing.
+
+Both were disproved by the bus host in minutes. The cost is not the wrong
+sentence - it is that documentation asserts with the same voice whether or not
+anything was run, so an unverified claim is indistinguishable from a tested one
+and gets built on.
+
+**How to write it instead:** name the check, the expected result, and who has to
+run it - "unverified from this environment; on the bus host, `kill -9` the
+bridge and confirm the `.err` still holds the prior PID's startup lines."
+`docs/BRIDGE.md`'s "Verifying supervision" section is the model: it lists the
+manual checks precisely because the test suite mocks launchd entirely. Tests
+that mock the host verify the caller, never the host's behavior - do not cite a
+passing suite as evidence for a claim in this section's scope.
+
+---
+
 ## DATABASE PROTECTION
 
 **The database at `~/.claude/contrib/agent-event-bus/data.db` contains irreplaceable event history.**


### PR DESCRIPTION
Adds a `VERIFICATION BOUNDARIES` section to `CLAUDE.md`, next to the corrected launchd note it generalizes.

**The rule:** host-specific behavior cannot be verified from a dev container. State such claims as unverified and hand them to the bus host; do not assert them. In scope: launchd/systemd semantics, `/health` and the running supervised bus or bridge, port binding, tmux/zellij injection, the real data dir.

**Why it needs a durable home.** Both corrections in #141 were confident claims made from a container that the bus host disproved in minutes:

- launchd was documented as *truncating* its `StandardOutPath`/`StandardErrorPath` captures on restart. It appends. That claim had propagated into three files and was motivating a follow-up — an append-mode file handler for the bridge — that would have been pure cost for a non-problem.
- A `/health` check was written up as reproducible when `registered` is the cached result of the last registration attempt and is never re-checked. Unloading the bus under a registered bridge still reports `true`, so the check verified nothing.

The cost isn't the wrong sentence. It's that prose asserts in the same voice whether or not anything was run, so an unverified claim is indistinguishable from a tested one and gets built on.

The section also says how to write it instead — name the check, the expected result, and who runs it — and points at `docs/BRIDGE.md`'s "Verifying supervision" section as the model, since that list exists precisely because the test suite mocks launchd entirely. It closes by noting that a suite which mocks the host verifies the caller, never the host, so a passing suite is not evidence for a claim in this scope.

Docs only; no code paths touched.

Split out of the #122 wake-path work so it lands independently of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)