### PR TITLE
docs: move the peer-logging operator notes to docs/PEER-LOGGING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,9 @@ DEV_MODE=1 agent-event-bus
 # register_session log line, so `lsof -i :PORT` can name the process. Prefer
 # it over DEV_MODE for a live diagnosis (DEV_MODE also fires a desktop
 # notification per tool call). Lines land in agent-event-bus.log, not the
-# console; neither switch reaches the launchd-supervised bus. Temporary
-# instrumentation - full operator notes, label vocabulary and caveats in
-# docs/PEER-LOGGING.md.
+# console; neither switch reaches the supervised bus (launchd or systemd).
+# To disable, UNSET it - `=0` still enables it. Temporary instrumentation -
+# full operator notes, label vocabulary and caveats in docs/PEER-LOGGING.md.
 AGENT_EVENT_BUS_LOG_PEER=1 agent-event-bus
 
 # Custom notification icon (requires terminal-notifier)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,9 @@ src/agent_event_bus/
 
 docs/BRIDGE.md     # Bridge operator docs - deliberately NOT in guide.md, which
                    # is served as an MCP resource into every session that reads it
+docs/PEER-LOGGING.md  # AGENT_EVENT_BUS_LOG_PEER operator notes (#145). Out of
+                   # CLAUDE.md for the same reason: temporary instrumentation
+                   # should not cost tokens in every session
 ```
 
 ## MCP Tools
@@ -198,58 +201,12 @@ AGENT_EVENT_BUS_LOG=/path/to/custom.log AGENT_EVENT_BUS_ERR=/path/to/custom.err 
 DEV_MODE=1 agent-event-bus
 
 # "Which process is registering?" (#145). Appends the caller's peer to the
-# register_session log line:
-#     register_session(name="x") → session=brave-trex from 127.0.0.1:54321
-# Then, while the calls are live: `lsof -i :54321`. The PORT is the
-# identifying half of a DIRECT connection - the bus listens on loopback, so
-# the address alone rarely narrows anything.
-#
-# Prefer this over DEV_MODE=1 for a live diagnosis: DEV_MODE also fires a
-# desktop notification per tool call (_dev_notify) and drops the logger to
-# DEBUG, so on a host with the #145 churn you would take ~1.5 notifications
-# per minute for as long as you watch. This variable turns on peer logging
-# alone. Both work; neither is on by default - it is instrumentation, not a
-# permanent log line. To turn it back off, UNSET it: any non-empty value is
-# truthy, so `=0` still enables it (the repo-wide idiom - see helpers.py,
-# server.py, bridge.py - but this is the one documented with an explicit
-# `=1`, which invites reaching for `=0`).
-#
-# WHERE TO WATCH: `agent-event-bus.log` (`make logs`), NOT the console. The
-# console handler is created only under DEV_MODE (server.py), so a foreground
-# run with this variable alone prints nothing to the terminal - the lines are
-# there, in the file, at INFO. That is the trade the paragraph above names
-# from the other side: DEV_MODE buys you console output and charges you the
-# notification per tool call.
-#
-# Only register_session carries it: get_events runs every few seconds per
-# session and would drown the log you are reading it from.
-#
-# The five forms a peer can take: `127.0.0.1:54321` (direct - the port names
-# the caller), `... via tailscale` (see below), `unknown peer` (the server
-# reported no peer - nothing to chase), `unknown peer (unparseable)` (a peer
-# EXISTS and this label could not render it - a bug here, not a dead end;
-# note the previous form is a prefix of this one, so match the longer first),
-# and `... - headers unreadable` (the port is good, the identity check
-# failed, so a MISSING `via tailscale` there is not evidence of a local
-# caller).
-#
-# CAVEAT - `tailscale serve`: a proxied request is terminated by the LOCAL
-# tailscaled, so the peer is tailscaled's socket and `lsof` names tailscaled
-# while the real caller is somewhere on the tailnet. Those lines are marked
-# `from 127.0.0.1:54321 via tailscale` (Tailscale's identity header is the
-# only thing in the ASGI scope that distinguishes them, and loopback bypasses
-# auth - so the marker narrows the candidates, it does not authenticate).
-# An unmarked loopback peer is a local process as far as anything in the
-# scope can tell: `tailscale serve` is the only proxy this deployment puts
-# in front of the bus, but nothing here proves the absence of another.
-#
-# CAVEAT - the SUPERVISED bus does not see this. The line below is a
-# foreground invocation; `scripts/com.evansenter.agent-event-bus.plist`
-# templates only PATH, PYTHONPATH, _ICON, _LOG and _ERR, so neither this
-# variable nor DEV_MODE reaches a launchd-managed server. On the bus host,
-# either add it to the plist's EnvironmentVariables and reload the
-# LaunchAgent, or stop the service and run the bus in the foreground for the
-# duration of the diagnosis.
+# register_session log line, so `lsof -i :PORT` can name the process. Prefer
+# it over DEV_MODE for a live diagnosis (DEV_MODE also fires a desktop
+# notification per tool call). Lines land in agent-event-bus.log, not the
+# console; neither switch reaches the launchd-supervised bus. Temporary
+# instrumentation - full operator notes, label vocabulary and caveats in
+# docs/PEER-LOGGING.md.
 AGENT_EVENT_BUS_LOG_PEER=1 agent-event-bus
 
 # Custom notification icon (requires terminal-notifier)
@@ -273,5 +230,6 @@ Notifications: Uses terminal-notifier if installed (`brew install terminal-notif
 
 - **Usage patterns, event types, channels**: `agent-event-bus://guide` or `src/agent_event_bus/guide.md`
 - **Re-awakening bridge (operators)**: `docs/BRIDGE.md`
