### PR TITLE
docs: correct the claims the first real wake disproved

### DIFF
--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -6,9 +6,11 @@ subsystem (RFC #122). It is documented here rather than in
 into working sessions, and this is operator documentation for a component
 most sessions never run.
 
-**Status: prototype.** Supervised on macOS since #139 (`make install-bridge`);
-no systemd unit yet, and the addressability and durability caveats below are
-real. See issue #122.
+**Status: prototype, but the wake path works.** Supervised on macOS since #139
+(`make install-bridge`), injecting since #149, and verified once end to end on
+the bus host - a live Claude Code session in a mapped zellij pane was woken by
+a DM, read the bus, and acted on the event. Still a prototype: no systemd unit,
+and the addressability and durability caveats below are real. See issue #122.
 
 ---
 
@@ -112,9 +114,12 @@ them check claims the unit's own comments make:
 4. **Clean unload** - `make uninstall-bridge`, then confirm the webhook row
    is gone and port 8082 is free.
 
-What none of this covers: whether a session actually *wakes*. That needs a
-live Claude Code session in a pane this host's `panes.json` maps, and a DM
-addressed to its `session_id` - see **Verifying a wake** below.
+What none of this covers: whether a session actually *wakes*. That is a
+separate check - see **Verifying a wake** below. It has been done once, on the
+bus host: a live Claude Code session in a mapped zellij pane was woken by a DM
+to its `session_id`, read the bus, and acted on the event. Re-run it after any
+change to the injection path, since none of the four checks above would catch
+a break in it.
 
 ## Backends
 
@@ -425,8 +430,21 @@ behaviour for a deployment that would rather latch than risk a mid-turn wake.
 
 ## Verifying a wake
 
-Unverifiable from a dev container (no launchd, no multiplexer, no session on
-the bus), so this is a checklist for the bus host rather than a claim:
+Still unverifiable from a dev container (no launchd, no multiplexer, no
+session on the bus), so this stays a checklist for the bus host. It has been
+run once end to end there - a live session in a mapped zellij pane woke, read
+the bus, and acted - and it is worth re-running after any change to the
+injection path, because nothing else exercises it.
+
+A safe way to run it: start a **scratch** session (`zellij attach -b probe`,
+then `claude` in it) rather than testing against a pane you are working in.
+An injection into a pane where someone is mid-keystroke submits their draft
+along with the wake text, and that is not a failure the bridge can prevent.
+
+Before enabling injection on a host that has been running the spool backend,
+**audit `panes.json`**: a stale entry from earlier testing can point at a pane
+someone is now using, and it is inert under `spool` but armed the moment the
+backend flips.
 
 1. Confirm the daemon found a multiplexer: the startup line
    `Wake injection available via: ...` in the bridge's `.err`. If it names
@@ -454,13 +472,16 @@ string into `cat` in the same pane arrived byte-exact every time. So
 `write-chars` transmits faithfully and the lost keystroke is the shell's line
 editor - autosuggestion-class ZLE widgets dropping input at paste speed.
 
-Two consequences. First, a garbled wake in a *shell* pane is the
-stale-mapping symptom, not a bridge fault - it means the session that owned
-that pane exited without clearing its entry. Second, whether a given TUI has
-its own version of this is a property of that TUI: it is **unverified** for
-Claude Code's input handling, which is not zsh ZLE. Worth checking on the
-first real wake, though the failure is cosmetic - a prompt missing a space
-still reads.
+**Claude Code's TUI does not do this.** Measured on the first real wake: the
+scrollback held `Check the event bus - a directed event arrived for this
+session.` intact, wrapped only by the pane width. Its input handling is not
+zsh ZLE, and the drop does not reproduce there.
+
+So a garbled wake in a *shell* pane is the stale-mapping symptom, not a bridge
+fault - it means the session that owned that pane exited without clearing its
+entry, and something injected into the shell that replaced it. Fidelity is a
+property of the receiving program, so a result for one does not transfer to
+another: measure a new target rather than assuming either way.
 
 ## Loop prevention and single-instance
 

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -436,10 +436,17 @@ run once end to end there - a live session in a mapped zellij pane woke, read
 the bus, and acted - and it is worth re-running after any change to the
 injection path, because nothing else exercises it.
 
-A safe way to run it: start a **scratch** session (`zellij attach -b probe`,
-then `claude` in it) rather than testing against a pane you are working in.
-An injection into a pane where someone is mid-keystroke submits their draft
-along with the wake text, and that is not a failure the bridge can prevent.
+A safe way to run it: use a **scratch** session rather than a pane you are
+working in. An injection into a pane where someone is mid-keystroke submits
+their draft along with the wake text, and that is not a failure the bridge can
+prevent.
+
+In a second terminal, `zellij -s probe` (or `tmux new -s probe`) and run
+`claude` inside it. Note that `zellij attach -b probe` is NOT that command -
+`-b` creates the session **detached**, so it returns immediately and leaves you
+nowhere; it is useful for driving a pane entirely from outside (`zellij
+--session probe action write-chars ...`), which is how this was first run, but
+it does not give you a pane to type in.
 
 Before enabling injection on a host that has been running the spool backend,
 **audit `panes.json`**: a stale entry from earlier testing can point at a pane

--- a/docs/superpowers/specs/2026-08-10-mux-wake-backend-design.md
+++ b/docs/superpowers/specs/2026-08-10-mux-wake-backend-design.md
@@ -199,12 +199,28 @@ writer, tests, `docs/BRIDGE.md`, plist. `dotfiles`: `session-start.sh`,
 load-bearing block ordering between `drain-directed-events.sh` and
 `enforce-insight-publish.sh`.
 
-## What cannot be verified from here
+## What could not be verified while writing this — and what happened after
 
-Per the verification-boundaries rule in `CLAUDE.md`. Hand to the bus host:
+Per the verification-boundaries rule in `CLAUDE.md`, these were handed to the
+bus host rather than asserted. All but the last have since been run there:
 
-- An actual Claude Code session waking. Needs a live session in a mapped pane.
-- `make install-bridge` picking up the new backend, and the supervised bridge
-  reading a real `panes.json`.
-- `ZELLIJ_PANE_ID` uniqueness across a session's full pane set in daily use
-  (single-pane and cross-tab addressing were verified directly).
+- **An actual Claude Code session waking** — *done*. A scratch session in a
+  mapped zellij pane went from an idle prompt to processing, called
+  `get_events`, and acted on the DM.
+- **`make install-bridge` picking up the new backend** — *done*. The preflight
+  logged `Wake injection available via: tmux, zellij` under launchd's own PATH.
+- **Injection fidelity into Claude Code's TUI** — *done, and it is fine*. The
+  one-space drop reproduces in an interactive zsh pane and not in the TUI. The
+  lesson generalizes better than the result: fidelity belongs to the receiving
+  program, so measure a new target rather than inferring from an old one.
+- **`ZELLIJ_PANE_ID` uniqueness across a session's full pane set in daily use**
+  — still open. Single-pane and cross-tab addressing were verified directly.
+- **Reboot** — still open; needs the host restarted.
+
+Two things the live run surfaced that no amount of local reasoning would have:
+a stale `panes.json` entry from earlier testing was pointing at the operator's
+own working pane (inert under `spool`, armed the instant the backend flipped),
+and the installer was still printing "no session is woken until a drain hook
+exists" — a caveat that outlived its uncertainty and had become the opposite of
+true. Both are the same failure shape the rule is about, pointing the other
+way: prose that stopped tracking reality and had nothing forcing it to.

--- a/docs/superpowers/specs/2026-08-10-mux-wake-backend-design.md
+++ b/docs/superpowers/specs/2026-08-10-mux-wake-backend-design.md
@@ -202,7 +202,7 @@ load-bearing block ordering between `drain-directed-events.sh` and
 ## What could not be verified while writing this — and what happened after
 
 Per the verification-boundaries rule in `CLAUDE.md`, these were handed to the
-bus host rather than asserted. All but the last have since been run there:
+bus host rather than asserted. All but the last two have since been run there:
 
 - **An actual Claude Code session waking** — *done*. A scratch session in a
   mapped zellij pane went from an idle prompt to processing, called

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -158,8 +158,22 @@ else
 fi
 
 echo ""
-echo "NOTE: nothing drains wake/<session>.jsonl yet (agent-event-bus#134)."
-echo "      The bridge will spool actionable DMs durably, but no session is"
-echo "      woken by them until a drain hook exists."
+# Was "nothing drains the spool, so no session is woken" - true until the mux
+# backend landed (#149), and printed by this script for months after it
+# stopped being true. Sessions are now woken by INJECTION, not by draining the
+# spool; the spool is durable bookkeeping and the fallback for anything that
+# cannot be injected. What actually gates a wake is the pane mapping, so name
+# that instead - it is the part an operator has to install.
+if [[ -s "$DATA_DIR/wake/panes.json" ]] && grep -q '[^[:space:]{}]' "$DATA_DIR/wake/panes.json" 2>/dev/null; then
+    echo "NOTE: wake/panes.json has entries, so mapped sessions on this host can"
+    echo "      be woken by a DM to their session_id. Unmapped sessions (and"
+    echo "      sessions on other machines) are spooled only."
+else
+    echo "NOTE: wake/panes.json is empty, so nothing here can be woken yet -"
+    echo "      every DM will spool and resolve to \"spool-unmapped\"."
+    echo "      Sessions map themselves via a SessionStart hook running:"
+    echo "        agent-event-bus-cli panes set --session-id \"\$SESSION_ID\""
+    echo "      See docs/BRIDGE.md, \"Maintaining the pane mapping\"."
+fi
 echo ""
 echo "To uninstall: $SCRIPT_DIR/uninstall-bridge-launchagent.sh"

--- a/scripts/install-bridge-launchagent.sh
+++ b/scripts/install-bridge-launchagent.sh
@@ -164,7 +164,22 @@ echo ""
 # spool; the spool is durable bookkeeping and the fallback for anything that
 # cannot be injected. What actually gates a wake is the pane mapping, so name
 # that instead - it is the part an operator has to install.
-if [[ -s "$DATA_DIR/wake/panes.json" ]] && grep -q '[^[:space:]{}]' "$DATA_DIR/wake/panes.json" 2>/dev/null; then
+# Parsed, not grepped. A content-shaped check ("any byte that is not
+# whitespace or a brace") calls `[]`, `null`, or a half-written file
+# "populated", so the installer would report that sessions can be woken while
+# the bridge - which PARSES this file and falls back to no-mapping - resolves
+# every delivery to spool-unmapped. That is the same inversion this message was
+# rewritten to remove, one layer down. Mirror the reader's own test instead:
+# a JSON object with at least one key.
+if "$VENV_PYTHON" -c "
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as f:
+        d = json.load(f)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if isinstance(d, dict) and d else 1)
+" "$DATA_DIR/wake/panes.json" 2>/dev/null; then
     echo "NOTE: wake/panes.json has entries, so mapped sessions on this host can"
     echo "      be woken by a DM to their session_id. Unmapped sessions (and"
     echo "      sessions on other machines) are spooled only."