+- **Peer logging / "which process is registering?" (#145)**: `docs/PEER-LOGGING.md`
 - **CLI usage**: `agent-event-bus-cli --help`
 - **Installation**: `README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ src/agent_event_bus/
 docs/BRIDGE.md     # Bridge operator docs - deliberately NOT in guide.md, which
                    # is served as an MCP resource into every session that reads it
 docs/PEER-LOGGING.md  # AGENT_EVENT_BUS_LOG_PEER operator notes (#145). Out of
-                   # CLAUDE.md for the same reason: temporary instrumentation
-                   # should not cost tokens in every session
+                      # CLAUDE.md for the same reason: temporary
+                      # instrumentation should not cost tokens every session
 ```
 
 ## MCP Tools

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -4,12 +4,43 @@ Operator instrumentation for [#145](https://github.com/evansenter/agent-event-bu
 something registers and immediately unregisters a session ~1.5 times a minute
 on the bus host, and nothing recorded *where* the calls came from.
 
-**Temporary by intent.** Once the process is named, this can be removed —
-delete this file and the `AGENT_EVENT_BUS_LOG_PEER` block in CLAUDE.md's
-Operations section along with `_peer_label` / `PEER_LOGGED_TOOLS` in
-`middleware.py`. Kept out of `CLAUDE.md` (and out of `guide.md`) for the same
-reason as `BRIDGE.md`: CLAUDE.md loads into every session, and this is
-operator material with a stated removal condition.
+Kept out of `CLAUDE.md` (and out of `guide.md`) for the same reason as
+`BRIDGE.md`: CLAUDE.md loads into every session, and this is operator material
+with a stated removal condition.
+
+## Removing it
+
+**Temporary by intent.** Once the process is named, delete all of the
+following — a partial removal leaves a dead helper, a vestigial parameter, or
+a dangling pointer:
+
+`src/agent_event_bus/middleware.py`
+- `PEER_LOGGED_TOOLS`
+- `_peer_logging_enabled()`
+- `_peer_label()`
+- the `peer` plumbing: `peer = _peer_label(scope)` in
+  `RequestLoggingMiddleware.__call__`, the extra argument to
+  `_log_tool_call(..., peer)`, that function's `peer` parameter, and the
+  `peer_suffix` it builds
+
+  Leave the `(scope.get("client") or ...)` / `(scope.get("headers") or ...)`
+  reads in `TailscaleAuthMiddleware` alone — those fix a real crash on an
+  explicit `None` and are not part of this instrumentation.
+
+`tests/test_middleware.py`
+- `TestPeerLogging` in full
+- `TestTailscaleAuthMiddleware::test_explicit_null_client_does_not_raise` and
+  `::test_explicit_null_headers_does_not_raise` **stay** — they pin the
+  crash fix above, not the peer label
+
+`CLAUDE.md` — four references, not one:
+- the `AGENT_EVENT_BUS_LOG_PEER` block in Operations
+- `_LOG_PEER` in the environment-variable list (Naming Conventions)
+- the `docs/PEER-LOGGING.md` line in the Architecture tree
+- the See Also entry
+
+`docs/PEER-LOGGING.md`
+- this file
 
 ## Turning it on
 
@@ -91,16 +122,19 @@ process as far as anything in the scope can tell: `tailscale serve` is the
 only proxy this deployment puts in front of the bus, but nothing here proves
 the absence of another.
 
-### The supervised bus does not see either switch
+### The supervised bus does not see either switch — on either platform
 
-`scripts/com.evansenter.agent-event-bus.plist` templates only `PATH`,
-`PYTHONPATH`, `AGENT_EVENT_BUS_ICON`, `_LOG` and `_ERR`, so neither
-`AGENT_EVENT_BUS_LOG_PEER` nor `DEV_MODE` reaches a launchd-managed server.
-On the bus host, either:
+Both service templates carry the same short set of variables (`PYTHONPATH`,
+`AGENT_EVENT_BUS_ICON`, `_LOG`, `_ERR`; the plist adds `PATH`), so neither
+`AGENT_EVENT_BUS_LOG_PEER` nor `DEV_MODE` reaches a supervised server:
 
-- add it to the plist's `EnvironmentVariables` and reload the LaunchAgent, or
-- stop the service and run the bus in the foreground for the duration of the
-  diagnosis.
+| Platform | File | Add |
+|---|---|---|
+| macOS (launchd) | `scripts/com.evansenter.agent-event-bus.plist` | a key in `EnvironmentVariables`, then reload the LaunchAgent |
+| Linux (systemd) | `scripts/agent-event-bus.service` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1`, then `systemctl --user daemon-reload` |
 
-Note that `make install-server` regenerates the plist from the template, so a
+Or, on either: stop the service and run the bus in the foreground for the
+duration of the diagnosis.
+
+Note that `make install-server` regenerates both from their templates, so a
 hand-edit does not survive a reinstall.

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -46,9 +46,12 @@ part that goes stale when the next one is added):
 `docs/PEER-LOGGING.md`
 - this file
 
-Then, last, grep for every name — the identifiers match neither `LOG_PEER` nor
-`PEER-LOGGING`, so a narrower grep comes back clean over a half-finished
-removal and reads as confirmation:
+Then, last, grep for every name. This step is self-erasing — it runs after
+this file is gone, because deleting it changes the output — so copy the
+command out first, or recover it with `git show HEAD:docs/PEER-LOGGING.md`.
+
+The identifiers match neither `LOG_PEER` nor `PEER-LOGGING`, so a narrower
+grep comes back clean over a half-finished removal and reads as confirmation:
 
 ```bash
 git grep -E "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix|_log_tool_call"
@@ -125,6 +128,7 @@ per session and would drown the log you are reading it from.
 | `unknown peer` | The server reported no peer — nothing to chase |
 | `unknown peer (unparseable)` | A peer **exists** and the label could not render it — a bug on that line, not a dead end |
 | `... - headers unreadable` | The port is good, the identity check failed — so a *missing* `via tailscale` here is **not** evidence of a local caller |
+| *no `from …` at all* | The switch is not reaching the process — the likeliest first observation. Either you are watching the console instead of the log (see [Where to watch](#where-to-watch)), or the bus is supervised and never saw the variable (see [the supervised-bus caveat](#the-supervised-bus-does-not-see-either-switch--on-either-platform)) |
 
 `unknown peer` is a prefix of `unknown peer (unparseable)` and the two carry
 opposite meanings, so match the longer string first.
@@ -170,7 +174,7 @@ install regenerates the copy the service manager actually reads:
 |---|---|---|
 | **Template** (in-repo) | `scripts/com.evansenter.agent-event-bus.plist` | `scripts/agent-event-bus.service` |
 | **Installed** (what runs) | `~/Library/LaunchAgents/com.evansenter.agent-event-bus.plist` | `~/.config/systemd/user/agent-event-bus.service` |
-| **What to add** | a key in `EnvironmentVariables` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1` |
+| **What to add** | a key in `EnvironmentVariables` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1`, under `[Service]` — beside the four already there |
 | **Apply an installed-unit edit** | `launchctl unload` + `load` (restarts the process) | `systemctl --user daemon-reload` **and** `systemctl --user restart agent-event-bus` |
 
 Two paths, and they differ in what a reinstall does to them:

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -48,7 +48,9 @@ part that goes stale when the next one is added):
 
 Then, last, grep for every name. This step is self-erasing — it runs after
 this file is gone, because deleting it changes the output — so copy the
-command out first, or recover it with `git show HEAD:docs/PEER-LOGGING.md`.
+command out first. To recover it afterwards, mind which side of the commit
+you are on: `git show HEAD:docs/PEER-LOGGING.md` while the deletion is still
+uncommitted, `git show HEAD~1:docs/PEER-LOGGING.md` once it has landed.
 
 The identifiers match neither `LOG_PEER` nor `PEER-LOGGING`, so a narrower
 grep comes back clean over a half-finished removal and reads as confirmation:
@@ -174,7 +176,7 @@ install regenerates the copy the service manager actually reads:
 |---|---|---|
 | **Template** (in-repo) | `scripts/com.evansenter.agent-event-bus.plist` | `scripts/agent-event-bus.service` |
 | **Installed** (what runs) | `~/Library/LaunchAgents/com.evansenter.agent-event-bus.plist` | `~/.config/systemd/user/agent-event-bus.service` |
-| **What to add** | a key in `EnvironmentVariables` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1`, under `[Service]` — beside the four already there |
+| **What to add** | a key in `EnvironmentVariables` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1`, under `[Service]` — beside the other `Environment=` lines |
 | **Apply an installed-unit edit** | `launchctl unload` + `load` (restarts the process) | `systemctl --user daemon-reload` **and** `systemctl --user restart agent-event-bus` |
 
 Two paths, and they differ in what a reinstall does to them:

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -33,11 +33,17 @@ a dangling pointer:
   `::test_explicit_null_headers_does_not_raise` **stay** — they pin the
   crash fix above, not the peer label
 
-`CLAUDE.md` — four references, not one:
+`CLAUDE.md` — several references, not one (no count here: the number is the
+part that goes stale when the next one is added):
 - the `AGENT_EVENT_BUS_LOG_PEER` block in Operations
+- the `(also turns on peer logging below)` parenthetical on the `DEV_MODE=1`
+  line — it dangles twice over, since "below" points at a block that is gone
+  and the side effect it describes disappears with `_peer_logging_enabled()`
 - `_LOG_PEER` in the environment-variable list (Naming Conventions)
 - the `docs/PEER-LOGGING.md` line in the Architecture tree
 - the See Also entry
+
+Grep `LOG_PEER` and `PEER-LOGGING` across the repo before calling it done.
 
 `docs/PEER-LOGGING.md`
 - this file
@@ -102,6 +108,11 @@ per session and would drown the log you are reading it from.
 
 `unknown peer` is a prefix of `unknown peer (unparseable)` and the two carry
 opposite meanings, so match the longer string first.
+
+IPv6 hosts are **bracketed** — `[::1]:54321`, `[fd7a:115c:a1e0::1]:54321` —
+which is the form `lsof`/`ss` print back. Unbracketed, there would be no way
+to see where the address ends and the port begins, and the port is the half
+you came for.
 
 ## Caveats
 

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -1,0 +1,106 @@
+# Peer logging — "which process is registering?"
+
+Operator instrumentation for [#145](https://github.com/evansenter/agent-event-bus/issues/145):
+something registers and immediately unregisters a session ~1.5 times a minute
+on the bus host, and nothing recorded *where* the calls came from.
+
+**Temporary by intent.** Once the process is named, this can be removed —
+delete this file and the `AGENT_EVENT_BUS_LOG_PEER` block in CLAUDE.md's
+Operations section along with `_peer_label` / `PEER_LOGGED_TOOLS` in
+`middleware.py`. Kept out of `CLAUDE.md` (and out of `guide.md`) for the same
+reason as `BRIDGE.md`: CLAUDE.md loads into every session, and this is
+operator material with a stated removal condition.
+
+## Turning it on
+
+```bash
+AGENT_EVENT_BUS_LOG_PEER=1 agent-event-bus
+```
+
+Appends the caller's peer to the `register_session` log line:
+
+```
+register_session(name="x") → session=brave-trex from 127.0.0.1:54321
+```
+
+Then, while the calls are live:
+
+```bash
+lsof -i :54321
+```
+
+The **port** is the identifying half of a *direct* connection — the bus
+listens on loopback, so the address alone rarely narrows anything.
+
+To turn it back off, **unset it**. Any non-empty value is truthy, so `=0`
+still enables it. That is the repo-wide idiom (see `helpers.py`, `server.py`,
+`bridge.py`), but this is the one documented with an explicit `=1`, which
+invites reaching for `=0`.
+
+### Why not `DEV_MODE=1`
+
+`DEV_MODE` also enables peer logging, but it is not a *quiet* switch: it fires
+a desktop notification per tool call (`_dev_notify`) and drops the logger to
+DEBUG. On a host with the #145 churn that is ~1.5 notifications per minute for
+as long as you watch, plus every real session.
+
+The trade runs both ways — `DEV_MODE` buys you console output and charges you
+the notifications. Neither switch is on by default.
+
+### Where to watch
+
+`agent-event-bus.log` (`make logs`) — **not** the console. The console handler
+is created only under `DEV_MODE` (`server.py`), so a foreground run with
+`AGENT_EVENT_BUS_LOG_PEER` alone prints nothing to the terminal. The lines are
+there, in the file, at INFO.
+
+### Scope
+
+Only `register_session` carries the peer. `get_events` runs every few seconds
+per session and would drown the log you are reading it from.
+
+## Reading the label
+
+| Form | Meaning |
+|------|---------|
+| `127.0.0.1:54321` | Direct — the port names the caller |
+| `... via tailscale` | Proxied; see the caveat below |
+| `unknown peer` | The server reported no peer — nothing to chase |
+| `unknown peer (unparseable)` | A peer **exists** and the label could not render it — a bug on that line, not a dead end |
+| `... - headers unreadable` | The port is good, the identity check failed — so a *missing* `via tailscale` here is **not** evidence of a local caller |
+
+`unknown peer` is a prefix of `unknown peer (unparseable)` and the two carry
+opposite meanings, so match the longer string first.
+
+## Caveats
+
+### `tailscale serve`
+
+A proxied request is terminated by the **local** tailscaled, so the peer is
+tailscaled's socket: `lsof` names tailscaled while the real caller is
+somewhere on the tailnet. Those lines are marked:
+
+```
+register_session(name="x") → session=brave-trex from 127.0.0.1:54321 via tailscale
+```
+
+Tailscale's identity header is the only thing in the ASGI scope that
+distinguishes them, and loopback bypasses auth — so the marker narrows the
+candidates, it does not authenticate. An unmarked loopback peer is a local
+process as far as anything in the scope can tell: `tailscale serve` is the
+only proxy this deployment puts in front of the bus, but nothing here proves
+the absence of another.
+
+### The supervised bus does not see either switch
+
+`scripts/com.evansenter.agent-event-bus.plist` templates only `PATH`,
+`PYTHONPATH`, `AGENT_EVENT_BUS_ICON`, `_LOG` and `_ERR`, so neither
+`AGENT_EVENT_BUS_LOG_PEER` nor `DEV_MODE` reaches a launchd-managed server.
+On the bus host, either:
+
+- add it to the plist's `EnvironmentVariables` and reload the LaunchAgent, or
+- stop the service and run the bus in the foreground for the duration of the
+  diagnosis.
+
+Note that `make install-server` regenerates the plist from the template, so a
+hand-edit does not survive a reinstall.

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -43,7 +43,15 @@ part that goes stale when the next one is added):
 - the `docs/PEER-LOGGING.md` line in the Architecture tree
 - the See Also entry
 
-Grep `LOG_PEER` and `PEER-LOGGING` across the repo before calling it done.
+Before calling it done, grep for every name — the identifiers match neither
+`LOG_PEER` nor `PEER-LOGGING`, so a narrower grep comes back clean over a
+half-finished removal and reads as confirmation:
+
+```bash
+grep -rE "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix" .
+```
+
+This, not the bullet list, is the part that does not rot.
 
 `docs/PEER-LOGGING.md`
 - this file
@@ -137,15 +145,31 @@ the absence of another.
 
 Both service templates carry the same short set of variables (`PYTHONPATH`,
 `AGENT_EVENT_BUS_ICON`, `_LOG`, `_ERR`; the plist adds `PATH`), so neither
-`AGENT_EVENT_BUS_LOG_PEER` nor `DEV_MODE` reaches a supervised server:
+`AGENT_EVENT_BUS_LOG_PEER` nor `DEV_MODE` reaches a supervised server.
 
-| Platform | File | Add |
+The simplest route is to **not use the service at all**: stop it and run the
+bus in the foreground for the duration of the diagnosis.
+
+To keep it supervised, note that a reload acts on the **installed** unit, not
+on the repo template — editing `scripts/…` alone changes nothing until an
+install regenerates the copy the service manager actually reads:
+
+| | macOS (launchd) | Linux (systemd) |
 |---|---|---|
-| macOS (launchd) | `scripts/com.evansenter.agent-event-bus.plist` | a key in `EnvironmentVariables`, then reload the LaunchAgent |
-| Linux (systemd) | `scripts/agent-event-bus.service` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1`, then `systemctl --user daemon-reload` |
+| **Template** (in-repo) | `scripts/com.evansenter.agent-event-bus.plist` | `scripts/agent-event-bus.service` |
+| **Installed** (what runs) | `~/Library/LaunchAgents/com.evansenter.agent-event-bus.plist` | `~/.config/systemd/user/agent-event-bus.service` |
+| **What to add** | a key in `EnvironmentVariables` | `Environment=AGENT_EVENT_BUS_LOG_PEER=1` |
+| **Apply an installed-unit edit** | `launchctl unload` + `load` (restarts the process) | `systemctl --user daemon-reload` **and** `systemctl --user restart agent-event-bus` |
 
-Or, on either: stop the service and run the bus in the foreground for the
-duration of the diagnosis.
+Two paths, and they differ in what a reinstall does to them:
 
-Note that `make install-server` regenerates both from their templates, so a
-hand-edit does not survive a reinstall.
+- **Edit the template, then `make install-server`** — regenerates the
+  installed unit and restarts. Slower, but the change survives future
+  reinstalls, which matters if the diagnosis runs long.
+- **Edit the installed unit, then apply as above** — faster, and wiped the
+  next time `make install-server` regenerates from the template.
+
+On systemd, `daemon-reload` alone is not enough: it re-reads unit files while
+the running service keeps its old environment, so the log never grows a
+`from …` suffix and the switch looks broken. `make restart` covers both
+platforms and is equivalent to the restart half.

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -51,8 +51,14 @@ Then, last, grep for every name — the identifiers match neither `LOG_PEER` nor
 removal and reads as confirmation:
 
 ```bash
-grep -rE "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix|_log_tool_call" .
+git grep -E "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix|_log_tool_call"
 ```
+
+`git grep`, not `grep -r`: the latter descends into ignored artifacts, and
+`htmlcov/` is a rendered copy of the source — so a stale coverage report keeps
+reporting `_peer_label` long after a correct removal, and the operator goes
+hunting for a leftover that is not there. Tracked files are exactly the set
+the checklist above enumerates, and stay so as new ignored artifacts appear.
 
 `_log_tool_call` is in the list to put its **signature** in view: if a removal
 takes `_peer_label` and `peer_suffix` but leaves the `peer` parameter behind,

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -43,18 +43,24 @@ part that goes stale when the next one is added):
 - the `docs/PEER-LOGGING.md` line in the Architecture tree
 - the See Also entry
 
-Before calling it done, grep for every name — the identifiers match neither
-`LOG_PEER` nor `PEER-LOGGING`, so a narrower grep comes back clean over a
-half-finished removal and reads as confirmation:
-
-```bash
-grep -rE "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix" .
-```
-
-This, not the bullet list, is the part that does not rot.
-
 `docs/PEER-LOGGING.md`
 - this file
+
+Then, last, grep for every name — the identifiers match neither `LOG_PEER` nor
+`PEER-LOGGING`, so a narrower grep comes back clean over a half-finished
+removal and reads as confirmation:
+
+```bash
+grep -rE "LOG_PEER|PEER-LOGGING|_peer_label|_peer_logging_enabled|PEER_LOGGED_TOOLS|peer_suffix|_log_tool_call" .
+```
+
+`_log_tool_call` is in the list to put its **signature** in view: if a removal
+takes `_peer_label` and `peer_suffix` but leaves the `peer` parameter behind,
+the only surviving token is the bare word `peer`, which is useless to grep —
+so that one leftover is visible here or not at all. Its handful of hits are
+readable by eye.
+
+This, not the bullet list, is the part that does not rot.
 
 ## Turning it on
 

--- a/docs/PEER-LOGGING.md
+++ b/docs/PEER-LOGGING.md
@@ -128,7 +128,7 @@ per session and would drown the log you are reading it from.
 | `unknown peer` | The server reported no peer — nothing to chase |
 | `unknown peer (unparseable)` | A peer **exists** and the label could not render it — a bug on that line, not a dead end |
 | `... - headers unreadable` | The port is good, the identity check failed — so a *missing* `via tailscale` here is **not** evidence of a local caller |
-| *no `from …` at all* | The switch is not reaching the process — the likeliest first observation. Either you are watching the console instead of the log (see [Where to watch](#where-to-watch)), or the bus is supervised and never saw the variable (see [the supervised-bus caveat](#the-supervised-bus-does-not-see-either-switch--on-either-platform)) |
+| *no `from …` at all* | Check the tool name first: only `register_session` carries a peer, so unsuffixed `get_events` lines are normal and mean nothing is wrong (see [Scope](#scope)). Otherwise the switch is not reaching the process — either you are watching the console instead of the log (see [Where to watch](#where-to-watch)), or the bus is supervised and never saw the variable (see [the supervised-bus caveat](#the-supervised-bus-does-not-see-either-switch--on-either-platform)) |
 
 `unknown peer` is a prefix of `unknown peer (unparseable)` and the two carry
 opposite meanings, so match the longer string first.


### PR DESCRIPTION
Follow-up to #147, taking the altitude note its review raised twice.

## Why

CLAUDE.md loads into every session, and the #145 block had grown to ~55 lines of prose — longer than the code it documents — for instrumentation with a stated removal condition. That's the argument CLAUDE.md already makes about tool docstrings ("tool definitions consume tokens in every conversation"), and the same reason `docs/BRIDGE.md` is deliberately kept out of `guide.md`.

## What

The Operations block goes from ~55 lines to **7**: what it does, why to prefer it over `DEV_MODE`, where the lines land, that the supervised bus sees neither switch, and a pointer.

Everything else moves to `docs/PEER-LOGGING.md` — the label vocabulary (all five forms, including the prefix hazard), the `tailscale serve` caveat, the plist caveat, and the `=0`-reads-as-enabled trap. Nothing was dropped.

The new file states the removal condition up front, so when #145 closes, deleting a file is the whole job rather than remembering to trim a paragraph back out of a section. It also picks up one fact that wasn't written down anywhere: `make install-server` regenerates the plist from the template, so a hand-edit to add the variable doesn't survive a reinstall.

Indexed in the Architecture tree and See Also, beside `BRIDGE.md`.

**No code change** — 693 passed, format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbSWrbyPaRCrYmyMf4KzsS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbSWrbyPaRCrYmyMf4KzsS)_