### PR DESCRIPTION
An idle Claude Code session woke. Four places still said it couldn't, or wasn't known to.

## The installer was asserting the opposite of what it had just done

`install-bridge-launchagent.sh` printed:

> NOTE: nothing drains wake/<session>.jsonl yet (agent-event-bus#134). The bridge will spool actionable DMs durably, but **no session is woken by them until a drain hook exists.**

That was true before #149. It printed during the very install that enabled injection an hour ago. Sessions are woken by **injection**, not by draining the spool — the spool is durable bookkeeping and the fallback for anything that can't be injected.

The replacement reports the thing that actually gates a wake: whether `panes.json` has entries, and if not, the command that writes them. Both branches exercised against real files.

## `docs/BRIDGE.md`

- **Status line** — "prototype" stays (no systemd unit, real caveats), but it now says the wake path works and has been verified once end to end.
- **After the supervision checks** — "what none of this covers: whether a session actually wakes" now points at the check that was run, and says to re-run it after any change to the injection path, since none of the other four would catch a break there.
- **TUI fidelity** — flipped from unverified to measured. The one-space drop reproduces in an interactive zsh pane and **not** in Claude Code's TUI, which took `Check the event bus - a directed event arrived for this session.` intact. The generalizable half is kept and sharpened: fidelity is a property of the *receiving program*, so measure a new target rather than inferring from an old one.

## Two things the live run taught

Added to **Verifying a wake**, because neither is derivable by reasoning:

1. **Use a scratch session.** Injecting into a pane where someone is mid-keystroke submits their draft along with the wake text, and the bridge cannot prevent that.
2. **Audit `panes.json` before flipping a host off `spool`.** A stale entry from earlier testing on this host pointed at the operator's own working pane — inert under the spool backend, armed the instant the backend changed.

## Design record

Now separates what has since been run on the host (the wake, the backend flip, TUI fidelity) from what's still open (`ZELLIJ_PANE_ID` uniqueness across a full pane set in daily use; reboot).

---

Docs and one installer message; no code paths touched. 778 tests pass, lint clean.

Both stale-doc findings here are the same shape as the ones that motivated `CLAUDE.md`'s verification-boundaries rule, pointing the other way: not a claim asserted without evidence, but a caveat that outlived its uncertainty with nothing forcing it to track reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)